### PR TITLE
feat: make invoice payments of prepay minerfee procotol atomic

### DIFF
--- a/lib/db/models/ReverseSwap.ts
+++ b/lib/db/models/ReverseSwap.ts
@@ -17,10 +17,11 @@ type ReverseSwapType = {
   status: string;
   timeoutBlockHeight: number;
 
-  invoice: string;
-  minerFeeInvoice?: string;
-
   preimage?: string;
+  invoice: string;
+
+  minerFeePreimage?: string;
+  minerFeeInvoice?: string;
 
   onchainAmount: number;
   transactionId?: string;
@@ -43,10 +44,11 @@ class ReverseSwap extends Model implements ReverseSwapType {
   public status!: string;
   public timeoutBlockHeight!: number;
 
-  public invoice!: string;
-  public minerFeeInvoice?: string;
-
   public preimage?: string;
+  public invoice!: string;
+
+  public minerFeePreimage?: string;
+  public minerFeeInvoice?: string;
 
   public onchainAmount!: number;
   public transactionId?: string;
@@ -67,15 +69,22 @@ class ReverseSwap extends Model implements ReverseSwapType {
       orderSide: { type: new DataTypes.INTEGER(), allowNull: false },
       status: { type: new DataTypes.STRING(255), allowNull: false },
       timeoutBlockHeight: { type: new DataTypes.INTEGER(), allowNull: false },
+      preimage: { type: new DataTypes.STRING(64), allowNull: true },
       invoice: { type: new DataTypes.STRING(255), allowNull: false, unique: true },
+      minerFeePreimage: { type: new DataTypes.STRING(64), allowNull: true, unique: true },
       minerFeeInvoice: { type: new DataTypes.STRING(255), allowNull: true, unique: true },
-      preimage: { type: new DataTypes.STRING(255), allowNull: true },
       onchainAmount: { type: new DataTypes.INTEGER(), allowNull: false },
       transactionId: { type: new DataTypes.STRING(255), allowNull: true },
       transactionVout: { type: new DataTypes.INTEGER(), allowNull: true },
     }, {
       sequelize,
       tableName: 'reverseSwaps',
+      indexes: [
+        {
+          unique: true,
+          fields: ['id', 'invoice', 'minerFeeInvoice'],
+        },
+      ],
     });
 
     ReverseSwap.belongsTo(Pair, {

--- a/lib/lightning/LndClient.ts
+++ b/lib/lightning/LndClient.ts
@@ -279,7 +279,7 @@ class LndClient extends BaseClient implements LndClient {
 
   public lookupInvoice = (preimageHash: Buffer) => {
     const request = new lndrpc.PaymentHash();
-    request.setRHash(preimageHash);
+    request.setRHash(Uint8Array.from(preimageHash));
 
     return this.unaryCall<lndrpc.PaymentHash, lndrpc.Invoice.AsObject>('lookupInvoice', request);
   }
@@ -496,8 +496,6 @@ class LndClient extends BaseClient implements LndClient {
           this.logger.debug(`${LndClient.serviceName} ${this.symbol} accepted ${invoice.getHtlcsList().length} HTLC${invoice.getHtlcsList().length > 1 ? 's' : ''} for invoice: ${invoice.getPaymentRequest()}`);
 
           this.emit('htlc.accepted', invoice.getPaymentRequest());
-
-          deleteSubscription();
         } else if (invoice.getState() === lndrpc.Invoice.InvoiceState.SETTLED) {
           this.logger.debug(`${LndClient.serviceName} ${this.symbol} invoice settled: ${invoice.getPaymentRequest()}`);
           this.emit('invoice.settled', invoice.getPaymentRequest());


### PR DESCRIPTION
Closes #202 

This PR makes the two invoices of Reverse Swaps in the prepay minerfee protocol *"atomic"* as described in #202. Either both reach the accepted state (pending HTLC) on the LND node Boltz is connected to, or both get cancelled. At least that's the intended behavior. The prepay miner fee is still custodial and a malicious Boltz instance could still claim it before there is a pending HTLC for the bigger invoice.