### PR TITLE
fix: custom integration test runner for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
         run: npm run test:unit
 
       - name: Integration tests
-        run: npm run test:int
+        run: node run-int.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,12 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   modulePathIgnorePatterns: ['dist'],
+  transform: {
+    '^.+\\.spec.ts?$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+      },
+    ],
+  },
 };

--- a/run-int.js
+++ b/run-int.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const childProcess = require('child_process');
+
+const runTest = (file) => {
+  console.log();
+  console.log(`Running test: ${file}`);
+  childProcess.execSync(`npx jest --testTimeout 10000 ${file}`);
+  console.log();
+};
+
+let testsRun = 0;
+
+const execDir = (dir) => {
+  const content = fs.readdirSync(dir);
+
+  for (const entry of content) {
+    if (entry.includes('.')) {
+      if (entry.endsWith('.spec.ts')) {
+        runTest(path.join(dir, entry));
+        testsRun++;
+      }
+
+      continue;
+    }
+
+    execDir(path.join(dir, entry));
+  }
+};
+
+execDir('test/integration');
+console.log(`Ran ${testsRun} test suites`);


### PR DESCRIPTION
Just running `npm run test:int` became flaky