### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boltz-backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boltz-backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Backend of boltz",
   "main": "dist/Boltz.js",
   "scripts": {


### PR DESCRIPTION
I needed to publish `v0.0.2` to [NPM](https://www.npmjs.com/package/boltz-backend) after merging #22 because the `detectSwap` method is required for https://github.com/BoltzExchange/boltz-frontend/pull/10. 

I will tag a release on GitHub after this PR is merged.