### PR TITLE
chore: switch from CircleCI to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+
+node_js:
+  - "lts/*"
+  - "node"
+
+services:
+  - docker
+
+cache:
+  directories:
+    - "node_modules"
+
+before_install:
+  - npm run docker:start
+
+script:
+  - npm run lint
+  - npm run compile
+  - npm run test:unit
+  - npm run test:int

--- a/test/Utils.ts
+++ b/test/Utils.ts
@@ -14,7 +14,7 @@ export const waitForFunctionToBeTrue = (func: () => boolean) => {
         clearInterval(interval);
         resolve();
       }
-    });
+    }, 25);
   });
 };
 


### PR DESCRIPTION
This PR add a Travis build file to the repo without removing the one for CircleCI. I want to keep running both in parallel for a while and test which one suits our needs best and is less flaky.

Btw: [this little change](https://github.com/BoltzExchange/boltz-backend/compare/travis?expand=1#diff-1f18275d9b4d7c24cfb053ee06434a25R17) made the CircleCI build a lot more stable and reliable. Maybe it solves our problem with the flaky integration tests entirely.