### PR TITLE
fix: claim swap after one confirmation

### DIFF
--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -187,7 +187,7 @@ class SwapManager {
   }
 
   private bindCurrency = (currency: Currency, maps: SwapMaps) => {
-    currency.chainClient.on('transaction.relevant.mempool', async (transactionHex: string) => {
+    currency.chainClient.on('transaction.relevant.block', async (transactionHex: string) => {
       const transaction = Transaction.fromHex(transactionHex);
 
       let vout = 0;

--- a/test/integration/chain/ChainClient.spec.ts
+++ b/test/integration/chain/ChainClient.spec.ts
@@ -50,8 +50,8 @@ describe('ChainClient', () => {
     const transaction = await btcManager.constructTransaction(btcAddress, 1);
     const relevantTxHex = transaction.toHex();
 
-    let blockEventReceived = false;
     let mempoolEventReceived = false;
+    let blockEventReceived = false;
 
     btcdClient.on('transaction.relevant.mempool', (transactionHex) => {
       if (transactionHex === relevantTxHex) {


### PR DESCRIPTION
Before this PR boltz would claim the swap once the lockup transaction is found in the mempool which is not optimal because:

- of RBF and simply because one should not rely on the immutability of transactions in the mempool
- if a transaction is confirmed before it reaches the mempool of the node to which boltz is connected boltz would not find the lockup transaciton

From now on boltz will claim the swap after one confirmation.