### PR TITLE
feat: detect multiple UTXOs per output

### DIFF
--- a/lib/consts/Database.ts
+++ b/lib/consts/Database.ts
@@ -1,6 +1,7 @@
 import Sequelize, { DataTypeAbstract, DefineAttributeColumnOptions } from 'sequelize';
 import { WalletInfo } from './Types';
 
+// TODO: don't have currency in OutputFactory and UtxoFactory
 export type SequelizeAttributes<T extends { [key: string]: any }> = {
   [P in keyof T]: string | DataTypeAbstract | DefineAttributeColumnOptions
 };
@@ -23,18 +24,31 @@ export type WalletAttributes = WalletFactory;
 
 export type WalletInstance = WalletAttributes & Sequelize.Instance<WalletAttributes>;
 
-export type UtxoFactory = {
-  txHash: string;
-  currency: string;
-  keyIndex: number;
-  vout: number;
+export type OutputFactory = {
   script: string;
   redeemScript?: string;
-  value: number;
+  currency: string;
+  keyIndex: number;
   type: number;
-  confirmed: boolean;
 };
 
-export type UtxoAttributes = UtxoFactory;
+export type OutputAttributes = OutputFactory & {
+  id: number;
+};
+
+export type OutputInstance = OutputAttributes & Sequelize.Instance<OutputAttributes>;
+
+export type UtxoFactory = {
+  txHash: string;
+  vout: number;
+  currency: string,
+  value: number;
+  confirmed: boolean;
+  outputId: number;
+};
+
+export type UtxoAttributes = UtxoFactory & {
+  id: number;
+};
 
 export type UtxoInstance = UtxoAttributes & Sequelize.Instance<UtxoAttributes>;

--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -6,6 +6,7 @@ import Logger from '../Logger';
 
 type Models = {
   Wallet: Sequelize.Model<db.WalletInstance, db.WalletAttributes>;
+  Output: Sequelize.Model<db.OutputInstance, db.OutputAttributes>;
   Utxo: Sequelize.Model<db.UtxoInstance, db.UtxoAttributes>;
 };
 
@@ -38,6 +39,7 @@ class Db {
 
     await Promise.all([
       this.models.Wallet.sync(),
+      this.models.Output.sync(),
       this.models.Utxo.sync(),
     ]);
   }

--- a/lib/db/models/Ouput.ts
+++ b/lib/db/models/Ouput.ts
@@ -1,0 +1,28 @@
+import Sequelize from 'sequelize';
+import * as db from '../../consts/Database';
+
+export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) => {
+  const attributes: db.SequelizeAttributes<db.OutputAttributes> = {
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    script: { type: dataTypes.STRING, allowNull: false },
+    redeemScript: { type: dataTypes.STRING, allowNull: true },
+    currency: { type: dataTypes.STRING, allowNull: false },
+    keyIndex: { type: dataTypes.INTEGER, allowNull: false },
+    type: { type: dataTypes.INTEGER, allowNull: false },
+  };
+
+  const options: Sequelize.DefineOptions<db.OutputInstance> = {
+    tableName: 'outputs',
+    timestamps: false,
+  };
+
+  const Output = sequelize.define<db.OutputInstance, db.OutputAttributes>('Output', attributes, options);
+
+  Output.associate = (models: Sequelize.Models) => {
+    models.Utxo.belongsTo(models.Wallet, {
+      foreignKey: 'currency',
+    });
+  };
+
+  return Output;
+};

