### PR TITLE
fix: catch LND errors when paying invoices

### DIFF
--- a/lib/db/models/Wallet.ts
+++ b/lib/db/models/Wallet.ts
@@ -3,7 +3,7 @@ import * as db from '../../consts/Database';
 
 export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) => {
   const attributes: db.SequelizeAttributes<db.WalletAttributes> = {
-    symbol: { type: dataTypes.STRING, primaryKey: true, allowNull: true },
+    symbol: { type: dataTypes.STRING, primaryKey: true, allowNull: false },
     highestUsedIndex: { type: dataTypes.INTEGER, allowNull: false },
     derivationPath: { type: dataTypes.STRING, allowNull: false },
     blockheight: { type: dataTypes.INTEGER, allowNull: false },

--- a/lib/lightning/LndClient.ts
+++ b/lib/lightning/LndClient.ts
@@ -69,6 +69,7 @@ class LndClient extends BaseClient implements LightningClient {
 
   /**
    * Create an LND client
+   *
    * @param config the lnd configuration
    */
   constructor(private logger: Logger, config: LndConfig, public readonly symbol: string) {


### PR DESCRIPTION
This PR should cause that LND errors, which are thrown when trying to pay invoices, are handled gracefully. 