### PR TITLE
fix: invoice decoding library

### DIFF
--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -83,12 +83,11 @@ export const minutesToMilliseconds = (minutes: number) => {
   return minutes * 60 * 1000;
 };
 
-// TODO: fix invoice decoding on testnet
 /**
  * Gets the amount of an invoice in satoshis
  */
 export const getInvoiceAmt = (invoice: string): number => {
-  return Number(bolt11.decode(invoice).millisatoshis) / 1000;
+  return bolt11.decode(invoice).satoshis || 0;
 };
 
 /**

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -24,6 +24,7 @@ import {
   getLightningCurrency,
   getSwapMemo,
   getVersion,
+  getInvoiceAmt,
 } from '../Utils';
 import {
   Balance,
@@ -336,9 +337,7 @@ class Service {
 
     const timeoutBlockDelta = this.timeoutDeltaProvider.getTimeout(pairId, side, false);
 
-    const { lndClient } = this.currencies.get(lightningCurrency)!;
-    const { numSatoshis: invoiceAmount } = await lndClient!.decodePayReq(invoice);
-
+    const invoiceAmount = getInvoiceAmt(invoice);
     const rate = getRate(pairRate, side, false);
 
     this.verifyAmount(pairId, rate, invoiceAmount, side, false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,33 +245,21 @@
       "integrity": "sha512-AM7vFNwSD7B4XI6yeRKccWbbD/lvwoFr8U3pqhzryBQo4uMkYe5V3/kMVnml4SNuxzyqdIFu4ur3TId02sC33A=="
     },
     "@boltz/bolt11": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@boltz/bolt11/-/bolt11-1.2.5.tgz",
-      "integrity": "sha512-9Ycr/83+Z6suYQTyz0INU/KmAicmJCZd5HfdkOMAP+QNt6ngnNncIvzdEKA3K3oWNFmgZFBlwv1pFJw5FVPscw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@boltz/bolt11/-/bolt11-1.2.7.tgz",
+      "integrity": "sha512-oqx2huOis113MIz/MUIvw6F+hd3ARIs/+tg+HVpVa0Oh6FZrfXYWsUmMHtdZfWLeCmtvXjZVp55lYDdYDyhOug==",
       "requires": {
         "@types/bn.js": "^4.11.3",
         "bech32": "^1.1.2",
         "bitcoinjs-lib": "^3.3.1",
         "bn.js": "^4.11.8",
-        "boltz-core": "^0.0.6",
+        "boltz-core": "0.0.10",
+        "create-hash": "^1.2.0",
         "lodash": "^4.17.11",
         "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.6.2"
+        "secp256k1": "^3.4.0"
       },
       "dependencies": {
-        "bip32": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.4.tgz",
-          "integrity": "sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==",
-          "requires": {
-            "bs58check": "^2.1.1",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "tiny-secp256k1": "^1.0.0",
-            "typeforce": "^1.11.5",
-            "wif": "^2.0.6"
-          }
-        },
         "bitcoinjs-lib": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-3.3.2.tgz",
@@ -292,43 +280,6 @@
             "typeforce": "^1.11.3",
             "varuint-bitcoin": "^1.0.4",
             "wif": "^2.0.1"
-          }
-        },
-        "boltz-core": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/boltz-core/-/boltz-core-0.0.6.tgz",
-          "integrity": "sha512-o0x9DGG7dymt2XkOcOVGb5i0vIlfthMAKKYO2+VVi7xzisagbTwTQS5wemEIeJhbOp6dez3Nu+AC9f+2kkc0EA==",
-          "requires": {
-            "@boltz/bitcoin-ops": "^2.0.0",
-            "bip65": "^1.0.3",
-            "bip66": "^1.1.5",
-            "bitcoinjs-lib": "^4.0.2",
-            "bn.js": "^4.11.8",
-            "varuint-bitcoin": "^1.1.0"
-          },
-          "dependencies": {
-            "bitcoinjs-lib": {
-              "version": "4.0.5",
-              "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.5.tgz",
-              "integrity": "sha512-gYs7K2hiY4Xb96J8AIF+Rx+hqbwjVlp5Zt6L6AnHOdzfe/2tODdmDxsEytnaxVCdhOUg0JnsGpl+KowBpGLxtA==",
-              "requires": {
-                "bech32": "^1.1.2",
-                "bip32": "^1.0.4",
-                "bip66": "^1.1.0",
-                "bitcoin-ops": "^1.4.0",
-                "bs58check": "^2.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.3",
-                "merkle-lib": "^2.0.10",
-                "pushdata-bitcoin": "^1.0.1",
-                "randombytes": "^2.0.1",
-                "safe-buffer": "^5.1.1",
-                "tiny-secp256k1": "^1.0.0",
-                "typeforce": "^1.11.3",
-                "varuint-bitcoin": "^1.0.4",
-                "wif": "^2.0.1"
-              }
-            }
           }
         }
       }
@@ -781,9 +732,9 @@
       }
     },
     "@types/bn.js": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
-      "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
       "requires": {
         "@types/node": "*"
       }
@@ -877,9 +828,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.25",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.25.tgz",
-      "integrity": "sha512-hnP1WpjN4KbGEK4dLayul6lgtys6FPz0UfxMeMQCv0M+sTnzN3ConfiO72jHgLxl119guHgI8gLqDOrRLsyp2g==",
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.0.tgz",
+      "integrity": "sha512-dXvuABY9nM1xgsXlOtLQXJKdacxZJd7AtvLsKZ/0b57ruMXDKCOXAC/M75GbllQX6o1pcZ5hAG4JzYy7Z/wM2w==",
       "dev": true,
       "requires": {
         "jest-diff": "^24.3.0"
@@ -4685,9 +4636,9 @@
       }
     },
     "get-port": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.0.tgz",
-      "integrity": "sha512-bjioH1E9bTQUvgaB6VycVy1QVbTZI41yTnF9qkZz6ixgy/uhCH6D63bKeZ6Code/07JYA61MeI94jSdHss8PNA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "dev": true
     },
     "get-stdin": {
@@ -9305,24 +9256,33 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "secp256k1": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
       "requires": {
         "bindings": "^1.5.0",
         "bip66": "^1.1.5",
         "bn.js": "^4.11.8",
         "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
-        "elliptic": "^6.4.1",
+        "elliptic": "^6.5.2",
         "nan": "^2.14.0",
         "safe-buffer": "^5.1.2"
       },
       "dependencies": {
-        "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        "elliptic": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@boltz/bolt11": "^1.2.5",
+    "@boltz/bolt11": "^1.2.7",
     "@google-cloud/storage": "^4.2.0",
     "@iarna/toml": "^2.2.3",
     "async-lock": "^1.2.2",
@@ -86,7 +86,7 @@
     "@types/async-lock": "^1.1.1",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.2",
-    "@types/jest": "^24.0.25",
+    "@types/jest": "^24.9.0",
     "@types/node-forge": "^0.9.1",
     "@types/node-schedule": "^1.3.0",
     "@types/uuid": "^3.4.6",
@@ -95,7 +95,7 @@
     "concurrently": "^5.0.2",
     "conventional-changelog": "^3.1.18",
     "conventional-changelog-cli": "^2.0.31",
-    "get-port": "^5.1.0",
+    "get-port": "^5.1.1",
     "grpc-tools": "^1.8.1",
     "grpc_tools_node_protoc_ts": "^2.5.9",
     "jest": "^24.9.0",

--- a/test/unit/Utils.spec.ts
+++ b/test/unit/Utils.spec.ts
@@ -156,6 +156,16 @@ describe('Utils', () => {
       // tslint:disable-next-line: max-line-length
       'lnbcrt987650n1pwddnskpp5d4tw4gpjgqdqlgkq5yc309r2kguure53cff8a0kjta5hurltc4yqdqqcqzpgzeu404h9udp5ay39kdvau7m5kdkvycajfhx46slgkfgyhpngnztptulxpx8s7qncp45v5nxjulje5268cu22gxysg9hm3ul8ktrw5zgqcg98hg',
     )).toEqual(98765);
+
+    expect(utils.getInvoiceAmt(
+      // tslint:disable-next-line: max-line-length
+      'lntltc1u1p0p7fuypp52k9p5mszjc9x0swfw5tum8rsdguzgxmqtg4rr2xaczhkrssvse0sdqqcqzjqxuya98m2834m3xdn7pe6kj5t2q8n3rx9ft37ygvkj07g4a2h7q3xp5mkh44f4jyuupg9t69xf0xknzqa7ufah4dqms5xz4veqplykmcqp4fue6',
+    )).toEqual(100);
+
+    expect(utils.getInvoiceAmt(
+      // tslint:disable-next-line: max-line-length
+      'lntb1p0p7f6lpp58zpsxk88e8uz2lndqrf9radths484jqlhmas92kt7md2cqszpn6qdqqcqzpgrzjqtejjv7p39kcv5gezydzgse8ea3kcw8zqe36afy64zem09us5hjgcxgphsqqqzsqqyqqqqlgqqqqqqgq9q4wqv5a4uwhhvfh93k2ue75lrre50tk99pk689qgf6ul5my5vr749689wcunnv7zjcuk7jlpwz44fv87ra2snsjzw34pnfs5d477u82cpm6cym6',
+    )).toEqual(0);
   });
 
   test('should get rate', () => {


### PR DESCRIPTION
I updated [our fork of of the lightning invoice parsing library](https://github.com/boltzexchange/bolt11) to fix the issues we had with parsing invoices on testnet. Which means that we can use the library again.