### PR TITLE
fix: missing -f parameter to docker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "node bin/boltzd",
     "dev": "npm run compile && npm run start",
     "lint": "eslint --max-warnings 0 --ext .ts .",
-    "docker:build": "docker build . -t boltz/backend:latest",
+    "docker:build": "docker build . -t boltz/backend:latest -f ./docker/boltz/Dockerfile",
     "docker:regtest": "./docker/regtest/startRegtest.sh",
     "docker:geth": "docker run -d --name geth -p 8545:8545 -p 8546:8546 boltz/geth:1.10.25",
     "docker:geth:deploy": "mkdir -p contracts && cp -R node_modules/boltz-core/hardhat.config.ts node_modules/boltz-core/scripts node_modules/boltz-core/artifacts contracts && cd contracts && hardhat deploy --network localhost",


### PR DESCRIPTION
In a [previous commit](https://github.com/BoltzExchange/boltz-backend/commit/d5f27f98a918c45593c455da386ab9d013a9ea88) the `Dockerfile` was updated and moved to a new folder, but the script in the `package.json` file was not updated.