### PR TITLE
Style & fee estimation

### DIFF
--- a/lib/chain/ChainClient.ts
+++ b/lib/chain/ChainClient.ts
@@ -93,19 +93,6 @@ class ChainClient extends BaseClient implements ChainClientInterface {
     return this.rpcClient.call<null>('loadtxfilter', reload, addresses, outpoints);
   }
 
-  /**
-   * Returns the estimated fee in stoshis per byte
-   *
-   * @param blocks after how many blocks the transaction should confirm
-   */
-  public estimateFee = async (blocks: number): Promise<number> => {
-    // BTCD returns the amount in whole Bitcoins per kilobyte not satoshis per byte and therefore the
-    // returned amount has to be multipled by 100000 to get the amount of satohis per byte
-    const bitcoins = await this.rpcClient.call<number>('estimatefee', blocks);
-
-    return Math.ceil(bitcoins * 100000);
-  }
-
   public sendRawTransaction = (rawTransaction: string, allowHighFees = true): Promise<string> => {
     return this.rpcClient.call<string>('sendrawtransaction', rawTransaction, allowHighFees);
   }

--- a/lib/chain/ChainClientInterface.ts
+++ b/lib/chain/ChainClientInterface.ts
@@ -47,8 +47,6 @@ interface ChainClientInterface {
 
   loadTxFiler (reload: boolean, addresses: string[], outpoints: string[]): Promise<null>;
 
-  estimateFee(blocks: number): Promise<number>;
-
   sendRawTransaction(rawTransaction: string, allowHighFees: boolean): Promise<string>;
   getRawTransaction(transactionHash: string): Promise<any>;
 

--- a/lib/lightning/Errors.ts
+++ b/lib/lightning/Errors.ts
@@ -4,7 +4,7 @@ import { concatErrorCode } from '../Utils';
 
 export default {
   COULD_NOT_FIND_FILES: (chainType: string): Error => ({
-    message: `could not find required files for LND ${chainType}`,
+    message: `could not find required files for ${chainType} LND`,
     code: concatErrorCode(ErrorCodePrefix.Lnd, 0),
   }),
 };

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -55,14 +55,9 @@ class Service extends EventEmitter {
    * Gets general information about this Boltz instance and the nodes it is connected to
    */
   public getInfo = async (): Promise<BoltzInfo> => {
-    const { currencies } = this.serviceComponents;
-    const version = packageJson.version;
-
     const currencyInfos: CurrencyInfo[] = [];
 
-    for (const entry of currencies) {
-      const currency = entry[1];
-
+    for (const [_, currency] of this.serviceComponents.currencies) {
       const chainInfo = await currency.chainClient.getInfo();
       const lndInfo = await currency.lndClient.getLndInfo();
 
@@ -74,7 +69,7 @@ class Service extends EventEmitter {
     }
 
     return {
-      version,
+      version: packageJson.version,
       currencies: currencyInfos,
     };
   }

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -1,5 +1,5 @@
 import { BIP32 } from 'bip32';
-import { Transaction, crypto } from 'bitcoinjs-lib';
+import { Transaction, crypto, address } from 'bitcoinjs-lib';
 import { OutputType, TransactionOutput, Scripts, pkRefundSwap, constructClaimTransaction } from 'boltz-core';
 import Logger from '../Logger';
 import { getHexBuffer, getHexString, getScriptHashEncodeFunction, reverseString } from '../Utils';
@@ -41,6 +41,7 @@ type SwapMaps = {
 // TODO: verify values and amounts
 // TODO: fees for the Boltz to collect
 // TODO: automatically refund failed swaps
+// TOOD: save pending swap to database to be able to claim/refund them if boltz crashes
 class SwapManager {
   public currencies = new Map<string, Currency & SwapMaps>();
 
@@ -243,8 +244,7 @@ class SwapManager {
     const preimage = payInvoice.paymentPreimage as string;
     this.logger.verbose(`Got preimage: ${preimage}`);
 
-    const destinationScript = p2wpkhOutput(crypto.hash160(details.claimKeys.publicKey));
-    const feePerByte = await currency.chainClient.estimateFee(1);
+    const destinationAddress = await this.walletManager.wallets.get(currency.symbol)!.getNewAddress(OutputType.Bech32);
 
     const claimTx = constructClaimTransaction(
       {
@@ -259,12 +259,11 @@ class SwapManager {
         script: outpuScript,
         value: outputValue,
       },
-      destinationScript,
-      feePerByte,
+      address.toOutputScript(destinationAddress, currency.network),
+      10,
     );
 
     this.logger.silly(`Broadcasting claim transaction: ${claimTx.getId()}`);
-
     await chainClient.sendRawTransaction(claimTx.toHex());
   }
 

--- a/lib/wallet/Wallet.ts
+++ b/lib/wallet/Wallet.ts
@@ -223,7 +223,7 @@ class Wallet {
       Promise<{ tx: Transaction, vout: number }> => {
 
     const utxos = await this.utxoRepository.getUtxosSorted(this.symbol);
-    const feePerByte = await this.chainClient.estimateFee(1);
+    const feePerByte = 10;
 
     // The UTXOs that will be spent
     const toSpend: UTXO[] = [];

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "docker:stop": "docker kill simnet && docker rm simnet",
     "test": "npm run test:unit && npm run test:int",
     "test:unit": "mocha test/unit/*.spec.ts test/unit/wallet/*.spec.ts",
-    "test:int": "npm run test:int:nostop && npm run docker:stop",
-    "test:int:nostop": "npm run docker:start && mocha test/integration/lightning/*.spec.ts test/integration/chain/*.spec.ts test/integration/swap/*.spec.ts test/integration/wallet/*.spec.ts"
+    "test:int": "npm run docker:start && mocha test/integration/lightning/*.spec.ts test/integration/chain/*.spec.ts test/integration/swap/*.spec.ts test/integration/wallet/*.spec.ts && npm run docker:stop"
   },
   "bin": {
     "boltzd": "./bin/boltzd",


### PR DESCRIPTION
This PR:

- fixes some minor details (wording, code style, and cleanup of the test scripts in `package.json`)
- removes the `estimateFee` RPC call from the ChainClient because LTCD does not support it. Checkout [this commit message](https://github.com/BoltzExchange/boltz-backend/commit/358dc252ad10b92663be13f2540e9257ee9d9981) for a more comprehensive explanation why.