### PR TITLE
fix: add scanned block height to GetInfo

### DIFF
--- a/lib/chain/ChainClient.ts
+++ b/lib/chain/ChainClient.ts
@@ -127,8 +127,13 @@ class ChainClient extends BaseClient {
     return this.client.request<NetworkInfo>('getnetworkinfo');
   }
 
-  public getBlockchainInfo = () => {
-    return this.client.request<BlockchainInfo>('getblockchaininfo');
+  public getBlockchainInfo = async () => {
+    const blockchainInfo = await this.client.request<BlockchainInfo>('getblockchaininfo');
+
+    return {
+      ...blockchainInfo,
+      scannedBlocks: this.zmqClient.blockHeight,
+    };
   }
 
   public getBlock = (hash: string): Promise<Block> => {

--- a/lib/chain/ZmqClient.ts
+++ b/lib/chain/ZmqClient.ts
@@ -33,7 +33,8 @@ class ZmqClient extends EventEmitter {
   public relevantInputs = new Set<string>();
   public relevantOutputs = new Set<string>();
 
-  private blockHeight = 0;
+  public blockHeight = 0;
+
   private bestBlockHash = '';
 
   private hashBlockAddress?: string;

--- a/lib/proto/boltzrpc_grpc_pb.js
+++ b/lib/proto/boltzrpc_grpc_pb.js
@@ -117,7 +117,7 @@ function deserialize_boltzrpc_UpdateTimeoutBlockDeltaResponse(buffer_arg) {
 
 var BoltzService = exports.BoltzService = {
   // Gets general information about this Boltz instance and the nodes it is connected to 
-  getInfo: {
+getInfo: {
     path: '/boltzrpc.Boltz/GetInfo',
     requestStream: false,
     responseStream: false,
@@ -129,7 +129,7 @@ var BoltzService = exports.BoltzService = {
     responseDeserialize: deserialize_boltzrpc_GetInfoResponse,
   },
   // Gets the balance for either all wallets or just a single one if specified 
-  getBalance: {
+getBalance: {
     path: '/boltzrpc.Boltz/GetBalance',
     requestStream: false,
     responseStream: false,
@@ -141,7 +141,7 @@ var BoltzService = exports.BoltzService = {
     responseDeserialize: deserialize_boltzrpc_GetBalanceResponse,
   },
   // Gets a new address of a specified wallet 
-  newAddress: {
+newAddress: {
     path: '/boltzrpc.Boltz/NewAddress',
     requestStream: false,
     responseStream: false,
@@ -153,7 +153,7 @@ var BoltzService = exports.BoltzService = {
     responseDeserialize: deserialize_boltzrpc_NewAddressResponse,
   },
   // Sends onchain coins to a specified address 
-  sendCoins: {
+sendCoins: {
     path: '/boltzrpc.Boltz/SendCoins',
     requestStream: false,
     responseStream: false,
@@ -165,7 +165,7 @@ var BoltzService = exports.BoltzService = {
     responseDeserialize: deserialize_boltzrpc_SendCoinsResponse,
   },
   // Updates the timeout block delta of a pair 
-  updateTimeoutBlockDelta: {
+updateTimeoutBlockDelta: {
     path: '/boltzrpc.Boltz/UpdateTimeoutBlockDelta',
     requestStream: false,
     responseStream: false,

--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -88,6 +88,9 @@ export class ChainInfo extends jspb.Message {
     getBlocks(): number;
     setBlocks(value: number): void;
 
+    getScannedBlocks(): number;
+    setScannedBlocks(value: number): void;
+
     getConnections(): number;
     setConnections(value: number): void;
 
@@ -109,6 +112,7 @@ export namespace ChainInfo {
     export type AsObject = {
         version: number,
         blocks: number,
+        scannedBlocks: number,
         connections: number,
         error: string,
     }

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -568,8 +568,9 @@ proto.boltzrpc.ChainInfo.toObject = function(includeInstance, msg) {
   var f, obj = {
     version: jspb.Message.getFieldWithDefault(msg, 1, 0),
     blocks: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    connections: jspb.Message.getFieldWithDefault(msg, 3, 0),
-    error: jspb.Message.getFieldWithDefault(msg, 4, "")
+    scannedBlocks: jspb.Message.getFieldWithDefault(msg, 3, 0),
+    connections: jspb.Message.getFieldWithDefault(msg, 4, 0),
+    error: jspb.Message.getFieldWithDefault(msg, 5, "")
   };
 
   if (includeInstance) {
@@ -616,9 +617,13 @@ proto.boltzrpc.ChainInfo.deserializeBinaryFromReader = function(msg, reader) {
       break;
     case 3:
       var value = /** @type {number} */ (reader.readUint64());
-      msg.setConnections(value);
+      msg.setScannedBlocks(value);
       break;
     case 4:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setConnections(value);
+      break;
+    case 5:
       var value = /** @type {string} */ (reader.readString());
       msg.setError(value);
       break;
@@ -665,17 +670,24 @@ proto.boltzrpc.ChainInfo.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
-  f = message.getConnections();
+  f = message.getScannedBlocks();
   if (f !== 0) {
     writer.writeUint64(
       3,
       f
     );
   }
+  f = message.getConnections();
+  if (f !== 0) {
+    writer.writeUint64(
+      4,
+      f
+    );
+  }
   f = message.getError();
   if (f.length > 0) {
     writer.writeString(
-      4,
+      5,
       f
     );
   }
@@ -713,32 +725,47 @@ proto.boltzrpc.ChainInfo.prototype.setBlocks = function(value) {
 
 
 /**
- * optional uint64 connections = 3;
+ * optional uint64 scanned_blocks = 3;
  * @return {number}
  */
-proto.boltzrpc.ChainInfo.prototype.getConnections = function() {
+proto.boltzrpc.ChainInfo.prototype.getScannedBlocks = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
 };
 
 
 /** @param {number} value */
-proto.boltzrpc.ChainInfo.prototype.setConnections = function(value) {
+proto.boltzrpc.ChainInfo.prototype.setScannedBlocks = function(value) {
   jspb.Message.setProto3IntField(this, 3, value);
 };
 
 
 /**
- * optional string error = 4;
+ * optional uint64 connections = 4;
+ * @return {number}
+ */
+proto.boltzrpc.ChainInfo.prototype.getConnections = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
+};
+
+
+/** @param {number} value */
+proto.boltzrpc.ChainInfo.prototype.setConnections = function(value) {
+  jspb.Message.setProto3IntField(this, 4, value);
+};
+
+
+/**
+ * optional string error = 5;
  * @return {string}
  */
 proto.boltzrpc.ChainInfo.prototype.getError = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
 };
 
 
 /** @param {string} value */
 proto.boltzrpc.ChainInfo.prototype.setError = function(value) {
-  jspb.Message.setProto3StringField(this, 4, value);
+  jspb.Message.setProto3StringField(this, 5, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -143,6 +143,7 @@ class Service {
         chain.setConnections(networkInfo.connections);
 
         chain.setBlocks(blockchainInfo.blocks);
+        chain.setScannedBlocks(blockchainInfo.scannedBlocks);
       } catch (error) {
         chain.setError(error);
       }

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -39,9 +39,10 @@ message CurrencyInfo {
 message ChainInfo {
   uint32 version = 1;
   uint64 blocks = 2;
-  uint64 connections = 3;
+  uint64 scanned_blocks = 3;
+  uint64 connections = 4;
 
-  string error = 4;
+  string error = 5;
 }
 
 message LndInfo {

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -167,6 +167,7 @@ const mockGetNetworkInfo = jest.fn().mockResolvedValue({
 
 const mockGetBlockchainInfo = jest.fn().mockResolvedValue({
   blocks: 123,
+  scannedBlocks: 321,
 });
 
 const rawTransaction = 'rawTransaction';
@@ -324,7 +325,6 @@ describe('Service', () => {
     expect(currency[1].chain).toEqual({
       ...(await mockGetNetworkInfo()),
       ...(await mockGetBlockchainInfo()),
-
       error: '',
     });
 


### PR DESCRIPTION
I have observed some weird behavior with Submarine Swaps: when the 0-conf transaction is rejected and the daemon is waiting for the it to be included in a block, it never detects the transaction to be confirmed even if it is mined.

To debug this I added the highest scanned block of the `ZmqClient` (the class handling new blocks and transactions from Bitcoin/Litecoin Core) to the response of the `GetInfo` gRPC call.