### PR TITLE
feat: add database version schema

### DIFF
--- a/lib/db/DatabaseVersionRepository.ts
+++ b/lib/db/DatabaseVersionRepository.ts
@@ -1,0 +1,19 @@
+import DatabaseVersion from './models/DatabaseVersion';
+
+class DatabaseVersionRepository {
+  public getVersion = (): Promise<DatabaseVersion | null> => {
+    return DatabaseVersion.findOne();
+  }
+
+  public createVersion = (version: number) => {
+    return DatabaseVersion.create({
+      version,
+    });
+  }
+
+  public dropTable = () => {
+    return DatabaseVersion.drop();
+  }
+}
+
+export default DatabaseVersionRepository;

--- a/lib/db/Migration.ts
+++ b/lib/db/Migration.ts
@@ -1,0 +1,36 @@
+import Logger from '../Logger';
+import DatabaseVersionRepository from './DatabaseVersionRepository';
+
+class Migration {
+  private versionRepository: DatabaseVersionRepository;
+
+  private static latestSchemaVersion = 1;
+
+  constructor(private logger: Logger) {
+    this.versionRepository = new DatabaseVersionRepository();
+  }
+
+  public migrate = async () => {
+    const versionRow = await this.versionRepository.getVersion();
+
+    // When no version row is found, just insert the latest version into the database
+    if (!versionRow) {
+      this.logger.verbose('No schema version found in database');
+      this.logger.debug(`Inserting latest schema version ${Migration.latestSchemaVersion} in database`);
+
+      await this.versionRepository.createVersion(Migration.latestSchemaVersion);
+      return;
+    }
+
+    switch (versionRow.version) {
+      case Migration.latestSchemaVersion:
+        this.logger.verbose(`Database already at latest schema version ${Migration.latestSchemaVersion}`);
+        break;
+
+      default:
+        throw `found unexpected database version ${versionRow.version}`;
+    }
+  }
+}
+
+export default Migration;

--- a/lib/db/ReverseSwapRepository.ts
+++ b/lib/db/ReverseSwapRepository.ts
@@ -3,24 +3,23 @@ import { SwapUpdateEvent } from '../consts/Enums';
 import ReverseSwap, { ReverseSwapType } from './models/ReverseSwap';
 
 class ReverseSwapRepository {
-
-  public getReverseSwaps = async (options?: WhereOptions): Promise<ReverseSwap[]> => {
+  public getReverseSwaps = (options?: WhereOptions): Promise<ReverseSwap[]> => {
     return ReverseSwap.findAll({
       where: options,
     });
   }
 
-  public getReverseSwap = async (options: WhereOptions): Promise<ReverseSwap> => {
+  public getReverseSwap = (options: WhereOptions): Promise<ReverseSwap> => {
     return ReverseSwap.findOne({
       where: options,
     });
   }
 
-  public addReverseSwap = async (reverseSwap: ReverseSwapType) => {
+  public addReverseSwap = (reverseSwap: ReverseSwapType) => {
     return ReverseSwap.create(reverseSwap);
   }
 
-  public setReverseSwapStatus = async (reverseSwap: ReverseSwap, status: string) => {
+  public setReverseSwapStatus = (reverseSwap: ReverseSwap, status: string) => {
     return reverseSwap.update({
       status,
     });
@@ -35,21 +34,21 @@ class ReverseSwapRepository {
     });
   }
 
-  public setInvoiceSettled = async (reverseSwap: ReverseSwap, preimage: string) => {
+  public setInvoiceSettled = (reverseSwap: ReverseSwap, preimage: string) => {
     return reverseSwap.update({
       preimage,
       status: SwapUpdateEvent.InvoiceSettled,
     });
   }
 
-  public setTransactionRefunded = async (reverseSwap: ReverseSwap, minerFee: number) => {
+  public setTransactionRefunded = (reverseSwap: ReverseSwap, minerFee: number) => {
     return reverseSwap.update({
       minerFee: reverseSwap.minerFee + minerFee,
       status: SwapUpdateEvent.TransactionRefunded,
     });
   }
 
-  public dropTable = async () => {
+  public dropTable = () => {
     return ReverseSwap.drop();
   }
 }

--- a/lib/db/models/DatabaseVersion.ts
+++ b/lib/db/models/DatabaseVersion.ts
@@ -1,0 +1,22 @@
+import { Model, Sequelize, DataTypes } from 'sequelize';
+
+type DatabaseVersionType = {
+  version: number;
+};
+
+class DatabaseVersion extends Model implements DatabaseVersionType {
+  public version!: number;
+
+  public static load = (sequelize: Sequelize) => {
+    DatabaseVersion.init({
+      version: { type: new DataTypes.INTEGER, primaryKey: true, allowNull: false },
+    }, {
+      sequelize,
+      timestamps: false,
+      tableName: 'version',
+    });
+  }
+}
+
+export default DatabaseVersion;
+export { DatabaseVersionType };

--- a/lib/db/models/KeyProvider.ts
+++ b/lib/db/models/KeyProvider.ts
@@ -20,8 +20,8 @@ class KeyProvider extends Model implements KeyProviderType {
       highestUsedIndex: { type: new DataTypes.INTEGER(), allowNull: false },
     }, {
       sequelize,
-      timestamps: false,
       tableName: 'keys',
+      timestamps: false,
     });
   }
 }

--- a/test/unit/db/Migration.spec.ts
+++ b/test/unit/db/Migration.spec.ts
@@ -1,0 +1,55 @@
+import Logger from '../../../lib/Logger';
+import Migration from '../../../lib/db/Migration';
+
+let mockGetVersionResult: any = undefined;
+const mockGetVersion = jest.fn().mockImplementation(async () => {
+  return mockGetVersionResult;
+});
+
+const mockCreateVersion = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../lib/db/DatabaseVersionRepository', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getVersion: mockGetVersion,
+      createVersion: mockCreateVersion,
+    };
+  });
+});
+
+describe('Migration', () => {
+  const migration = new Migration(Logger.disabledLogger);
+
+  beforeEach(() => {
+    mockGetVersionResult = undefined;
+
+    jest.clearAllMocks();
+  });
+
+  test('should insert the latest database schema version in case there none already', async () => {
+    await migration.migrate();
+
+    expect(mockGetVersion).toHaveBeenCalledTimes(1);
+
+    expect(mockCreateVersion).toHaveBeenCalledTimes(1);
+    expect(mockCreateVersion).toHaveBeenCalledWith(Migration['latestSchemaVersion']);
+  });
+
+  test('should do nothing in case the database has already the latest schema version', async () => {
+    mockGetVersionResult = {
+      version: Migration['latestSchemaVersion'],
+    };
+
+    await migration.migrate();
+
+    expect(mockGetVersion).toHaveBeenCalledTimes(1);
+  });
+
+  test('should throw when there is an unexpected database schema version', async () => {
+    mockGetVersionResult = {
+      version: -42,
+    };
+
+    await expect(migration.migrate()).rejects.toEqual(`found unexpected database version ${mockGetVersionResult.version}`);
+  });
+});


### PR DESCRIPTION
To allow graceful database migrations in the future, this PR introduces a new database table that stores nothing but an integer which defines the database schema version. Based on that schema version, future breaking database changes can be handled gracefully by detecting the schema of the existing database and updating it accordingly.