### PR TITLE
feat(grpc): add preimage to invoice settled events

### DIFF
--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -167,11 +167,12 @@ class GrpcService {
       call.write(response);
     });
 
-    this.service.on('invoice.settled', (invoice: string) => {
+    this.service.on('invoice.settled', (invoice: string, preimage: string) => {
       const response = new boltzrpc.SubscribeInvoicesResponse();
 
       response.setEvent(boltzrpc.InvoiceEvent.SETTLED);
       response.setInvoice(invoice);
+      response.setPreimage(preimage);
 
       call.write(response);
     });

--- a/lib/lightning/LndClient.ts
+++ b/lib/lightning/LndClient.ts
@@ -3,9 +3,9 @@ import grpc, { ClientReadableStream } from 'grpc';
 import Errors from './Errors';
 import Logger from '../Logger';
 import BaseClient from '../BaseClient';
-import LightningClient from './LightningClient';
 import * as lndrpc from '../proto/lndrpc_pb';
 import { ClientStatus } from '../consts/Enums';
+import LightningClient from './LightningClient';
 import { LightningClient as GrpcClient } from '../proto/lndrpc_grpc_pb';
 
 // TODO: error handling
@@ -43,8 +43,8 @@ interface LndClient {
   on(event: 'invoice.paid', listener: (invoice: string) => void): this;
   emit(event: 'invoice.paid', invoice: string): boolean;
 
-  on(event: 'invoice.settled', listener: (invoice: string) => void): this;
-  emit(event: 'invoice.settled', string: string): boolean;
+  on(event: 'invoice.settled', listener: (invoice: string, preimage: string) => void): this;
+  emit(event: 'invoice.settled', string: string, preimage: string): boolean;
 }
 
 interface LightningMethodIndex extends GrpcClient {
@@ -313,7 +313,7 @@ class LndClient extends BaseClient implements LightningClient {
           const paymentReq = invoice.getPaymentRequest();
 
           this.logger.silly(`${this.symbol} LND invoice settled: ${paymentReq}`);
-          this.emit('invoice.settled', paymentReq);
+          this.emit('invoice.settled', paymentReq, invoice.getRPreimage_asB64());
         }
       })
       .on('error', (error) => {

--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -505,6 +505,9 @@ export class SubscribeInvoicesResponse extends jspb.Message {
     getInvoice(): string;
     setInvoice(value: string): void;
 
+    getPreimage(): string;
+    setPreimage(value: string): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): SubscribeInvoicesResponse.AsObject;
@@ -520,6 +523,7 @@ export namespace SubscribeInvoicesResponse {
     export type AsObject = {
         event: InvoiceEvent,
         invoice: string,
+        preimage: string,
     }
 }
 

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -3417,7 +3417,8 @@ proto.boltzrpc.SubscribeInvoicesResponse.prototype.toObject = function(opt_inclu
 proto.boltzrpc.SubscribeInvoicesResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     event: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    invoice: jspb.Message.getFieldWithDefault(msg, 2, "")
+    invoice: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    preimage: jspb.Message.getFieldWithDefault(msg, 3, "")
   };
 
   if (includeInstance) {
@@ -3462,6 +3463,10 @@ proto.boltzrpc.SubscribeInvoicesResponse.deserializeBinaryFromReader = function(
       var value = /** @type {string} */ (reader.readString());
       msg.setInvoice(value);
       break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setPreimage(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -3505,6 +3510,13 @@ proto.boltzrpc.SubscribeInvoicesResponse.serializeBinaryToWriter = function(mess
       f
     );
   }
+  f = message.getPreimage();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
 };
 
 
@@ -3535,6 +3547,21 @@ proto.boltzrpc.SubscribeInvoicesResponse.prototype.getInvoice = function() {
 /** @param {string} value */
 proto.boltzrpc.SubscribeInvoicesResponse.prototype.setInvoice = function(value) {
   jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional string preimage = 3;
+ * @return {string}
+ */
+proto.boltzrpc.SubscribeInvoicesResponse.prototype.getPreimage = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.boltzrpc.SubscribeInvoicesResponse.prototype.setPreimage = function(value) {
+  jspb.Message.setField(this, 3, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -1,14 +1,14 @@
 import { EventEmitter } from 'events';
 import { Transaction, address } from 'bitcoinjs-lib';
-import Logger from '../Logger';
-import { Info as ChainInfo } from '../chain/ChainClientInterface';
-import { Info as LndInfo } from '../lightning/LndClient';
-import SwapManager from '../swap/SwapManager';
-import WalletManager, { Currency } from '../wallet/WalletManager';
-import { WalletBalance } from '../wallet/Wallet';
 import Errors from './Errors';
-import { getHexBuffer, getOutputType, getHexString } from '../Utils';
+import Logger from '../Logger';
+import SwapManager from '../swap/SwapManager';
 import { OrderSide } from '../proto/boltzrpc_pb';
+import { WalletBalance } from '../wallet/Wallet';
+import { Info as LndInfo } from '../lightning/LndClient';
+import { Info as ChainInfo } from '../chain/ChainClientInterface';
+import WalletManager, { Currency } from '../wallet/WalletManager';
+import { getHexBuffer, getOutputType, getHexString } from '../Utils';
 
 const packageJson = require('../../package.json');
 
@@ -37,8 +37,8 @@ interface Service {
   on(even: 'invoice.paid', listener: (invoice: string) => void): this;
   emit(event: 'invoice.paid', invoice: string): boolean;
 
-  on(event: 'invoice.settled', listener: (invoice: string) => void): this;
-  emit(event: 'invoice.settled', string: string): boolean;
+  on(event: 'invoice.settled', listener: (invoice: string, preimage: string) => void): this;
+  emit(event: 'invoice.settled', string: string, preimage: string): boolean;
 }
 
 // TODO: "invalid argument" errors
@@ -208,8 +208,8 @@ class Service extends EventEmitter {
         this.emit('invoice.paid', invoice);
       });
 
-      currency.lndClient.on('invoice.settled', (invoice) => {
-        this.emit('invoice.settled', invoice);
+      currency.lndClient.on('invoice.settled', (invoice, preimage) => {
+        this.emit('invoice.settled', invoice, preimage);
       });
     });
   }

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -136,6 +136,7 @@ message SubscribeInvoicesRequest {}
 message SubscribeInvoicesResponse {
   InvoiceEvent event = 1;
   string invoice = 2;
+  string preimage = 3;
 }
 
 message CreateSwapRequest {


### PR DESCRIPTION
This PR adds the `preimage` to the invoice settled events so that the user doesn't have to paste it manually.