--- a/lib/db/models/Utxo.ts
+++ b/lib/db/models/Utxo.ts
@@ -3,15 +3,13 @@ import * as db from '../../consts/Database';
 
 export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) => {
   const attributes: db.SequelizeAttributes<db.UtxoAttributes> = {
-    txHash: { type: dataTypes.STRING, primaryKey: true, allowNull: false },
-    currency: { type: dataTypes.STRING, allowNull: false },
-    keyIndex: { type: dataTypes.INTEGER, allowNull: false },
+    id: { type: dataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    txHash: { type: dataTypes.STRING, allowNull: false },
     vout: { type: dataTypes.INTEGER, allowNull: false },
-    script: { type: dataTypes.STRING, allowNull: false },
-    redeemScript: { type: dataTypes.STRING, allowNull: true },
+    currency: { type: dataTypes.STRING, allowNull: false },
     value: { type: dataTypes.INTEGER, allowNull: false },
-    type: { type: dataTypes.INTEGER, allowNull: false },
     confirmed: { type: dataTypes.BOOLEAN, allowNull: true },
+    outputId: { type: dataTypes.INTEGER, allowNull: false },
   };
 
   const options: Sequelize.DefineOptions<db.UtxoInstance> = {
@@ -22,8 +20,8 @@ export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) 
   const Utxo = sequelize.define<db.UtxoInstance, db.UtxoAttributes>('Utxo', attributes, options);
 
   Utxo.associate = (models: Sequelize.Models) => {
-    models.Utxo.belongsTo(models.Wallet, {
-      foreignKey: 'currency',
+    models.Utxo.belongsTo(models.Output, {
+      foreignKey: 'outputId',
     });
   };
 

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -1,5 +1,5 @@
 import { BIP32 } from 'bip32';
-import { Transaction, crypto, address } from 'bitcoinjs-lib';
+import { Transaction, address } from 'bitcoinjs-lib';
 import { OutputType, TransactionOutput, Scripts, pkRefundSwap, constructClaimTransaction } from 'boltz-core';
 import Logger from '../Logger';
 import { getHexBuffer, getHexString, getScriptHashEncodeFunction, reverseString } from '../Utils';
@@ -8,7 +8,7 @@ import WalletManager, { Currency } from '../wallet/WalletManager';
 import { OrderSide } from '../proto/boltzrpc_pb';
 import LndClient from '../lightning/LndClient';
 
-const { p2wpkhOutput, p2shP2wshOutput } = Scripts;
+const { p2shP2wshOutput } = Scripts;
 
 type BaseSwapDetails = {
   redeemScript: Buffer;
@@ -87,10 +87,7 @@ class SwapManager {
 
     this.logger.verbose(`Creating new Swap from ${receivingCurrency.symbol} to ${sendingCurrency.symbol} with preimage hash: ${paymentHash}`);
 
-    const { keys, index } = receivingCurrency.wallet.getNewKeys();
-
-    // Listen to the address to which the swap output will be claimed
-    await receivingCurrency.wallet.listenToOutput(p2wpkhOutput(crypto.hash160(keys.publicKey)), index, OutputType.Bech32);
+    const { keys } = receivingCurrency.wallet.getNewKeys();
 
     const timeoutBlockHeight = bestBlock.height + 10;
     const redeemScript = pkRefundSwap(

--- a/lib/wallet/OutputRepository.ts
+++ b/lib/wallet/OutputRepository.ts
@@ -1,0 +1,20 @@
+import { Models } from '../db/Database';
+import * as db from '../consts/Database';
+
+class OutputRepository {
+  constructor(private models: Models) {}
+
+  public getOutputs = async (currency: string) => {
+    return this.models.Output.findAll({
+      where: {
+        currency,
+      },
+    });
+  }
+
+  public addOutput = async (output: db.OutputFactory) => {
+    return this.models.Output.create(<db.OutputAttributes>output);
+  }
+}
+
+export default OutputRepository;

--- a/lib/wallet/UtxoRepository.ts
+++ b/lib/wallet/UtxoRepository.ts
@@ -59,7 +59,7 @@ class UtxoRepository {
   }
 
   public addUtxo = async (utxo: db.UtxoFactory) => {
-    return this.models.Utxo.create(utxo);
+    return this.models.Utxo.create(<db.UtxoAttributes>utxo);
   }
 
   public removeUtxo = async (txHash: string) => {

--- a/lib/wallet/Wallet.ts
+++ b/lib/wallet/Wallet.ts
@@ -7,6 +7,7 @@ import UtxoRepository from './UtxoRepository';
 import ChainClient from '../chain/ChainClient';
 import WalletRepository from './WalletRepository';
 import { UtxoInstance } from '../consts/Database';
+import OutputRepository from './OutputRepository';
 import { getPubKeyHashEncodeFuntion, getHexString, getHexBuffer, reverseBuffer } from '../Utils';
 
 type UTXO = TransactionOutput & {
@@ -22,10 +23,13 @@ type WalletBalance = {
 
 // TODO: detect funds received whlie Boltz was not running
 // TODO: more advanced UTXO management
-// TODO: multiple transaction to same output
 // TODO: multiple outputs to the wallet in one transaction
 class Wallet {
-  private relevantOutputs = new Map<string, { keyIndex: number, type: OutputType, redeemScript?: string }>();
+  // A map between output scripts and information necessary to spend them
+  private relevantOutputs = new Map<string, { id: number, keyIndex: number, type: OutputType, redeemScript?: string }>();
+
+  // A map between the ids and relevant output scripts
+  private outputIds = new Map<number, string>();
 
   private symbol: string;
 
@@ -41,6 +45,7 @@ class Wallet {
   constructor(
     private logger: Logger,
     private walletRepository: WalletRepository,
+    private outputRepository: OutputRepository,
     private utxoRepository: UtxoRepository,
     private masterNode: BIP32,
     public readonly network: Network,
@@ -68,8 +73,6 @@ class Wallet {
         if (outputInfo) {
           if (confirmed) {
             this.logUtxoFoundMessage(true, transaction.getId(), vout, output.value, blockHeight);
-            this.relevantOutputs.delete(hexScript);
-
           } else {
             this.logUtxoFoundMessage(false, transaction.getId(), vout, output.value);
           }
@@ -78,11 +81,9 @@ class Wallet {
             vout,
             confirmed,
             currency: this.symbol,
-            txHash: getHexString(transaction.getHash()),
-            script: getHexString(output.script),
-            redeemScript: outputInfo.redeemScript,
             value: output.value,
-            ...outputInfo,
+            outputId: outputInfo.id,
+            txHash: getHexString(transaction.getHash()),
           });
 
           if (confirmed) {
@@ -108,12 +109,30 @@ class Wallet {
 
       upsertUtxo(txHex, blockHeight);
     });
-
-    this.checkUnconfirmedFunds();
   }
 
   public get highestUsedIndex() {
     return this.highestIndex;
+  }
+
+  public init = async () => {
+    const outputs = await this.outputRepository.getOutputs(this.symbol);
+    const addresses: string[] = [];
+
+    outputs.forEach((output) => {
+      addresses.push(this.encodeAddress(getHexBuffer(output.script)));
+
+      this.outputIds.set(output.id, output.script);
+      this.relevantOutputs.set(output.script, {
+        id: output.id,
+        keyIndex: output.keyIndex,
+        type: output.type,
+        redeemScript: output.redeemScript,
+      });
+    });
+
+    await this.chainClient.loadTxFiler(false, addresses, []);
+    await this.checkUnconfirmedFunds();
   }
 
   /**
@@ -164,6 +183,7 @@ class Wallet {
     }
 
     const address = this.encodeAddress(outputScript);
+    this.logger.debug(`Generated new ${this.symbol} address: ${address}`);
 
     await this.listenToOutput(outputScript, index, type, address, redeemScript);
 
@@ -180,16 +200,6 @@ class Wallet {
       outputScript,
       this.network,
     );
-  }
-
-  /**
-   * Add an output that can be spent by the wallet
-   */
-  public listenToOutput = async (output: Buffer, keyIndex: number, type: OutputType, address?: string, redeemScript?: string) => {
-    this.relevantOutputs.set(getHexString(output), { keyIndex, type, redeemScript });
-
-    const chainAddress = address ? address : this.encodeAddress(output);
-    await this.chainClient.loadTxFiler(false, [chainAddress], []);
   }
 
   /**
@@ -246,16 +256,19 @@ class Wallet {
 
     // Accumulate UTXOs to spend
     for (const utxoInstance of utxos) {
-      const redeemScript = utxoInstance.redeemScript ? getHexBuffer(utxoInstance.redeemScript) : undefined;
+      const script = this.outputIds.get(utxoInstance.outputId)!;
+      const output = this.relevantOutputs.get(script)!;
+
+      const redeemScript = output.redeemScript ? getHexBuffer(output.redeemScript) : undefined;
 
       toSpend.push({
         redeemScript,
         txHash: getHexBuffer(utxoInstance.txHash),
         vout: utxoInstance.vout,
-        type: utxoInstance.type,
-        script: getHexBuffer(utxoInstance.script),
+        type: output.type,
+        script: getHexBuffer(script),
         value: utxoInstance.value,
-        keys: this.getKeysByIndex(utxoInstance.keyIndex),
+        keys: this.getKeysByIndex(output.keyIndex),
       });
 
       toRemove.push(utxoInstance.txHash);
@@ -327,37 +340,59 @@ class Wallet {
   /**
    * Checks if unconfirmed funds got confirmed since last startup
    */
-  private checkUnconfirmedFunds = () => {
-    this.utxoRepository.getUnconfirmedUtxos(this.symbol).then((utxos: UtxoInstance[]) => {
-      utxos.forEach(async (utxo) => {
-        // The reversed version of the hex representation of a Buffer is not equal to the reversed Buffer.
-        // Therefore we have to go full circle from a string to back to the Buffer, reverse that Buffer
-        // and convert it back to a string to get the id of the transaction that is used by BTCD
-        const transactionId = getHexString(
-          reverseBuffer(
-            getHexBuffer(utxo.txHash),
-          ),
-        );
+  private checkUnconfirmedFunds = async () => {
+    const utxos = await this.utxoRepository.getUnconfirmedUtxos(this.symbol);
 
-        const transactionInfo = await this.chainClient.getRawTransaction(transactionId, 1);
+    utxos.forEach(async (utxo) => {
+      // The reversed version of the hex representation of a Buffer is not equal to the reversed Buffer.
+      // Therefore we have to go full circle from a string to back to the Buffer, reverse that Buffer
+      // and convert it back to a string to get the id of the transaction that is used by BTCD
+      const transactionId = getHexString(
+        reverseBuffer(
+          getHexBuffer(utxo.txHash),
+        ),
+      );
 
-        if (transactionInfo.confirmations) {
-          const bestBlock = await this.chainClient.getBestBlock();
+      const transactionInfo = await this.chainClient.getRawTransaction(transactionId, 1);
 
-          // BTCD shows 1 confirmtation if the transaction in the best block (tip of the chain). Therefore to get the
-          // block height in which it got confirmed we have to get the height of the best block minus how deep the block
-          // in which the transaction confirmed is in the chain (confirmations minus one)
-          this.logUtxoFoundMessage(true, transactionId, utxo.vout, utxo.value, bestBlock.height - (transactionInfo.confirmations - 1));
+      if (transactionInfo.confirmations) {
+        const bestBlock = await this.chainClient.getBestBlock();
 
-          utxo.set('confirmed', true);
-          await utxo.save();
-        } else {
-          // Listen and wait for the transaction to get confirmed
-          await this.listenToOutput(getHexBuffer(utxo.script), utxo.keyIndex, utxo.type, undefined, utxo.redeemScript);
-        }
-      });
-    }).catch((error) => {
-      this.logger.error(`Could not get unconfirmed UTXOs: ${error}`);
+        // BTCD shows 1 confirmtation if the transaction in the best block (tip of the chain). Therefore to get the
+        // block height in which it got confirmed we have to get the height of the best block minus how deep the block
+        // in which the transaction confirmed is in the chain (confirmations minus one)
+        this.logUtxoFoundMessage(true, transactionId, utxo.vout, utxo.value, bestBlock.height - (transactionInfo.confirmations - 1));
+
+        utxo.set('confirmed', true);
+        await utxo.save();
+      }
+    });
+  }
+
+  /**
+   * Add an output that can be spent by the wallet
+   */
+  private listenToOutput = async (script: Buffer, keyIndex: number, type: OutputType, address?: string, redeemScript?: string) => {
+    const scriptString = getHexString(script);
+
+    const chainAddress = address ? address : this.encodeAddress(script);
+
+    await this.chainClient.loadTxFiler(false, [chainAddress], []);
+
+    const outputInstance = await this.outputRepository.addOutput({
+      type,
+      keyIndex,
+      redeemScript,
+      script: scriptString,
+      currency: this.symbol,
+    });
+
+    this.outputIds.set(outputInstance.id, scriptString);
+    this.relevantOutputs.set(scriptString, {
+      type,
+      keyIndex,
+      redeemScript,
+      id: outputInstance.id,
     });
   }
 

--- a/test/integration/wallet/Wallet.spec.ts
+++ b/test/integration/wallet/Wallet.spec.ts
@@ -9,6 +9,7 @@ import Database from '../../../lib/db/Database';
 import UtxoRepository from '../../../lib/wallet/UtxoRepository';
 import WalletRepository from '../../../lib/wallet/WalletRepository';
 import { getOutputType } from '../../../lib/Utils';
+import OutputRepository from '../../../lib/wallet/OutputRepository';
 
 // TODO: test detection of UTXOs in mempool
 describe('Wallet', () => {
@@ -20,11 +21,13 @@ describe('Wallet', () => {
 
   const database = new Database(Logger.disabledLogger, ':memory:');
   const walletRepository = new WalletRepository(database.models);
+  const outputRepository = new OutputRepository(database.models);
   const utxoRepository = new UtxoRepository(database.models);
 
   const wallet = new Wallet(
     Logger.disabledLogger,
     walletRepository,
+    outputRepository,
     utxoRepository,
     masterNode,
     Networks.bitcoinSimnet,


### PR DESCRIPTION
This PR refactors the way UTXOs and addresses are handled by separating the UTXOs and outputs (scripts of the addresses) in the database which means that:
- every address can have multiple UTXOs in an efficient way (also known as address reuse; should be avoided if possible)
- there are no problems if a single transaction sends funds to multiple addresses of Boltz (the transaction hash used to be the primary key of the `utxos` table in the database)
- Boltz listens new transactions on all addresses the wallet ever created. Before this PR Boltz forgot about old addresses it created  on every restart.

This is a breaking change to the database. Please remove your existing `boltz.db` before running Boltz.