### PR TITLE
fix: config file parsing

### DIFF
--- a/bin/boltzd
+++ b/bin/boltzd
@@ -27,11 +27,6 @@ const { argv } = require('yargs')
       type: 'string',
       describe: 'Path to the wallet file',
     },
-    network: {
-      describe: 'The network the lnd clients are using',
-      type: 'string',
-      choices: ['mainnet', 'testnet', 'simnet', 'regtest'],
-    },
     'grpc.host': {
       describe: 'Host of the Boltz gRPC interface',
       type: 'string',
@@ -46,34 +41,6 @@ const { argv } = require('yargs')
     },
     'grpc.keypath': {
       describe: 'Path to the key of the TLS certificate of the Boltz gRPC interface',
-      type: 'string',
-    },
-    'btcd.configpath': {
-      describe: 'Path to btcd config',
-      type: 'string',
-    },
-    'btcd.lndport': {
-      describe: 'Port for the gRPC interface',
-      type: 'string',
-    },
-    'btcd.lndhost': {
-      describe: 'Host for the gRPC interface',
-      type: 'string',
-    },
-    'ltcd.configpath': {
-      describe: 'Path to ltcd config',
-      type: 'string',
-    },
-    'ltcd.lndport': {
-      describe: 'Port for the gRPC interface',
-      type: 'string',
-    },
-    'ltcd.lndhost': {
-      describe: 'Host for the gRPC interface',
-      type: 'string',
-    },
-    lndpath: {
-      describe: 'Path to lnd',
       type: 'string',
     },
     currencies: {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "boltz-core": "^0.0.5",
     "cross-os": "^1.3.0",
     "grpc": "^1.18.0",
-    "ini": "^1.3.5",
     "inquirer": "^6.2.2",
     "node-forge": "^0.7.6",
     "sequelize": "^4.42.0",


### PR DESCRIPTION
This PR removes code that got deprecated with the switch to Bitcoin Core and fixes the parsing of config files that are not located in the default path.

Maybe we should add parsing of the config files of Bitcoin / Litecoin Core and LND in the future again but I don't think that it is important right now.