### PR TITLE
fix: correct timeout block height in map

### DIFF
--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -120,7 +120,7 @@ class SwapManager {
     const { rHash, paymentRequest } = await receivingCurrency.lndClient.addInvoice(amount);
     const { keys } = sendingCurrency.wallet.getNewKeys();
 
-    const { blocks } = await receivingCurrency.chainClient.getBlockchainInfo();
+    const { blocks } = await sendingCurrency.chainClient.getBlockchainInfo();
     const timeoutBlockHeight = blocks + timeoutBlockNumber;
 
     const redeemScript = pkRefundSwap(


### PR DESCRIPTION
This PR fixes an bug that caused the block height of the wrong chain to be queried