### PR TITLE
chore: update Docker images

### DIFF
--- a/docker/berkeley-db/Dockerfile
+++ b/docker/berkeley-db/Dockerfile
@@ -1,8 +1,7 @@
 # Build BerkeleyDB
-FROM alpine:3.9 as berkeley-db
+FROM alpine:3.9.3 as berkeley-db
 
-RUN apk update
-RUN apk upgrade
+RUN apk update && apk upgrade
 RUN apk --no-cache add \
   autoconf \
   automake \
@@ -20,11 +19,10 @@ RUN mkdir -p ${BERKELEYDB_PREFIX}
 WORKDIR /${BERKELEYDB_VERSION}/build_unix
 
 RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
-RUN make -j4
+RUN make -j$(nproc)
 RUN make install
-RUN rm -rf ${BERKELEYDB_PREFIX}/docs
 
 # Assemble the final image
-FROM alpine:3.9
+FROM alpine:3.9.3
 
 COPY --from=berkeley-db /opt /opt

--- a/docker/bitcoin-core/Dockerfile
+++ b/docker/bitcoin-core/Dockerfile
@@ -1,10 +1,9 @@
 # Build Bitcoin Core
-FROM alpine:3.9 as bitcoin-core
+FROM alpine:3.9.3 as bitcoin-core
 
 COPY --from=boltz/berkeley-db /opt /opt
 
-RUN apk update
-RUN apk upgrade
+RUN apk update && apk upgrade
 RUN apk --no-cache add \
   file \
   gnupg \
@@ -23,7 +22,7 @@ RUN apk --no-cache add \
 
 RUN gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "90C8019E36C2E964"
 
-ENV BITCOIN_VERSION=0.17.1
+ENV BITCOIN_VERSION=0.18.0
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
 RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
@@ -51,17 +50,18 @@ RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/incl
     --with-utils \
     --with-libs
 
-RUN make -j4
+RUN make -j$(nproc)
 RUN make install
-RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
-RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
+
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-wallet
 
 # Assemble the final image
-FROM alpine:3.9
+FROM alpine:3.9.3
 
-RUN apk update
-RUN apk upgrade
+RUN apk update && apk upgrade
 RUN apk --no-cache add \
   boost \
   libzmq \
@@ -69,7 +69,7 @@ RUN apk --no-cache add \
   libressl \
   boost-program_options
 
-ENV BITCOIN_VERSION=0.17.1
+ENV BITCOIN_VERSION=0.18.0
 
 COPY --from=bitcoin-core /opt/bitcoin-${BITCOIN_VERSION}/bin /bin
 

--- a/docker/litecoin-core/Dockerfile
+++ b/docker/litecoin-core/Dockerfile
@@ -1,13 +1,11 @@
 # Build Litecoin Core
-FROM alpine:3.9 as litecoin-core
+FROM alpine:3.9.3 as litecoin-core
 
 COPY --from=boltz/berkeley-db /opt /opt
 
-RUN apk update
-RUN apk upgrade
+RUN apk update && apk upgrade
 RUN apk --no-cache add \
   file \
-  gnupg \
   libtool \
   chrpath \
   automake \
@@ -21,9 +19,7 @@ RUN apk --no-cache add \
   protobuf-dev \
   linux-headers
 
-RUN gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "0xFE3348877809386C"
-
-ENV LITECOIN_VERSION=0.17.1rc1
+ENV LITECOIN_VERSION=0.17.1
 ENV LITECOIN_PREFIX=/opt/litecoin-${LITECOIN_VERSION}
 
 RUN wget https://github.com/litecoin-project/litecoin/archive/v${LITECOIN_VERSION}.tar.gz
@@ -50,19 +46,17 @@ RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/incl
     --with-utils \
     --with-libs
 
-RUN make -j4
+RUN make -j$(nproc)
 RUN make install
-RUN strip ${LITECOIN_PREFIX}/bin/litecoin-cli
-RUN strip ${LITECOIN_PREFIX}/bin/litecoin-tx
+
 RUN strip ${LITECOIN_PREFIX}/bin/litecoind
