### PR TITLE
Check unconfirmed UTXOs on startup

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -1,14 +1,13 @@
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 import toml from 'toml';
-import ini from 'ini';
 import { Arguments } from 'yargs';
 import { pki, md } from 'node-forge';
-import { deepMerge, resolveHome, splitListen, getServiceDataDir } from './Utils';
-import { RpcConfig } from './RpcClient';
-import { LndConfig } from './lightning/LndClient';
-import { GrpcConfig } from './grpc/GrpcServer';
 import Errors from './consts/Errors';
+import { RpcConfig } from './RpcClient';
+import { GrpcConfig } from './grpc/GrpcServer';
+import { LndConfig } from './lightning/LndClient';
+import { deepMerge, resolveHome, getServiceDataDir } from './Utils';
 
 type ServiceOptions = {
   configpath?: string;
@@ -140,35 +139,6 @@ class Config {
     deepMerge(this.config, args);
 
     return this.config;
-  }
-
-  // TODO: don't use "deepMerge" in "parseIniConfig"
-  private parseIniConfig = (filename: string, mergeTarget: any, isLndConfig: boolean) => {
-    if (fs.existsSync(filename)) {
-      try {
-        const config = ini.parse(fs.readFileSync(filename, 'utf-8'))['Application Options'];
-
-        if (isLndConfig) {
-          const configLND: LndConfig = config;
-          if (config.listen) {
-            const listen = splitListen(config.listen);
-            mergeTarget.host = listen.host;
-            mergeTarget.port = listen.port;
-          }
-          deepMerge(mergeTarget, configLND);
-        } else {
-          const configClient: RpcConfig = config;
-          if (config.listen) {
-            const listen = splitListen(config.listen);
-            mergeTarget.host = listen.host;
-            mergeTarget.port = listen.port;
-          }
-          deepMerge(mergeTarget, configClient);
-        }
-      } catch (error) {
-        throw Errors.COULD_NOT_PARSE_CONFIG(filename, JSON.stringify(error));
-      }
-    }
   }
 
   private parseTomlConfig = (filename: string): any => {

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -216,3 +216,14 @@ export const getScriptHashEncodeFunction = (outputType: OutputType) => {
 export const reverseString = (input: string) => {
   return input.split('').reverse().join('');
 };
+
+export const reverseBuffer = (input: Buffer) => {
+  const buffer = Buffer.allocUnsafe(input.length);
+
+  for (let i = 0, j = input.length - 1; i <= j; i += 1, j -= 1) {
+    buffer[i] = input[j];
+    buffer[j] = input[i];
+  }
+
+  return buffer;
+};

--- a/lib/chain/ChainClient.ts
+++ b/lib/chain/ChainClient.ts
@@ -97,8 +97,8 @@ class ChainClient extends BaseClient implements ChainClientInterface {
     return this.rpcClient.call<string>('sendrawtransaction', rawTransaction, allowHighFees);
   }
 
-  public getRawTransaction = (transactionHash: string) => {
-    return this.rpcClient.call<any>('getrawtransaction', transactionHash);
+  public getRawTransaction = (transactionHash: string, verbose = 0) => {
+    return this.rpcClient.call<any>('getrawtransaction', transactionHash, verbose);
   }
 
   public generate = (blocks: number): Promise<string[]> => {

--- a/lib/chain/ChainClientInterface.ts
+++ b/lib/chain/ChainClientInterface.ts
@@ -48,7 +48,7 @@ interface ChainClientInterface {
   loadTxFiler (reload: boolean, addresses: string[], outpoints: string[]): Promise<null>;
 
   sendRawTransaction(rawTransaction: string, allowHighFees: boolean): Promise<string>;
-  getRawTransaction(transactionHash: string): Promise<any>;
+  getRawTransaction(transactionHash: string, verbose: number): Promise<any>;
 
   generate(blocks: number): Promise<string[]>;
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -57,7 +57,7 @@ class Service extends EventEmitter {
   public getInfo = async (): Promise<BoltzInfo> => {
     const currencyInfos: CurrencyInfo[] = [];
 
-    for (const [_, currency] of this.serviceComponents.currencies) {
+    for (const [, currency] of this.serviceComponents.currencies) {
       const chainInfo = await currency.chainClient.getInfo();
       const lndInfo = await currency.lndClient.getLndInfo();
 

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -40,7 +40,7 @@ type SwapMaps = {
 // TODO: verify values and amounts
 // TODO: fees for the Boltz to collect
 // TODO: automatically refund failed swaps
-// TOOD: save pending swap to database to be able to claim/refund them if boltz crashes
+// TODO: save pending swap to database to be able to claim/refund them if boltz crashes
 class SwapManager {
   public currencies = new Map<string, Currency & SwapMaps>();
 

--- a/lib/wallet/UtxoRepository.ts
+++ b/lib/wallet/UtxoRepository.ts
@@ -24,6 +24,15 @@ class UtxoRepository {
     });
   }
 
+  public getUnconfirmedUtxos = async (currency: string) => {
+    return this.models.Utxo.findAll({
+      where: {
+        currency,
+        confirmed: false,
+      },
+    });
+  }
+
   public getUtxo = async (txHash: string) => {
     return this.models.Utxo.findAll({
       where: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3064,7 +3064,7 @@
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
@@ -3074,7 +3074,7 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true
         },
@@ -3098,7 +3098,7 @@
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true
         },
@@ -3110,7 +3110,7 @@
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
@@ -3138,7 +3138,7 @@
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
@@ -3166,7 +3166,7 @@
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
@@ -3228,7 +3228,7 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true
         },
@@ -3246,7 +3246,7 @@
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
@@ -3256,7 +3256,7 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true
         },
@@ -3347,7 +3347,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -3361,7 +3361,7 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
@@ -3434,7 +3434,7 @@
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
@@ -3521,13 +3521,13 @@
         },
         "mime-db": {
           "version": "1.30.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.17",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
@@ -3566,7 +3566,7 @@
         },
         "node-pre-gyp": {
           "version": "0.6.38",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6Sog+DQWQVu0CG9tH7eLPac9ET0=",
           "dev": true,
           "requires": {
@@ -3645,7 +3645,7 @@
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
@@ -3667,7 +3667,7 @@
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
@@ -3685,7 +3685,7 @@
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "requires": {
@@ -3697,7 +3697,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true
             }
@@ -3705,7 +3705,7 @@
         },
         "readable-stream": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
@@ -3759,13 +3759,13 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "semver": {
           "version": "5.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
@@ -3792,7 +3792,7 @@
         },
         "sshpk": {
           "version": "1.13.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "dev": true,
           "requires": {
@@ -3808,7 +3808,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true
             }
@@ -3827,7 +3827,7 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
@@ -3836,7 +3836,7 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true
         },
@@ -3868,7 +3868,7 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
           "requires": {
@@ -3884,7 +3884,7 @@
         },
         "tough-cookie": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
           "dev": true,
           "requires": {
@@ -3921,7 +3921,7 @@
         },
         "uuid": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         },
@@ -3946,7 +3946,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {

--- a/test/integration/chain/ChainClient.spec.ts
+++ b/test/integration/chain/ChainClient.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import path from 'path';
 import { ECPair, TransactionBuilder, Transaction, Network } from 'bitcoinjs-lib';
 import { Networks } from 'boltz-core';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
     "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
     /* Additional Checks */
-    "noUnusedLocals": false, /* Report errors on unused locals. */
+    "noUnusedLocals": true, /* Report errors on unused locals. */
     "noUnusedParameters": true, /* Report errors on unused parameters. */
     "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,6 @@
     "max-line-length": [true, 150],
     "no-else-after-return": false,
     "function-name": false,
-    "no-unused-variable": false, // TODO: rule disabled during early development stages, should be reenabled later
     "align": false,
     "typedef-whitespace": [
       true, {


### PR DESCRIPTION
This PR is the first one that starts working on improving the wallet of `boltz-backend`. Unconfirmed funds that Boltz found in the mempool before a restart will be looked up to find out whether they got included in a block and if not treated like all other unconfirmed UTXOs (listen to events from BTCD until included in a block).

From this PR onwards the BTCD and LTCD nodes Boltz is connected to have to have `txindex` enabled so that the aforementioned transactions can be looked up.