### PR TITLE
feat: detection of chain reorganizations

### DIFF
--- a/lib/chain/ChainClient.ts
+++ b/lib/chain/ChainClient.ts
@@ -81,6 +81,10 @@ class ChainClient extends BaseClient {
     return this.client.request<Block>('getblock', [hash]);
   }
 
+  public invalidateBlock = (hash: string) => {
+    return this.client.request<void>('invalidateblock', [hash]);
+  }
+
   /**
    * Adds outputs to the list of relevant ones
    *

--- a/tslint.json
+++ b/tslint.json
@@ -53,7 +53,7 @@
     "no-floating-promises": [true, "Bluebird"],
     "no-null-keyword": true,
     "jsdoc-format": true,
-    "no-unnecessary-type-assertion": true,
+    "no-unnecessary-type-assertion": false,
     "await-promise": [true, "Bluebird"],
     "no-inferrable-types": true
   }


### PR DESCRIPTION
Closes https://github.com/BoltzExchange/boltz-backend/issues/96

This PR adds a feature that allows Boltz to detect reorganizations of the BTC and LTC chains. It does not mark UTXOs as unconfirmed after a reorganization or any other advanced things but just make sure no block height is missed by the `block` events of the `ZmqClient`