### PR TITLE
chore: update Go alpine version

### DIFF
--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-alpine as builder
+FROM golang:1.12.4-alpine as builder
 
 # Install git
 RUN apk update && apk upgrade && apk add --no-cache git make gcc libc-dev


### PR DESCRIPTION
This PR just bumps the Go version of the Docker LND image.

Btw: I updated the [Litecoin regtest LND branch](https://github.com/BoltzExchange/lnd/pull/1) so that it is on par with the latest LND release again.