### PR TITLE
feat: send all funds of wallet

### DIFF
--- a/lib/cli/BuilderComponents.ts
+++ b/lib/cli/BuilderComponents.ts
@@ -49,7 +49,7 @@ export default {
   },
   timeoutBlockNumber: {
     describe: 'after how my blocks the onchain script of the swap should time out',
-    default: '10',
     type: 'number',
+    default: '10',
   },
 };

--- a/lib/cli/commands/SendCoins.ts
+++ b/lib/cli/commands/SendCoins.ts
@@ -3,7 +3,7 @@ import BuilderComponents from '../BuilderComponents';
 import { callback, loadBoltzClient } from '../Command';
 import { SendCoinsRequest } from '../../proto/boltzrpc_pb';
 
-export const command = 'sendcoins <currency> <address> <amount> [fee_per_byte]';
+export const command = 'sendcoins <currency> <address> <amount> [fee_per_byte] [send_all]';
 
 export const describe = 'sends coins to a specified address';
 
@@ -18,6 +18,10 @@ export const builder = {
     type: 'number',
   },
   fee_per_byte: BuilderComponents.feePerByte,
+  send_all: {
+    describe: 'ignores the amount and sends the whole balance of the wallet',
+    type: 'boolean',
+  },
 };
 
 export const handler = (argv: Arguments<any>) => {
@@ -27,6 +31,7 @@ export const handler = (argv: Arguments<any>) => {
   request.setAddress(argv.address);
   request.setAmount(argv.amount);
   request.setSatPerVbyte(argv.fee_per_byte);
+  request.setSendAll(argv.send_all);
 
   loadBoltzClient(argv).sendCoins(request, callback);
 };

--- a/lib/db/models/Output.ts
+++ b/lib/db/models/Output.ts
@@ -14,12 +14,12 @@ class Output extends Model {
 
   public static load = (sequelize: Sequelize) => {
     Output.init({
-      id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+      id: { type: new DataTypes.INTEGER(), primaryKey: true, autoIncrement: true },
       script: { type: new DataTypes.STRING(255), allowNull: false },
       redeemScript: { type: new DataTypes.STRING(255), allowNull: true },
       currency: { type: new DataTypes.STRING(255), allowNull: false },
-      keyIndex: { type: DataTypes.INTEGER, allowNull: false },
-      type: { type: DataTypes.BOOLEAN, allowNull: false },
+      keyIndex: { type: new DataTypes.INTEGER(), allowNull: false },
+      type: { type: new DataTypes.INTEGER(), allowNull: false },
     }, {
       sequelize,
       timestamps: false,

--- a/lib/db/models/Utxo.ts
+++ b/lib/db/models/Utxo.ts
@@ -17,12 +17,12 @@ class Utxo extends Model {
 
   public static load = (sequelize: Sequelize) => {
     Utxo.init({
-      id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-      outputId: { type: DataTypes.INTEGER, allowNull: false },
+      id: { type: new DataTypes.INTEGER(), primaryKey: true, autoIncrement: true },
+      outputId: { type: new DataTypes.INTEGER(), allowNull: false },
       currency: { type: new DataTypes.STRING(255), allowNull: false },
       txHash: { type: new DataTypes.STRING(255), allowNull: false },
-      vout: { type: DataTypes.INTEGER, allowNull: false },
-      value: { type: DataTypes.INTEGER, allowNull: false },
+      vout: { type: new DataTypes.INTEGER(), allowNull: false },
+      value: { type: new DataTypes.INTEGER(), allowNull: false },
       confirmed: { type: DataTypes.BOOLEAN, allowNull: false },
       spent: { type: DataTypes.BOOLEAN, allowNull: false },
     }, {

--- a/lib/db/models/Wallet.ts
+++ b/lib/db/models/Wallet.ts
@@ -10,10 +10,10 @@ class Wallet extends Model {
 
   public static load = (sequelize: Sequelize) => {
     Wallet.init({
-      symbol: { type: DataTypes.STRING(255), primaryKey: true, allowNull: false },
-      highestUsedIndex: { type: DataTypes.INTEGER, allowNull: false },
-      derivationPath: { type: DataTypes.STRING(255), allowNull: false },
-      blockHeight: { type: DataTypes.INTEGER, allowNull: false },
+      symbol: { type: new DataTypes.STRING(255), primaryKey: true, allowNull: false },
+      highestUsedIndex: { type: new DataTypes.INTEGER(), allowNull: false },
+      derivationPath: { type: new DataTypes.STRING(255), allowNull: false },
+      blockHeight: { type: new DataTypes.INTEGER(), allowNull: false },
     }, {
       sequelize,
       timestamps: false,

--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -850,6 +850,9 @@ export class SendCoinsRequest extends jspb.Message {
     getSatPerVbyte(): number;
     setSatPerVbyte(value: number): void;
 
+    getSendAll(): boolean;
+    setSendAll(value: boolean): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): SendCoinsRequest.AsObject;
@@ -867,6 +870,7 @@ export namespace SendCoinsRequest {
         address: string,
         amount: number,
         satPerVbyte: number,
+        sendAll: boolean,
     }
 }
 

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -5675,7 +5675,8 @@ proto.boltzrpc.SendCoinsRequest.toObject = function(includeInstance, msg) {
     currency: jspb.Message.getFieldWithDefault(msg, 1, ""),
     address: jspb.Message.getFieldWithDefault(msg, 2, ""),
     amount: jspb.Message.getFieldWithDefault(msg, 3, 0),
-    satPerVbyte: jspb.Message.getFieldWithDefault(msg, 4, 0)
+    satPerVbyte: jspb.Message.getFieldWithDefault(msg, 4, 0),
+    sendAll: jspb.Message.getFieldWithDefault(msg, 5, false)
   };
 
   if (includeInstance) {
@@ -5727,6 +5728,10 @@ proto.boltzrpc.SendCoinsRequest.deserializeBinaryFromReader = function(msg, read
     case 4:
       var value = /** @type {number} */ (reader.readUint32());
       msg.setSatPerVbyte(value);
+      break;
+    case 5:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setSendAll(value);
       break;
     default:
       reader.skipField();
@@ -5782,6 +5787,13 @@ proto.boltzrpc.SendCoinsRequest.serializeBinaryToWriter = function(message, writ
   if (f !== 0) {
     writer.writeUint32(
       4,
+      f
+    );
+  }
+  f = message.getSendAll();
+  if (f) {
+    writer.writeBool(
+      5,
       f
     );
   }
@@ -5845,6 +5857,23 @@ proto.boltzrpc.SendCoinsRequest.prototype.getSatPerVbyte = function() {
 /** @param {number} value */
 proto.boltzrpc.SendCoinsRequest.prototype.setSatPerVbyte = function(value) {
   jspb.Message.setProto3IntField(this, 4, value);
+};
+
+
+/**
+ * optional bool send_all = 5;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.boltzrpc.SendCoinsRequest.prototype.getSendAll = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 5, false));
+};
+
+
+/** @param {boolean} value */
+proto.boltzrpc.SendCoinsRequest.prototype.setSendAll = function(value) {
+  jspb.Message.setProto3BooleanField(this, 5, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -86,7 +86,7 @@ const argChecks = {
     if (!(rate > 0)) throw Errors.INVALID_ARGUMENT('rate must a positive number');
   },
   VALID_AMOUNT: ({ amount }: { amount: number }) => {
-    if (!(amount > 0) || amount % 1 !== 0) throw Errors.INVALID_ARGUMENT('amount must a positive integer');
+    if (!(amount >= 0) || amount % 1 !== 0) throw Errors.INVALID_ARGUMENT('amount must a positive integer');
   },
   VALID_FEE_PER_VBYTE: ({ satPerVbyte }: { satPerVbyte: number }) => {
     if (!(satPerVbyte > 0) || satPerVbyte % 1 !== 0) throw Errors.INVALID_ARGUMENT('sat per vbyte fee must be positive integer');
@@ -368,7 +368,7 @@ class Service extends EventEmitter {
   /**
    * Sends coins to a specified address
    */
-  public sendCoins = async (args: { currency: string, address: string, amount: number, satPerVbyte: number }) => {
+  public sendCoins = async (args: { currency: string, address: string, amount: number, satPerVbyte: number, sendAll: boolean }) => {
     argChecks.HAS_ADDRESS(args);
     argChecks.VALID_CURRENCY(args);
     argChecks.VALID_AMOUNT(args);
@@ -381,7 +381,7 @@ class Service extends EventEmitter {
 
     const output = SwapUtils.getOutputScriptType(address.toOutputScript(args.address, currency.network))!;
 
-    const { transaction, vout } = await wallet.sendToAddress(args.address, output.type, output.isSh!, args.amount, fee);
+    const { transaction, vout } = await wallet.sendToAddress(args.address, output.type, output.isSh!, args.amount, fee, args.sendAll);
     await currency.chainClient.sendRawTransaction(transaction.toHex());
 
     return {

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -209,6 +209,7 @@ message SendCoinsRequest {
   string address = 2;
   uint64 amount = 3;
   uint32 sat_per_vbyte = 4;
+  bool send_all = 5;
 }
 message SendCoinsResponse {
   string transaction_hash = 1;


### PR DESCRIPTION
This PR adds the option to spend all funds of the wallet in one transaction. That feature is nice to have for database migrations in which the funds have to be sent to a temporary wallet.