### PR TITLE
refactor: remove concept of trading pairs

### DIFF
--- a/lib/Boltz.ts
+++ b/lib/Boltz.ts
@@ -52,10 +52,10 @@ class Boltz {
     this.swapManager = new SwapManager(
       this.logger,
       this.walletManager,
-      [{
-        quote: litecoin,
-        base: bitcoin,
-      }],
+      [
+        bitcoin,
+        litecoin,
+      ],
     );
 
     this.service = new Service({

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -5,25 +5,6 @@ import { OutputType, Scripts } from 'boltz-core';
 const { p2wshOutput, p2shP2wshOutput, p2shOutput, p2wpkhOutput, p2pkhOutput, p2shP2wpkhOutput } = Scripts;
 
 /**
- * Get the pair id of a pair
- */
-export const getPairId = (quoteSymbol: string, baseSymbol: string): string => {
-  return `${quoteSymbol}/${baseSymbol}`;
-};
-
-/**
- * Get the quote and base asset of a pair id
- */
-export const splitPairId = (pairId: string): { quote: string, base: string } => {
-  const split = pairId.split('/');
-
-  return {
-    quote: split[0],
-    base: split[1],
-  };
-};
-
-/**
  * Splits a derivation path into multiple parts
  */
 export const splitDerivationPath = (path: string): { master: string, sub: number[] } => {

--- a/lib/cli/BuilderComponents.ts
+++ b/lib/cli/BuilderComponents.ts
@@ -3,14 +3,22 @@ export default {
     describe: 'ticker symbol of the currency',
     type: 'string',
   },
-  pairId: {
-    describe: 'traiding pair id of the order',
+  base_currency: {
+    describe: 'base currency of the order',
+    type: 'string',
+  },
+  quote_currency: {
+    describe: 'quote currency of the order',
     type: 'string',
   },
   orderSide: {
     describe: 'whether the order is a buy or sell one',
     type: 'string',
     choices: ['buy', 'sell'],
+  },
+  rate: {
+    describe: 'conversion rate of base and quote currency',
+    type: 'number',
   },
   outputType: {
     describe: 'type of the output',

--- a/lib/cli/commands/CreateReverseSwap.ts
+++ b/lib/cli/commands/CreateReverseSwap.ts
@@ -4,13 +4,15 @@ import BuilderComponents from '../BuilderComponents';
 import { CreateReverseSwapRequest } from '../../proto/boltzrpc_pb';
 import { getOrderSide } from '../Utils';
 
-export const command = 'createreverseswap <pair_id> <order_side> <claim_public_key> <amount>';
+export const command = 'createreverseswap <base_currency> <quote_currency> <order_side> <rate> <claim_public_key> <amount>';
 
 export const describe = 'creates a new swap from Lightning to the chain';
 
 export const builder = {
-  pair_id: BuilderComponents.pairId,
+  base_currency: BuilderComponents.base_currency,
+  quote_currency: BuilderComponents.quote_currency,
   order_side: BuilderComponents.orderSide,
+  rate: BuilderComponents.rate,
   claim_public_key: {
     describe: 'public key with which a claiming transaction has to be signed',
     type: 'string',
@@ -24,8 +26,10 @@ export const builder = {
 export const handler = (argv: Arguments) => {
   const request = new CreateReverseSwapRequest();
 
-  request.setPairId(argv.pair_id);
+  request.setBaseCurrency(argv.base_currency);
+  request.setQuoteCurrency(argv.quote_currency);
   request.setOrderSide(getOrderSide(argv.order_side));
+  request.setRate(argv.rate);
   request.setClaimPublicKey(argv.claim_public_key);
   request.setAmount(argv.amount);
 

--- a/lib/cli/commands/CreateSwap.ts
+++ b/lib/cli/commands/CreateSwap.ts
@@ -5,13 +5,15 @@ import BuilderComponents from '../BuilderComponents';
 import { CreateSwapRequest } from '../../proto/boltzrpc_pb';
 import { getOutputType, getOrderSide } from '../Utils';
 
-export const command = 'createswap <pair_id> <order_side> <invoice> <refund_public_key> [output_type] [show_qr]';
+export const command = 'createswap <base_currency> <quote_currency> <order_side> <rate> <invoice> <refund_public_key> [output_type] [show_qr]';
 
 export const describe = 'create a new swap from the chain to Lightning';
 
 export const builder = {
-  pair_id: BuilderComponents.pairId,
+  base_currency: BuilderComponents.base_currency,
+  quote_currency: BuilderComponents.quote_currency,
   order_side: BuilderComponents.orderSide,
+  rate: BuilderComponents.rate,
   invoice: {
     describe: 'invoice to pay',
     type: 'string',
@@ -47,8 +49,10 @@ export const callback = (error: Error | null, response: GrpcResponse) => {
 export const handler = (argv: Arguments) => {
   const request = new CreateSwapRequest();
 
-  request.setPairId(argv.pair_id);
+  request.setBaseCurrency(argv.base_currency);
+  request.setQuoteCurrency(argv.quote_currency);
   request.setOrderSide(getOrderSide(argv.order_side));
+  request.setRate(argv.rate);
   request.setInvoice(argv.invoice);
   request.setRefundPublicKey(argv.refund_public_key);
   request.setOutputType(getOutputType(argv.output_type));

--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -398,11 +398,17 @@ export namespace BroadcastTransactionResponse {
 }
 
 export class CreateSwapRequest extends jspb.Message { 
-    getPairId(): string;
-    setPairId(value: string): void;
+    getBaseCurrency(): string;
+    setBaseCurrency(value: string): void;
+
+    getQuoteCurrency(): string;
+    setQuoteCurrency(value: string): void;
 
     getOrderSide(): OrderSide;
     setOrderSide(value: OrderSide): void;
+
+    getRate(): number;
+    setRate(value: number): void;
 
     getInvoice(): string;
     setInvoice(value: string): void;
@@ -426,8 +432,10 @@ export class CreateSwapRequest extends jspb.Message {
 
 export namespace CreateSwapRequest {
     export type AsObject = {
-        pairId: string,
+        baseCurrency: string,
+        quoteCurrency: string,
         orderSide: OrderSide,
+        rate: number,
         invoice: string,
         refundPublicKey: string,
         outputType: OutputType,
@@ -472,11 +480,17 @@ export namespace CreateSwapResponse {
 }
 
 export class CreateReverseSwapRequest extends jspb.Message { 
-    getPairId(): string;
-    setPairId(value: string): void;
+    getBaseCurrency(): string;
+    setBaseCurrency(value: string): void;
+
+    getQuoteCurrency(): string;
+    setQuoteCurrency(value: string): void;
 
     getOrderSide(): OrderSide;
     setOrderSide(value: OrderSide): void;
+
+    getRate(): number;
+    setRate(value: number): void;
 
     getClaimPublicKey(): string;
     setClaimPublicKey(value: string): void;
@@ -497,8 +511,10 @@ export class CreateReverseSwapRequest extends jspb.Message {
 
 export namespace CreateReverseSwapRequest {
     export type AsObject = {
-        pairId: string,
+        baseCurrency: string,
+        quoteCurrency: string,
         orderSide: OrderSide,
+        rate: number,
         claimPublicKey: string,
         amount: number,
     }

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -2723,11 +2723,13 @@ proto.boltzrpc.CreateSwapRequest.prototype.toObject = function(opt_includeInstan
  */
 proto.boltzrpc.CreateSwapRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    pairId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    orderSide: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    invoice: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    refundPublicKey: jspb.Message.getFieldWithDefault(msg, 4, ""),
-    outputType: jspb.Message.getFieldWithDefault(msg, 5, 0)
+    baseCurrency: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    quoteCurrency: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    orderSide: jspb.Message.getFieldWithDefault(msg, 3, 0),
+    rate: jspb.Message.getFieldWithDefault(msg, 4, 0),
+    invoice: jspb.Message.getFieldWithDefault(msg, 5, ""),
+    refundPublicKey: jspb.Message.getFieldWithDefault(msg, 6, ""),
+    outputType: jspb.Message.getFieldWithDefault(msg, 7, 0)
   };
 
   if (includeInstance) {
@@ -2766,21 +2768,29 @@ proto.boltzrpc.CreateSwapRequest.deserializeBinaryFromReader = function(msg, rea
     switch (field) {
     case 1:
       var value = /** @type {string} */ (reader.readString());
-      msg.setPairId(value);
+      msg.setBaseCurrency(value);
       break;
     case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setQuoteCurrency(value);
+      break;
+    case 3:
       var value = /** @type {!proto.boltzrpc.OrderSide} */ (reader.readEnum());
       msg.setOrderSide(value);
       break;
-    case 3:
+    case 4:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setRate(value);
+      break;
+    case 5:
       var value = /** @type {string} */ (reader.readString());
       msg.setInvoice(value);
       break;
-    case 4:
+    case 6:
       var value = /** @type {string} */ (reader.readString());
       msg.setRefundPublicKey(value);
       break;
-    case 5:
+    case 7:
       var value = /** @type {!proto.boltzrpc.OutputType} */ (reader.readEnum());
       msg.setOutputType(value);
       break;
@@ -2813,38 +2823,52 @@ proto.boltzrpc.CreateSwapRequest.prototype.serializeBinary = function() {
  */
 proto.boltzrpc.CreateSwapRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getPairId();
+  f = message.getBaseCurrency();
   if (f.length > 0) {
     writer.writeString(
       1,
       f
     );
   }
+  f = message.getQuoteCurrency();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
   f = message.getOrderSide();
   if (f !== 0.0) {
     writer.writeEnum(
-      2,
+      3,
+      f
+    );
+  }
+  f = message.getRate();
+  if (f !== 0) {
+    writer.writeInt64(
+      4,
       f
     );
   }
   f = message.getInvoice();
   if (f.length > 0) {
     writer.writeString(
-      3,
+      5,
       f
     );
   }
   f = message.getRefundPublicKey();
   if (f.length > 0) {
     writer.writeString(
-      4,
+      6,
       f
     );
   }
   f = message.getOutputType();
   if (f !== 0.0) {
     writer.writeEnum(
-      5,
+      7,
       f
     );
   }
@@ -2852,77 +2876,107 @@ proto.boltzrpc.CreateSwapRequest.serializeBinaryToWriter = function(message, wri
 
 
 /**
- * optional string pair_id = 1;
+ * optional string base_currency = 1;
  * @return {string}
  */
-proto.boltzrpc.CreateSwapRequest.prototype.getPairId = function() {
+proto.boltzrpc.CreateSwapRequest.prototype.getBaseCurrency = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.boltzrpc.CreateSwapRequest.prototype.setPairId = function(value) {
+proto.boltzrpc.CreateSwapRequest.prototype.setBaseCurrency = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
 
 /**
- * optional OrderSide order_side = 2;
- * @return {!proto.boltzrpc.OrderSide}
+ * optional string quote_currency = 2;
+ * @return {string}
  */
-proto.boltzrpc.CreateSwapRequest.prototype.getOrderSide = function() {
-  return /** @type {!proto.boltzrpc.OrderSide} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
+proto.boltzrpc.CreateSwapRequest.prototype.getQuoteCurrency = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
-/** @param {!proto.boltzrpc.OrderSide} value */
-proto.boltzrpc.CreateSwapRequest.prototype.setOrderSide = function(value) {
+/** @param {string} value */
+proto.boltzrpc.CreateSwapRequest.prototype.setQuoteCurrency = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
 
 /**
- * optional string invoice = 3;
- * @return {string}
+ * optional OrderSide order_side = 3;
+ * @return {!proto.boltzrpc.OrderSide}
  */
-proto.boltzrpc.CreateSwapRequest.prototype.getInvoice = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+proto.boltzrpc.CreateSwapRequest.prototype.getOrderSide = function() {
+  return /** @type {!proto.boltzrpc.OrderSide} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
 };
 
 
-/** @param {string} value */
-proto.boltzrpc.CreateSwapRequest.prototype.setInvoice = function(value) {
+/** @param {!proto.boltzrpc.OrderSide} value */
+proto.boltzrpc.CreateSwapRequest.prototype.setOrderSide = function(value) {
   jspb.Message.setField(this, 3, value);
 };
 
 
 /**
- * optional string refund_public_key = 4;
- * @return {string}
+ * optional int64 rate = 4;
+ * @return {number}
  */
-proto.boltzrpc.CreateSwapRequest.prototype.getRefundPublicKey = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+proto.boltzrpc.CreateSwapRequest.prototype.getRate = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
 };
 
 
-/** @param {string} value */
-proto.boltzrpc.CreateSwapRequest.prototype.setRefundPublicKey = function(value) {
+/** @param {number} value */
+proto.boltzrpc.CreateSwapRequest.prototype.setRate = function(value) {
   jspb.Message.setField(this, 4, value);
 };
 
 
 /**
- * optional OutputType output_type = 5;
+ * optional string invoice = 5;
+ * @return {string}
+ */
+proto.boltzrpc.CreateSwapRequest.prototype.getInvoice = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/** @param {string} value */
+proto.boltzrpc.CreateSwapRequest.prototype.setInvoice = function(value) {
+  jspb.Message.setField(this, 5, value);
+};
+
+
+/**
+ * optional string refund_public_key = 6;
+ * @return {string}
+ */
+proto.boltzrpc.CreateSwapRequest.prototype.getRefundPublicKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
+};
+
+
+/** @param {string} value */
+proto.boltzrpc.CreateSwapRequest.prototype.setRefundPublicKey = function(value) {
+  jspb.Message.setField(this, 6, value);
+};
+
+
+/**
+ * optional OutputType output_type = 7;
  * @return {!proto.boltzrpc.OutputType}
  */
 proto.boltzrpc.CreateSwapRequest.prototype.getOutputType = function() {
-  return /** @type {!proto.boltzrpc.OutputType} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+  return /** @type {!proto.boltzrpc.OutputType} */ (jspb.Message.getFieldWithDefault(this, 7, 0));
 };
 
 
 /** @param {!proto.boltzrpc.OutputType} value */
 proto.boltzrpc.CreateSwapRequest.prototype.setOutputType = function(value) {
-  jspb.Message.setField(this, 5, value);
+  jspb.Message.setField(this, 7, value);
 };
 
 
@@ -3223,10 +3277,12 @@ proto.boltzrpc.CreateReverseSwapRequest.prototype.toObject = function(opt_includ
  */
 proto.boltzrpc.CreateReverseSwapRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    pairId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    orderSide: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    claimPublicKey: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    amount: jspb.Message.getFieldWithDefault(msg, 4, 0)
+    baseCurrency: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    quoteCurrency: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    orderSide: jspb.Message.getFieldWithDefault(msg, 3, 0),
+    rate: jspb.Message.getFieldWithDefault(msg, 4, 0),
+    claimPublicKey: jspb.Message.getFieldWithDefault(msg, 5, ""),
+    amount: jspb.Message.getFieldWithDefault(msg, 6, 0)
   };
 
   if (includeInstance) {
@@ -3265,17 +3321,25 @@ proto.boltzrpc.CreateReverseSwapRequest.deserializeBinaryFromReader = function(m
     switch (field) {
     case 1:
       var value = /** @type {string} */ (reader.readString());
-      msg.setPairId(value);
+      msg.setBaseCurrency(value);
       break;
     case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setQuoteCurrency(value);
+      break;
+    case 3:
       var value = /** @type {!proto.boltzrpc.OrderSide} */ (reader.readEnum());
       msg.setOrderSide(value);
       break;
-    case 3:
+    case 4:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setRate(value);
+      break;
+    case 5:
       var value = /** @type {string} */ (reader.readString());
       msg.setClaimPublicKey(value);
       break;
-    case 4:
+    case 6:
       var value = /** @type {number} */ (reader.readInt64());
       msg.setAmount(value);
       break;
@@ -3308,94 +3372,138 @@ proto.boltzrpc.CreateReverseSwapRequest.prototype.serializeBinary = function() {
  */
 proto.boltzrpc.CreateReverseSwapRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getPairId();
+  f = message.getBaseCurrency();
   if (f.length > 0) {
     writer.writeString(
       1,
       f
     );
   }
-  f = message.getOrderSide();
-  if (f !== 0.0) {
-    writer.writeEnum(
+  f = message.getQuoteCurrency();
+  if (f.length > 0) {
+    writer.writeString(
       2,
       f
     );
   }
-  f = message.getClaimPublicKey();
-  if (f.length > 0) {
-    writer.writeString(
+  f = message.getOrderSide();
+  if (f !== 0.0) {
+    writer.writeEnum(
       3,
       f
     );
   }
-  f = message.getAmount();
+  f = message.getRate();
   if (f !== 0) {
     writer.writeInt64(
       4,
       f
     );
   }
+  f = message.getClaimPublicKey();
+  if (f.length > 0) {
+    writer.writeString(
+      5,
+      f
+    );
+  }
+  f = message.getAmount();
+  if (f !== 0) {
+    writer.writeInt64(
+      6,
+      f
+    );
+  }
 };
 
 
 /**
- * optional string pair_id = 1;
+ * optional string base_currency = 1;
  * @return {string}
  */
-proto.boltzrpc.CreateReverseSwapRequest.prototype.getPairId = function() {
+proto.boltzrpc.CreateReverseSwapRequest.prototype.getBaseCurrency = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.boltzrpc.CreateReverseSwapRequest.prototype.setPairId = function(value) {
+proto.boltzrpc.CreateReverseSwapRequest.prototype.setBaseCurrency = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
 
 /**
- * optional OrderSide order_side = 2;
- * @return {!proto.boltzrpc.OrderSide}
+ * optional string quote_currency = 2;
+ * @return {string}
  */
-proto.boltzrpc.CreateReverseSwapRequest.prototype.getOrderSide = function() {
-  return /** @type {!proto.boltzrpc.OrderSide} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
+proto.boltzrpc.CreateReverseSwapRequest.prototype.getQuoteCurrency = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
-/** @param {!proto.boltzrpc.OrderSide} value */
-proto.boltzrpc.CreateReverseSwapRequest.prototype.setOrderSide = function(value) {
+/** @param {string} value */
+proto.boltzrpc.CreateReverseSwapRequest.prototype.setQuoteCurrency = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
 
 /**
- * optional string claim_public_key = 3;
- * @return {string}
+ * optional OrderSide order_side = 3;
+ * @return {!proto.boltzrpc.OrderSide}
  */
-proto.boltzrpc.CreateReverseSwapRequest.prototype.getClaimPublicKey = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+proto.boltzrpc.CreateReverseSwapRequest.prototype.getOrderSide = function() {
+  return /** @type {!proto.boltzrpc.OrderSide} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
 };
 
 
-/** @param {string} value */
-proto.boltzrpc.CreateReverseSwapRequest.prototype.setClaimPublicKey = function(value) {
+/** @param {!proto.boltzrpc.OrderSide} value */
+proto.boltzrpc.CreateReverseSwapRequest.prototype.setOrderSide = function(value) {
   jspb.Message.setField(this, 3, value);
 };
 
 
 /**
- * optional int64 amount = 4;
+ * optional int64 rate = 4;
  * @return {number}
  */
-proto.boltzrpc.CreateReverseSwapRequest.prototype.getAmount = function() {
+proto.boltzrpc.CreateReverseSwapRequest.prototype.getRate = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
 };
 
 
 /** @param {number} value */
-proto.boltzrpc.CreateReverseSwapRequest.prototype.setAmount = function(value) {
+proto.boltzrpc.CreateReverseSwapRequest.prototype.setRate = function(value) {
   jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * optional string claim_public_key = 5;
+ * @return {string}
+ */
+proto.boltzrpc.CreateReverseSwapRequest.prototype.getClaimPublicKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/** @param {string} value */
+proto.boltzrpc.CreateReverseSwapRequest.prototype.setClaimPublicKey = function(value) {
+  jspb.Message.setField(this, 5, value);
+};
+
+
+/**
+ * optional int64 amount = 6;
+ * @return {number}
+ */
+proto.boltzrpc.CreateReverseSwapRequest.prototype.getAmount = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 6, 0));
+};
+
+
+/** @param {number} value */
+proto.boltzrpc.CreateReverseSwapRequest.prototype.setAmount = function(value) {
+  jspb.Message.setField(this, 6, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -132,7 +132,9 @@ class Service {
   /**
    * Creates a new Swap from the chain to Lightning
    */
-  public createSwap = async (args: { pairId: string, orderSide: number, invoice: string, refundPublicKey: string, outputType: number }) => {
+  public createSwap = async (args: { baseCurrency: string, quoteCurrency: string, orderSide: number, rate: number
+    invoice: string, refundPublicKey: string, outputType: number }) => {
+
     const { swapManager } = this.serviceComponents;
 
     const orderSide = this.getOrderSide(args.orderSide);
@@ -140,20 +142,22 @@ class Service {
 
     const refundPublicKey = getHexBuffer(args.refundPublicKey);
 
-    return await swapManager.createSwap(args.pairId, orderSide, args.invoice, refundPublicKey, outputType);
+    return await swapManager.createSwap(args.baseCurrency, args.quoteCurrency, orderSide, args.rate, args.invoice, refundPublicKey, outputType);
   }
 
   /**
    * Creates a new Swap from Lightning to the chain
    */
-  public createReverseSwap = async (args: { pairId: string, orderSide: number, claimPublicKey: string, amount: number }) => {
+  public createReverseSwap = async (args: { baseCurrency: string, quoteCurrency: string, orderSide: number, rate: number,
+    claimPublicKey: string, amount: number }) => {
+
     const { swapManager } = this.serviceComponents;
 
     const orderSide = this.getOrderSide(args.orderSide);
 
     const claimPublicKey = getHexBuffer(args.claimPublicKey);
 
-    return await swapManager.createReverseSwap(args.pairId, orderSide, claimPublicKey, args.amount);
+    return await swapManager.createReverseSwap(args.baseCurrency, args.quoteCurrency, orderSide, args.rate, claimPublicKey, args.amount);
   }
 
   private getCurrency = (currencySymbol: string) => {

--- a/lib/swap/Errors.ts
+++ b/lib/swap/Errors.ts
@@ -3,8 +3,8 @@ import { ErrorCodePrefix } from '../consts/Enums';
 import { concatErrorCode } from '../Utils';
 
 export default {
-  PAIR_NOT_FOUND: (pairId: string): Error => ({
-    message: `could not find pair ${pairId}`,
+  CURRENCY_NOT_FOUND: (currency: string): Error => ({
+    message: `could not find currency: ${currency}`,
     code: concatErrorCode(ErrorCodePrefix.Swap, 0),
   }),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@boltz/bitcoin-ops": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@boltz/bitcoin-ops/-/bitcoin-ops-2.0.0.tgz",
+      "integrity": "sha512-AM7vFNwSD7B4XI6yeRKccWbbD/lvwoFr8U3pqhzryBQo4uMkYe5V3/kMVnml4SNuxzyqdIFu4ur3TId02sC33A=="
+    },
     "@fimbul/bifrost": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@fimbul/bifrost/-/bifrost-0.15.0.tgz",
@@ -43,11 +48,6 @@
         "reflect-metadata": "^0.1.12",
         "tslib": "^1.8.1"
       }
-    },
-    "@michael1011/bitcoin-ops": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@michael1011/bitcoin-ops/-/bitcoin-ops-1.4.3.tgz",
-      "integrity": "sha512-U3KPRLaIdmbfbFrMaVV/CxZl3uzqvUU3lVeh2tnfxo48iduKFtQn1g5axGD+X2LD4f+0hu0u85bLQZ0JAzS95g=="
     },
     "@types/bip32": {
       "version": "1.0.0",
@@ -911,11 +911,11 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "boltz-core": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/boltz-core/-/boltz-core-0.0.2.tgz",
-      "integrity": "sha512-+vKJBKFZDlXVL3P26d1bwacqnO3IBaEoscbZk3Y8jX6sPCC2A6xPraXteN7qa00xUXUB4pSlZXMS+h1NJzVytA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/boltz-core/-/boltz-core-0.0.3.tgz",
+      "integrity": "sha512-ibEAcHwb5Y1eXzv+yD3J+Ij7WdVotWKc9W6QIst72A/PbMVXQK3Dw6ybV1O9Wha8oZ1TS77IFsu4N3QJE9wTvA==",
       "requires": {
-        "@michael1011/bitcoin-ops": "^1.4.3",
+        "@boltz/bitcoin-ops": "^2.0.0",
         "bip65": "^1.0.3",
         "bip66": "^1.1.5",
         "bitcoinjs-lib": "^4.0.2",
@@ -3257,13 +3257,13 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
@@ -3273,19 +3273,19 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
@@ -3295,43 +3295,43 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
@@ -3341,7 +3341,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
@@ -3350,7 +3350,7 @@
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
@@ -3359,7 +3359,7 @@
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
@@ -3369,25 +3369,25 @@
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
@@ -3396,25 +3396,25 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
@@ -3423,7 +3423,7 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
@@ -3432,7 +3432,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true
             }
@@ -3440,7 +3440,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -3449,25 +3449,25 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
@@ -3477,25 +3477,25 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
@@ -3506,13 +3506,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
@@ -3524,7 +3524,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "requires": {
@@ -3535,7 +3535,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
@@ -3551,7 +3551,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
@@ -3560,7 +3560,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true
             }
@@ -3568,7 +3568,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -3582,19 +3582,19 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "dev": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
@@ -3604,13 +3604,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
@@ -3622,13 +3622,13 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
@@ -3639,7 +3639,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
@@ -3649,19 +3649,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -3670,38 +3670,38 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
@@ -3710,19 +3710,19 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "dev": true,
           "requires": {
@@ -3734,7 +3734,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true
             }
@@ -3742,13 +3742,13 @@
         },
         "mime-db": {
           "version": "1.30.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.17",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
@@ -3757,7 +3757,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -3766,13 +3766,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -3781,13 +3781,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "node-pre-gyp": {
           "version": "0.6.38",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6Sog+DQWQVu0CG9tH7eLPac9ET0=",
           "dev": true,
           "requires": {
@@ -3805,7 +3805,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
@@ -3815,7 +3815,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
@@ -3827,25 +3827,25 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -3854,19 +3854,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
@@ -3876,37 +3876,37 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "requires": {
@@ -3918,7 +3918,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true
             }
@@ -3926,7 +3926,7 @@
         },
         "readable-stream": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
@@ -3941,7 +3941,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
@@ -3971,7 +3971,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
@@ -3980,31 +3980,31 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "semver": {
           "version": "5.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
@@ -4013,7 +4013,7 @@
         },
         "sshpk": {
           "version": "1.13.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "dev": true,
           "requires": {
@@ -4029,7 +4029,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true
             }
@@ -4037,7 +4037,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -4048,7 +4048,7 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
@@ -4057,13 +4057,13 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -4072,13 +4072,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
@@ -4089,7 +4089,7 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
           "requires": {
@@ -4105,7 +4105,7 @@
         },
         "tough-cookie": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
           "dev": true,
           "requires": {
@@ -4114,7 +4114,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
@@ -4123,32 +4123,32 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
@@ -4159,7 +4159,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true
             }
@@ -4167,7 +4167,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {
@@ -4176,7 +4176,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "bip39": "^2.5.0",
     "bitcoinjs-lib": "^4.0.2",
     "bluebird": "^3.5.3",
-    "boltz-core": "0.0.2",
+    "boltz-core": "0.0.3",
     "cross-os": "^1.3.0",
     "grpc": "^1.16.1",
     "ini": "^1.3.5",

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -107,11 +107,13 @@ message BroadcastTransactionResponse {
 }
 
 message CreateSwapRequest {
-  string pair_id = 1;
-  OrderSide order_side = 2;
-  string invoice = 3;
-  string refund_public_key = 4;
-  OutputType output_type = 5; 
+  string base_currency = 1;
+  string quote_currency = 2;
+  OrderSide order_side = 3;
+  int64 rate = 4;
+  string invoice = 5;
+  string refund_public_key = 6;
+  OutputType output_type = 7;
 }
 message CreateSwapResponse {
   string redeem_script = 1;
@@ -122,11 +124,13 @@ message CreateSwapResponse {
 }
 
 message CreateReverseSwapRequest {
-  string pair_id = 1;
-  OrderSide order_side = 2;
-  string claim_public_key = 3;
+  string base_currency = 1;
+  string quote_currency = 2;
+  OrderSide order_side = 3;
+  int64 rate = 4;
+  string claim_public_key = 5;
   // Amount of the invoice that will be returned
-  int64 amount = 4;
+  int64 amount = 6;
 }
 message CreateReverseSwapResponse {
   string invoice = 1;

--- a/test/unit/Utils.spec.ts
+++ b/test/unit/Utils.spec.ts
@@ -3,22 +3,6 @@ import os from 'os';
 import * as utils from '../../lib/Utils';
 
 describe('Utils', () => {
-  const base = 'LTC';
-  const quote = 'BTC';
-
-  const pairId = `${quote}/${base}`;
-
-  it('should concat pairId', () => {
-    expect(utils.getPairId(quote, base)).to.be.equal(pairId);
-  });
-
-  it('should split pairId', () => {
-    expect(utils.splitPairId(pairId)).to.be.deep.equal({
-      base,
-      quote,
-    });
-  });
-
   it('should split derivation path', () => {
     const master = 'm';
     const sub = [0, 2, 543];


### PR DESCRIPTION
This PR removes trading pairs from the backend and uses `base` and `quote` currencies instead. It also adds `rate`s to the `createSwap` and `createReverseSwap` methods.