### PR TITLE
fix: fee calculation of reverse swaps

### DIFF
--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -182,7 +182,8 @@ export const getOutputType = (type: number) => {
     case 0: return OutputType.Bech32;
     case 1: return OutputType.Compatibility;
     case 2: return OutputType.Legacy;
-    default: throw Error('type dose not exist');
+
+    default: throw Error('type does not exist');
   }
 };
 

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -133,7 +133,7 @@ class SwapManager {
     const outputScript = p2wshOutput(redeemScript);
     const address = sendingCurrency.wallet.encodeAddress(outputScript);
 
-    const sendingAmount = this.calculateExpectedAmount(amount - fee, 1 / this.getRate(rate, orderSide));
+    const sendingAmount = this.calculateExpectedAmount(amount, 1 / this.getRate(rate, orderSide)) - fee;
 
     const { vout, transaction } = await sendingCurrency.wallet.sendToAddress(address, OutputType.Bech32, true, sendingAmount);
     this.logger.debug(`Sending ${sendingAmount} on ${sendingCurrency.symbol} to swap address ${address}: ${transaction.getId()}:${vout}`);


### PR DESCRIPTION
This PR in combination with a fix in the frontend should make the fee calculation of reverse swaps of the `LTC/BTC` pair more accurate.