### PR TITLE
chore: move Berkeley DB build into own container

### DIFF
--- a/docker/berkeley-db/Dockerfile
+++ b/docker/berkeley-db/Dockerfile
@@ -1,0 +1,30 @@
+# Build BerkeleyDB
+FROM alpine:3.9 as berkeley-db
+
+RUN apk update
+RUN apk upgrade
+RUN apk --no-cache add \
+  autoconf \
+  automake \
+  libressl \
+  build-base
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
+RUN make -j4
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Assemble the final image
+FROM alpine:3.9
+
+COPY --from=berkeley-db /opt /opt

--- a/docker/bitcoin-core/Dockerfile
+++ b/docker/bitcoin-core/Dockerfile
@@ -1,33 +1,7 @@
-# Build BerkeleyDB
-FROM alpine:3.9 as berkeleydb
-
-RUN apk update
-RUN apk upgrade
-RUN apk --no-cache add \
-  autoconf \
-  automake \
-  libressl \
-  build-base
-
-ENV BERKELEYDB_VERSION=db-4.8.30.NC
-ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
-
-RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
-RUN tar -xzf *.tar.gz
-RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
-RUN mkdir -p ${BERKELEYDB_PREFIX}
-
-WORKDIR /${BERKELEYDB_VERSION}/build_unix
-
-RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
-RUN make -j4
-RUN make install
-RUN rm -rf ${BERKELEYDB_PREFIX}/docs
-
 # Build Bitcoin Core
 FROM alpine:3.9 as bitcoin-core
 
-COPY --from=berkeleydb /opt /opt
+COPY --from=boltz/berkeley-db /opt /opt
 
 RUN apk update
 RUN apk upgrade

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 
+function print () {
+  echo -e "\e[32mBuilding $1\e[0m"
+}
+
+print "Berkeley DB"
+docker build -t boltz/berkeley-db -f berkeley-db/Dockerfile .
+
+print "Bitcoin Core"
 docker build -t boltz/bitcoin-core -f bitcoin-core/Dockerfile .
+
+print "Litecoin Core"
 docker build -t boltz/litecoin-core -f litecoin-core/Dockerfile .
 
+print "LND"
 docker build -t boltz/lnd -f lnd/Dockerfile .
 
+print "regtest image"
 docker build -t boltz/regtest -f regtest/Dockerfile .

--- a/docker/litecoin-core/Dockerfile
+++ b/docker/litecoin-core/Dockerfile
@@ -1,33 +1,7 @@
-# Build BerkeleyDB
-FROM alpine:3.9 as berkeleydb
-
-RUN apk update
-RUN apk upgrade
-RUN apk --no-cache add \
-  autoconf \
-  automake \
-  libressl \
-  build-base
-
-ENV BERKELEYDB_VERSION=db-4.8.30.NC
-ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
-
-RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
-RUN tar -xzf *.tar.gz
-RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
-RUN mkdir -p ${BERKELEYDB_PREFIX}
-
-WORKDIR /${BERKELEYDB_VERSION}/build_unix
-
-RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
-RUN make -j4
-RUN make install
-RUN rm -rf ${BERKELEYDB_PREFIX}/docs
-
 # Build Litecoin Core
 FROM alpine:3.9 as litecoin-core
 
-COPY --from=berkeleydb /opt /opt
+COPY --from=boltz/berkeley-db /opt /opt
 
 RUN apk update
 RUN apk upgrade


### PR DESCRIPTION
This PR moves the build of Berkeley DB from the images of Bitcoin Core and Litecoin Core into its own Dockerfile which should reduce the build time of the images.