### PR TITLE
Fallback for pubrawblock and lock for wallet

### DIFF
--- a/docker/regtest/Dockerfile
+++ b/docker/regtest/Dockerfile
@@ -47,9 +47,11 @@ COPY regtest/data/lnd/macaroons /root/.lnd-ltc2/data/chain/litecoin/regtest/
 # Configure ZMQ for Bitcoin and Litecoin Core
 RUN echo "zmqpubrawtx=tcp://0.0.0.0:29000" >> /root/.bitcoin/bitcoin.conf
 RUN echo "zmqpubrawblock=tcp://0.0.0.0:29001" >> /root/.bitcoin/bitcoin.conf
+RUN echo "zmqpubhashblock=tcp://0.0.0.0:29002" >> /root/.bitcoin/bitcoin.conf
 
 RUN echo "zmqpubrawtx=tcp://0.0.0.0:30000" >> /root/.litecoin/litecoin.conf
 RUN echo "zmqpubrawblock=tcp://0.0.0.0:30001" >> /root/.litecoin/litecoin.conf
+RUN echo "zmqpubhashblock=tcp://0.0.0.0:30002" >> /root/.litecoin/litecoin.conf
 
 # Copy start scripts
 COPY regtest/scripts /bin/

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,12 @@
         "tslib": "^1.8.1"
       }
     },
+    "@types/async-lock": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.1.1.tgz",
+      "integrity": "sha512-TU1X8jmAU2BjwKryBFV/GDezz7Ge0xu9ZuYC7dy6wKj4hnL0JcxeseCOr/G2JkGylff6hdUBrR+Ee5ApAQeU5g==",
+      "dev": true
+    },
     "@types/bip32": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/bip32/-/bip32-1.0.1.tgz",
@@ -814,6 +820,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "async-lock": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.1.4.tgz",
+      "integrity": "sha512-9vsVXt+mIvb8rV0G6V1x68Bvp/VksPJoZJxF/n/l9N60chNJ44opPr9WdZZfAV3leUdXt4xNvfyNWyY/j5enBA=="
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nodemon:watch": "nodemon --watch dist -e js bin/boltzd",
     "lint": "tslint --project tsconfig.json && tslint --config tslint-alt.json 'bin/*' 'test/**/*.ts'",
     "lint:fix": "tslint --fix --project tsconfig.json && tslint --fix --config tslint-alt.json 'bin/*' 'test/**/*.ts'",
-    "docker:start": "docker run -d --name regtest -p 18443:18443 -p 19443:19443 -p 29000:29000 -p 29001:29001 -p 30000:30000 -p 30001:30001 -p 10009:10009 -p 10010:10010 -p 11009:11009 -p 11010:11010 -p 8081:8081 boltz/regtest",
+    "docker:start": "docker run -d --name regtest -p 18443:18443 -p 19443:19443 -p 29000:29000 -p 29001:29001 -p 29002:29002 -p 30000:30000 -p 30001:30001 -p 30002:30002 -p 10009:10009 -p 10010:10010 -p 11009:11009 -p 11010:11010 -p 8081:8081 boltz/regtest",
     "docker:stop": "docker kill regtest && docker rm regtest",
     "test": "npm run test:unit && npm run docker:start && npm run test:int && npm run docker:stop",
     "test:unit": "mocha test/unit/*.spec.ts test/unit/wallet/*.spec.ts",
@@ -57,6 +57,7 @@
     "LICENSE"
   ],
   "dependencies": {
+    "async-lock": "^1.1.4",
     "bip32": "^1.0.2",
     "bip39": "^2.5.0",
     "bitcoinjs-lib": "^4.0.3",
@@ -78,6 +79,7 @@
     "zeromq": "^5.1.0"
   },
   "devDependencies": {
+    "@types/async-lock": "^1.1.1",
     "@types/bip32": "^1.0.1",
     "@types/bip39": "^2.4.2",
     "@types/bitcoinjs-lib": "^4.0.0",


### PR DESCRIPTION
`pubrawblock` sometimes stops working on Litecoin Core for whatever reason. It is not related to our Docker image because it also happens on https://testnet.boltz.exchange too which is running a normal binary of Litecoin Core. To fix that I added a fallback for that ZMQ filter: `pubhashblock`. The fallback is way slower than `pubrawblock` because it depends on sending a RPC request to Litecoin Core to get the data about the block but it is still much better than not getting informed about new blocks at all.

For handling the events from `pubhashblock` I needed a lock because if an event handler is `async`, Node doesn't wait until it is done before sending the next event. And while I was already at it, I also added such a lock to the wallet to prevent race conditions and double spending coins.