-RUN strip ${LITECOIN_PREFIX}/lib/libbitcoinconsensus.a
-RUN strip ${LITECOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
+RUN strip ${LITECOIN_PREFIX}/bin/litecoin-tx
+RUN strip ${LITECOIN_PREFIX}/bin/litecoin-cli
 
 # Assemble the final image
-FROM alpine:3.9
+FROM alpine:3.9.3
 
-RUN apk update
-RUN apk upgrade
+RUN apk update && apk upgrade
 RUN apk --no-cache add \
   boost \
   libzmq \
@@ -70,10 +64,10 @@ RUN apk --no-cache add \
   libressl \
   boost-program_options
 
-ENV LITECOIN_VERSION=0.17.1rc1
+ENV LITECOIN_VERSION=0.17.1
 
 COPY --from=litecoin-core /opt/litecoin-${LITECOIN_VERSION}/bin /bin
 
 EXPOSE 19332 19333 19444 19443
 
-ENTRYPOINT ["litecoind", "--help"]
+ENTRYPOINT ["litecoind"]

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.12.4-alpine as builder
 
 # Install git
-RUN apk update && apk upgrade && apk add --no-cache git make gcc libc-dev
+RUN apk update && apk upgrade
+RUN apk add --no-cache git make gcc libc-dev
 
 # Install LND
 RUN git clone https://github.com/boltzexchange/lnd.git $GOPATH/src/github.com/boltzexchange/lnd
@@ -11,7 +12,7 @@ RUN git checkout litcoin-regtest
 RUN make install
 
 # Start again with a new image to reduce the size
-FROM alpine:3.9 as final
+FROM alpine:3.9.3 as final
 
 # Expose LND ports (server, gRPC)
 EXPOSE 9735 10009

--- a/docker/regtest/Dockerfile
+++ b/docker/regtest/Dockerfile
@@ -1,6 +1,7 @@
-FROM alpine:3.9
+FROM alpine:3.9.3
 
 # Install dependencies
+RUN apk update && apk upgrade
 RUN apk --no-cache add \
   jq \
   boost \

--- a/docker/regtest/data/core/config.conf
+++ b/docker/regtest/data/core/config.conf
@@ -9,3 +9,8 @@ txindex=1
 rpcuser=kek
 rpcpassword=kek
 rpcallowip=0.0.0.0/0
+
+deprecatedrpc=generate
+
+[regtest]
+rpcbind=0.0.0.0

--- a/docker/regtest/scripts/setup.sh
+++ b/docker/regtest/scripts/setup.sh
@@ -29,7 +29,7 @@ function openChannel () {
   $1 generate 6 > /dev/null
 
   while true; do
-    numActiveChannels="$($2 getinfo | jq -r ".num_active_channels")"
+    numActiveChannels="$($2 getinfo | jq -r ".num_pending_channels")"
 
     if [ ${numActiveChannels} == "1" ]; then
       break	

--- a/docker/regtest/scripts/utils.sh
+++ b/docker/regtest/scripts/utils.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 function waitForNode () {
   while true; do
     if $1 getblockchaininfo 2>&1 | grep blocks > /dev/null 2>&1; then


### PR DESCRIPTION
This PR updates the alpine base images of our Docker images to `3.9.3` and:

- updates Bitcoin Core to version `0.18.0`. The RPC call `generate` was deprecated in that version but it can still be used until `0.19.0` (I had to manually allow that call [in the config](https://github.com/BoltzExchange/boltz-backend/compare/update-bitcoin-core?expand=1#diff-9b9353917242ad1d1b179693e2624521R13)). [Here](https://bitcoincore.org/en/releases/0.18.0/) is the complete changelog for reference.
- updates Litecoin Core to `0.17.1`. Mining a new block with `generate` still fails on Litecoin occasionally. I tried changing the base images to [`debian-slim`](https://hub.docker.com/_/debian) but it didn't have any influence on that issue. There is a PR that fixes this bug already but it will probably take a little while to be merged: https://github.com/litecoin-project/litecoin/pull/585
