### PR TITLE
feat: use lowball for emitting unconfirmed transactions

### DIFF
--- a/lib/Boltz.ts
+++ b/lib/Boltz.ts
@@ -10,9 +10,13 @@ import { formatError, getVersion } from './Utils';
 import VersionCheck from './VersionCheck';
 import Api from './api/Api';
 import BackupScheduler from './backup/BackupScheduler';
-import ChainClient from './chain/ChainClient';
-import ElementsClient from './chain/ElementsClient';
+import ChainClient, {
+  BlockChainInfoScanned,
+  IChainClient,
+} from './chain/ChainClient';
+import ElementsWrapper from './chain/ElementsWrapper';
 import { CurrencyType } from './consts/Enums';
+import { NetworkInfo } from './consts/Types';
 import Database from './db/Database';
 import ChainTip from './db/models/ChainTip';
 import ChainTipRepository from './db/repositories/ChainTipRepository';
@@ -281,7 +285,38 @@ class Boltz {
     }
   };
 
-  private connectChainClient = async (client: ChainClient) => {
+  private connectChainClient = async (client: IChainClient) => {
+    const formatChainInfo = (
+      networkInfo: (NetworkInfo & { lowball?: NetworkInfo }) | undefined,
+      blockchainInfo:
+        | (BlockChainInfoScanned & {
+            lowball?: BlockChainInfoScanned;
+          })
+        | undefined,
+    ) => {
+      if (networkInfo === undefined || blockchainInfo === undefined) {
+        return undefined;
+      }
+
+      const res: any = {
+        version: networkInfo.version,
+        protocolversion: networkInfo.protocolversion,
+        connections: networkInfo.connections,
+        blocks: blockchainInfo.blocks,
+        bestblockhash: blockchainInfo.bestblockhash,
+        verificationprogress: blockchainInfo.verificationprogress,
+      };
+
+      if (networkInfo.lowball && blockchainInfo.lowball) {
+        res.lowball = formatChainInfo(
+          networkInfo.lowball,
+          blockchainInfo.lowball,
+        );
+      }
+
+      return res;
+    };
+
     const service = `${client.symbol} chain`;
 
     try {
@@ -292,14 +327,7 @@ class Boltz {
 
       VersionCheck.checkChainClientVersion(client.symbol, networkInfo.version);
 
-      this.logStatus(service, {
-        version: networkInfo.version,
-        protocolversion: networkInfo.protocolversion,
-        connections: networkInfo.connections,
-        blocks: blockchainInfo.blocks,
-        bestblockhash: blockchainInfo.bestblockhash,
-        verificationprogress: blockchainInfo.verificationprogress,
-      });
+      this.logStatus(service, formatChainInfo(networkInfo, blockchainInfo));
     } catch (error) {
       this.logCouldNotConnect(service, error);
     }
@@ -435,7 +463,7 @@ class Boltz {
         type: CurrencyType.Liquid,
         symbol: symbol,
         network: LiquidNetworks[network],
-        chainClient: new ElementsClient(this.logger, chain),
+        chainClient: new ElementsWrapper(this.logger, chain),
         limits: {
           ...this.config.liquid,
         },

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -43,6 +43,10 @@ type ChainConfig = {
   mempoolSpace?: string;
 };
 
+type LiquidChainConfig = ChainConfig & {
+  lowball?: ChainConfig;
+};
+
 type PreferredWallet = 'lnd' | 'core' | undefined;
 
 type BaseCurrencyConfig = {
@@ -181,7 +185,9 @@ type ConfigType = {
   pairs: PairConfig[];
   currencies: CurrencyConfig[];
 
-  liquid?: BaseCurrencyConfig;
+  liquid?: Omit<BaseCurrencyConfig, 'chain'> & {
+    chain: LiquidChainConfig;
+  };
 
   rsk?: RskConfig;
   ethereum: EthereumConfig;
@@ -515,6 +521,7 @@ export {
   PostgresConfig,
   CurrencyConfig,
   PreferredWallet,
+  LiquidChainConfig,
   BaseCurrencyConfig,
   NotificationConfig,
   EthProviderServiceConfig,

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -49,7 +49,7 @@ type LiquidChainConfig = ChainConfig & {
 
 type PreferredWallet = 'lnd' | 'core' | undefined;
 
-type BaseCurrencyConfig = {
+type BaseCurrencyConfig<T = ChainConfig> = {
   symbol: string;
   network: Network;
 
@@ -62,7 +62,7 @@ type BaseCurrencyConfig = {
 
   maxZeroConfAmount: number;
 
-  chain: ChainConfig;
+  chain: T;
 };
 
 type RoutingOffsetException = {
@@ -185,9 +185,7 @@ type ConfigType = {
   pairs: PairConfig[];
   currencies: CurrencyConfig[];
 
-  liquid?: Omit<BaseCurrencyConfig, 'chain'> & {
-    chain: LiquidChainConfig;
-  };
+  liquid?: BaseCurrencyConfig<LiquidChainConfig>;
 
   rsk?: RskConfig;
   ethereum: EthereumConfig;

--- a/lib/Core.ts
+++ b/lib/Core.ts
@@ -47,7 +47,7 @@ import {
   getHexString,
   reverseBuffer,
 } from './Utils';
-import ChainClient from './chain/ChainClient';
+import { IChainClient } from './chain/ChainClient';
 import { CurrencyType, SwapVersion } from './consts/Enums';
 import { liquidSymbol } from './consts/LiquidTypes';
 import Swap from './db/models/Swap';
@@ -284,7 +284,7 @@ export const constructRefundTransaction = (
 };
 
 export const calculateTransactionFee = async (
-  chainClient: ChainClient,
+  chainClient: IChainClient,
   transaction: Transaction | LiquidTransaction,
 ) => {
   return chainClient.symbol !== liquidSymbol

--- a/lib/PromiseUtils.ts
+++ b/lib/PromiseUtils.ts
@@ -27,3 +27,22 @@ export const racePromise = async <T>(
     throw e;
   }
 };
+
+export const allSettled = async <T>(promises: Promise<T>[]): Promise<T[]> => {
+  const settled = await Promise.allSettled(promises);
+  const results = settled
+    .filter(
+      (res): res is PromiseFulfilledResult<Awaited<T>> =>
+        res.status === 'fulfilled',
+    )
+    .map((res) => res.value);
+
+  if (results.length === 0) {
+    throw (settled[0] as PromiseRejectedResult).reason;
+  }
+
+  return results;
+};
+
+export const allSettledFirst = async <T>(promises: Promise<T>[]): Promise<T> =>
+  (await allSettled(promises))[0];

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -8,7 +8,7 @@ import os from 'os';
 import path from 'path';
 import packageJson from '../package.json';
 import commitHash from './Version';
-import ChainClient from './chain/ChainClient';
+import { IChainClient } from './chain/ChainClient';
 import { etherDecimals } from './consts/Consts';
 import { OrderSide, SwapVersion } from './consts/Enums';
 
@@ -553,7 +553,7 @@ export const getUnixTime = (): number => {
  * Calculates the miner fee of a transaction on a UTXO based chain
  */
 export const calculateUtxoTransactionFee = async (
-  chainClient: ChainClient,
+  chainClient: IChainClient,
   transaction: Transaction,
 ): Promise<number> => {
   let fee = 0n;

--- a/lib/api/Utils.ts
+++ b/lib/api/Utils.ts
@@ -6,7 +6,7 @@ import CountryCodes from '../service/CountryCodes';
 import ServiceErrors from '../service/Errors';
 import Errors from './Errors';
 
-type ApiArgument = {
+export type ApiArgument = {
   name: string;
   type: 'string' | 'number' | 'boolean' | 'object';
   hex?: boolean;

--- a/lib/chain/ChainClient.ts
+++ b/lib/chain/ChainClient.ts
@@ -1,5 +1,4 @@
 import { Transaction } from 'bitcoinjs-lib';
-import { Transaction as LiquidTransaction } from 'liquidjs-lib/src/transaction';
 import BaseClient from '../BaseClient';
 import { ChainConfig } from '../Config';
 import Logger from '../Logger';
@@ -18,7 +17,11 @@ import {
 import ChainTipRepository from '../db/repositories/ChainTipRepository';
 import MempoolSpace from './MempoolSpace';
 import RpcClient from './RpcClient';
-import ZmqClient, { ZmqNotification, filters } from './ZmqClient';
+import ZmqClient, {
+  SomeTransaction,
+  ZmqNotification,
+  filters,
+} from './ZmqClient';
 
 enum AddressType {
   Legacy = 'legacy',
@@ -31,7 +34,7 @@ type BlockChainInfoScanned = BlockchainInfo & {
   scannedBlocks: number;
 };
 
-type ChainClientEvents<T extends Transaction | LiquidTransaction> = {
+type ChainClientEvents<T extends SomeTransaction> = {
   'status.changed': ClientStatus;
   block: number;
   transaction: {
@@ -40,9 +43,8 @@ type ChainClientEvents<T extends Transaction | LiquidTransaction> = {
   };
 };
 
-interface IChainClient<
-  T extends Transaction | LiquidTransaction = Transaction | LiquidTransaction,
-> extends TypedEventEmitter<ChainClientEvents<T>> {
+interface IChainClient<T extends SomeTransaction = SomeTransaction>
+  extends TypedEventEmitter<ChainClientEvents<T>> {
   get symbol(): string;
   get currencyType(): CurrencyType;
 
@@ -74,7 +76,7 @@ interface IChainClient<
   ): Promise<string>;
 }
 
-class ChainClient<T extends Transaction | LiquidTransaction = Transaction>
+class ChainClient<T extends SomeTransaction = Transaction>
   extends BaseClient<ChainClientEvents<T>>
   implements IChainClient<T>
 {

--- a/lib/chain/ChainClient.ts
+++ b/lib/chain/ChainClient.ts
@@ -1,10 +1,11 @@
 import { Transaction } from 'bitcoinjs-lib';
-import { Transaction as LiquidTransaction } from 'liquidjs-lib';
+import { Transaction as LiquidTransaction } from 'liquidjs-lib/src/transaction';
 import BaseClient from '../BaseClient';
 import { ChainConfig } from '../Config';
 import Logger from '../Logger';
 import { formatError, getHexString } from '../Utils';
 import { ClientStatus, CurrencyType } from '../consts/Enums';
+import TypedEventEmitter from '../consts/TypedEventEmitter';
 import {
   Block,
   BlockVerbose,
@@ -26,21 +27,64 @@ enum AddressType {
   Taproot = 'bech32m',
 }
 
-class ChainClient extends BaseClient<{
+type BlockChainInfoScanned = BlockchainInfo & {
+  scannedBlocks: number;
+};
+
+type ChainClientEvents<T extends Transaction | LiquidTransaction> = {
   'status.changed': ClientStatus;
   block: number;
   transaction: {
-    transaction: Transaction | LiquidTransaction;
+    transaction: T;
     confirmed: boolean;
   };
-}> {
+};
+
+interface IChainClient<
+  T extends Transaction | LiquidTransaction = Transaction | LiquidTransaction,
+> extends TypedEventEmitter<ChainClientEvents<T>> {
+  get symbol(): string;
+  get currencyType(): CurrencyType;
+
+  connect(): Promise<void>;
+
+  rescanChain(startHeight: number): Promise<void>;
+
+  addInputFilter(inputHash: Buffer): void;
+  addOutputFilter(outputScript: Buffer): void;
+  removeOutputFilter(outputScript: Buffer): void;
+  removeInputFilter(inputHash: Buffer): void;
+
+  getBlockchainInfo(): Promise<BlockChainInfoScanned>;
+  getNetworkInfo(): Promise<NetworkInfo>;
+
+  sendRawTransaction(transactionHex: string): Promise<string>;
+  getRawTransaction(transactionId: string): Promise<string>;
+  getRawTransactionVerbose(transactionId: string): Promise<RawTransaction>;
+
+  estimateFee(confTarget?: number): Promise<number>;
+
+  listUnspent(minimalConfirmations?: number): Promise<UnspentUtxo[]>;
+  getNewAddress(type: AddressType): Promise<string>;
+  sendToAddress(
+    address: string,
+    amount: number,
+    satPerVbyte?: number,
+    subtractFeeFromAmount?: boolean,
+  ): Promise<string>;
+}
+
+class ChainClient<T extends Transaction | LiquidTransaction = Transaction>
+  extends BaseClient<ChainClientEvents<T>>
+  implements IChainClient<T>
+{
   public static readonly serviceName = 'Core';
   public static readonly decimals = 100000000;
 
   public currencyType: CurrencyType = CurrencyType.BitcoinLike;
 
   protected client: RpcClient;
-  protected zmqClient: ZmqClient;
+  protected zmqClient: ZmqClient<T>;
   protected feeFloor = 2;
 
   private readonly mempoolSpace?: MempoolSpace;
@@ -139,11 +183,7 @@ class ChainClient extends BaseClient<{
     return this.client.request<NetworkInfo>('getnetworkinfo');
   };
 
-  public getBlockchainInfo = async (): Promise<
-    BlockchainInfo & {
-      scannedBlocks: number;
-    }
-  > => {
+  public getBlockchainInfo = async () => {
     const blockchainInfo =
       await this.client.request<BlockchainInfo>('getblockchaininfo');
 
@@ -254,8 +294,10 @@ class ChainClient extends BaseClient<{
     ]);
   };
 
-  public listUnspent = (minconf = 0): Promise<UnspentUtxo[]> => {
-    return this.client.request<UnspentUtxo[]>('listunspent', [minconf]);
+  public listUnspent = (minimalConfirmations = 0): Promise<UnspentUtxo[]> => {
+    return this.client.request<UnspentUtxo[]>('listunspent', [
+      minimalConfirmations,
+    ]);
   };
 
   public generate = async (blocks: number): Promise<string[]> => {
@@ -341,4 +383,4 @@ class ChainClient extends BaseClient<{
 }
 
 export default ChainClient;
-export { AddressType };
+export { AddressType, BlockChainInfoScanned, ChainClientEvents, IChainClient };

--- a/lib/chain/ElementsClient.ts
+++ b/lib/chain/ElementsClient.ts
@@ -1,3 +1,4 @@
+import { Transaction } from 'liquidjs-lib';
 import { ChainConfig } from '../Config';
 import Logger from '../Logger';
 import { CurrencyType } from '../consts/Enums';
@@ -6,16 +7,31 @@ import {
   LiquidBalances,
   liquidSymbol,
 } from '../consts/LiquidTypes';
-import ChainClient, { AddressType } from './ChainClient';
+import ChainClient, { AddressType, IChainClient } from './ChainClient';
 
 enum LiquidAddressType {
   Blech32 = 'blech32',
 }
 
-class ElementsClient extends ChainClient {
+interface IElementsClient extends IChainClient<Transaction> {
+  getAddressInfo(address: string): Promise<AddressInfo>;
+
+  getBalances(): Promise<LiquidBalances>;
+  getNewAddress(type?: AddressType | LiquidAddressType): Promise<string>;
+  dumpBlindingKey(address: string): Promise<string>;
+}
+
+class ElementsClient
+  extends ChainClient<Transaction>
+  implements IElementsClient
+{
   public static readonly symbol = liquidSymbol;
 
-  constructor(logger: Logger, config: ChainConfig) {
+  constructor(
+    logger: Logger,
+    config: ChainConfig,
+    public readonly isLowball = false,
+  ) {
     super(logger, config, ElementsClient.symbol);
     this.currencyType = CurrencyType.Liquid;
     this.feeFloor = 0.11;
@@ -79,4 +95,4 @@ class ElementsClient extends ChainClient {
 }
 
 export default ElementsClient;
-export { LiquidAddressType };
+export { LiquidAddressType, IElementsClient };

--- a/lib/chain/ElementsWrapper.ts
+++ b/lib/chain/ElementsWrapper.ts
@@ -1,0 +1,170 @@
+import { Transaction } from 'liquidjs-lib';
+import BaseClient from '../BaseClient';
+import { LiquidChainConfig } from '../Config';
+import Logger from '../Logger';
+import { CurrencyType } from '../consts/Enums';
+import { UnspentUtxo } from '../consts/Types';
+import { AddressType, ChainClientEvents } from './ChainClient';
+import ElementsClient, {
+  IElementsClient,
+  LiquidAddressType,
+} from './ElementsClient';
+
+class ElementsWrapper
+  extends BaseClient<ChainClientEvents<Transaction>>
+  implements IElementsClient
+{
+  public readonly currencyType = CurrencyType.Liquid;
+
+  private readonly clients: ElementsClient[] = [];
+
+  constructor(logger: Logger, config: LiquidChainConfig) {
+    super(logger, ElementsClient.symbol);
+
+    this.clients.push(new ElementsClient(this.logger, config, false));
+
+    if (config.lowball !== undefined) {
+      this.logger.info(`Using lowball for ${this.clients[0].serviceName()}`);
+      this.clients.push(new ElementsClient(this.logger, config, true));
+    }
+  }
+
+  public serviceName = () => 'ElementsWrapper';
+
+  public connect = async () => {
+    await Promise.all(this.clients.map((c) => c.connect()));
+
+    this.publicClient().on('status.changed', this.setClientStatus);
+
+    this.publicClient().on('block', (blockHeight) =>
+      this.emit('block', blockHeight),
+    );
+
+    // Only emit confirmed transactions from the public client when a lowball
+    // client is configured
+    const hasLowball = this.lowballClient() !== undefined;
+
+    this.publicClient().on('transaction', ({ transaction, confirmed }) => {
+      if (hasLowball && !confirmed) {
+        return;
+      }
+
+      this.emit('transaction', { transaction, confirmed });
+    });
+
+    this.lowballClient()?.on('transaction', ({ transaction, confirmed }) => {
+      if (confirmed) {
+        return;
+      }
+
+      this.emit('transaction', { transaction, confirmed });
+    });
+  };
+
+  public disconnect = () => this.clients.forEach((c) => c.disconnect());
+
+  public rescanChain = (startHeight: number) =>
+    // Only rescan with the public client to avoid duplicate events
+    this.publicClient().rescanChain(startHeight);
+
+  public addInputFilter = (inputHash: Buffer) =>
+    this.clients.forEach((c) => c.addInputFilter(inputHash));
+
+  public addOutputFilter = (outputScript: Buffer) =>
+    this.clients.forEach((c) => c.addOutputFilter(outputScript));
+
+  public removeOutputFilter = (outputScript: Buffer) =>
+    this.clients.forEach((c) => c.removeOutputFilter(outputScript));
+
+  public removeInputFilter = (inputHash: Buffer) =>
+    this.clients.forEach((c) => c.removeInputFilter(inputHash));
+
+  public getBlockchainInfo = () =>
+    this.annotateLowballInfo((c) => c.getBlockchainInfo());
+
+  public getNetworkInfo = () =>
+    this.annotateLowballInfo((c) => c.getNetworkInfo());
+
+  public sendRawTransaction = (transactionHex: string) =>
+    this.allSettled(
+      this.clients.map((c) => c.sendRawTransaction(transactionHex)),
+    );
+
+  public getRawTransaction = (transactionId: string) =>
+    this.allSettled(
+      this.clients.map((c) => c.getRawTransaction(transactionId)),
+    );
+
+  public getRawTransactionVerbose = (transactionId: string) =>
+    this.allSettled(
+      this.clients.map((c) => c.getRawTransactionVerbose(transactionId)),
+    );
+
+  public estimateFee = () => this.publicClient().estimateFee();
+
+  public listUnspent = (
+    minimalConfirmations?: number,
+  ): Promise<UnspentUtxo[]> =>
+    this.walletClient().listUnspent(minimalConfirmations);
+
+  public getAddressInfo = (address: string) =>
+    this.walletClient().getAddressInfo(address);
+
+  public getBalances = () => this.walletClient().getBalances();
+
+  public getNewAddress = (type?: AddressType | LiquidAddressType) =>
+    this.walletClient().getNewAddress(type);
+
+  public dumpBlindingKey = (address: string) =>
+    this.walletClient().dumpBlindingKey(address);
+
+  public sendToAddress = (
+    address: string,
+    amount: number,
+    satPerVbyte?: number,
+    subtractFeeFromAmount?: boolean,
+  ) =>
+    this.walletClient().sendToAddress(
+      address,
+      amount,
+      satPerVbyte,
+      subtractFeeFromAmount,
+    );
+
+  private walletClient = () => this.publicClient();
+
+  private publicClient = () => this.clients.find((c) => !c.isLowball)!;
+
+  private lowballClient = () => this.clients.find((c) => c.isLowball);
+
+  private allSettled = async <T>(promises: Promise<T>[]): Promise<T> => {
+    const settled = await Promise.allSettled(promises);
+    const results = settled
+      .filter(
+        (res): res is PromiseFulfilledResult<Awaited<T>> =>
+          res.status === 'fulfilled',
+      )
+      .map((res) => res.value);
+
+    if (results.length === 0) {
+      throw (settled[0] as PromiseRejectedResult).reason;
+    }
+
+    return results[0];
+  };
+
+  private annotateLowballInfo = async <T>(
+    fn: (c: ElementsClient) => Promise<T>,
+  ): Promise<T & { lowball?: T }> => {
+    const infos: [boolean, T][] = await Promise.all(
+      this.clients.map(async (c) => [c.isLowball, await fn(c)]),
+    );
+
+    return {
+      ...infos.find(([isLowball]) => !isLowball)![1],
+      lowball: infos.find(([isLowball]) => isLowball)?.[1],
+    };
+  };
+}
+
+export default ElementsWrapper;

--- a/lib/chain/ElementsWrapper.ts
+++ b/lib/chain/ElementsWrapper.ts
@@ -86,9 +86,7 @@ class ElementsWrapper
     this.annotateLowballInfo((c) => c.getNetworkInfo());
 
   public sendRawTransaction = (transactionHex: string) =>
-    this.allSettled(
-      this.clients.map((c) => c.sendRawTransaction(transactionHex)),
-    );
+    this.publicClient().sendRawTransaction(transactionHex);
 
   public getRawTransaction = (transactionId: string) =>
     this.allSettled(

--- a/lib/chain/ElementsWrapper.ts
+++ b/lib/chain/ElementsWrapper.ts
@@ -40,8 +40,8 @@ class ElementsWrapper
       this.emit('block', blockHeight),
     );
 
-    // Only emit confirmed transactions from the public client when a lowball
-    // client is configured
+    // If we have a lowball client, bubble up only confirmed transactions
+    // of the public client
     const hasLowball = this.lowballClient() !== undefined;
 
     this.publicClient().on('transaction', ({ transaction, confirmed }) => {

--- a/lib/chain/ZmqClient.ts
+++ b/lib/chain/ZmqClient.ts
@@ -22,9 +22,9 @@ const filters = {
   hashBlock: 'pubhashblock',
 };
 
-class ZmqClient<
-  T extends Transaction | LiquidTransaction,
-> extends TypedEventEmitter<{
+export type SomeTransaction = Transaction | LiquidTransaction;
+
+class ZmqClient<T extends SomeTransaction> extends TypedEventEmitter<{
   block: number;
   transaction: {
     transaction: T;
@@ -348,9 +348,7 @@ class ZmqClient<
     });
   };
 
-  private isRelevantTransaction = (
-    transaction: Transaction | LiquidTransaction,
-  ) => {
+  private isRelevantTransaction = (transaction: SomeTransaction) => {
     for (const input of transaction.ins) {
       if (this.relevantInputs.has(getHexString(input.hash))) {
         return true;

--- a/lib/chain/ZmqClient.ts
+++ b/lib/chain/ZmqClient.ts
@@ -22,10 +22,12 @@ const filters = {
   hashBlock: 'pubhashblock',
 };
 
-class ZmqClient extends TypedEventEmitter<{
+class ZmqClient<
+  T extends Transaction | LiquidTransaction,
+> extends TypedEventEmitter<{
   block: number;
   transaction: {
-    transaction: Transaction | LiquidTransaction;
+    transaction: T;
     confirmed: boolean;
   };
 }> {
@@ -136,7 +138,7 @@ class ZmqClient extends TypedEventEmitter<{
   };
 
   public rescanChain = async (startHeight: number): Promise<void> => {
-    const checkTransaction = (transaction: Transaction | LiquidTransaction) => {
+    const checkTransaction = (transaction: T) => {
       if (this.isRelevantTransaction(transaction)) {
         this.emit('transaction', { transaction, confirmed: true });
       }
@@ -150,7 +152,7 @@ class ZmqClient extends TypedEventEmitter<{
           const block = await this.chainClient.getBlockVerbose(hash);
 
           for (const { hex } of block.tx) {
-            checkTransaction(parseTransaction(this.currencyType, hex));
+            checkTransaction(parseTransaction(this.currencyType, hex) as T);
           }
         } else {
           const block = await this.chainClient.getBlock(hash);
@@ -158,7 +160,7 @@ class ZmqClient extends TypedEventEmitter<{
           for (const tx of block.tx) {
             const rawTransaction = await this.chainClient.getRawTransaction(tx);
             checkTransaction(
-              parseTransaction(this.currencyType, rawTransaction),
+              parseTransaction(this.currencyType, rawTransaction) as T,
             );
           }
         }
@@ -181,7 +183,10 @@ class ZmqClient extends TypedEventEmitter<{
     const socket = await this.createSocket(address, 'rawtx');
 
     socket.on('message', async (_, rawTransaction: Buffer) => {
-      const transaction = parseTransaction(this.currencyType, rawTransaction);
+      const transaction = parseTransaction(
+        this.currencyType,
+        rawTransaction,
+      ) as T;
       const id = transaction.getId();
 
       // If the client has already verified that the transaction is relevant for the wallet

--- a/lib/service/ElementsService.ts
+++ b/lib/service/ElementsService.ts
@@ -1,7 +1,7 @@
 import { Transaction } from 'liquidjs-lib';
 import { UnblindedOutput, unblindOutput } from '../Core';
 import { getHexBuffer } from '../Utils';
-import ElementsClient from '../chain/ElementsClient';
+import ElementsClient, { IElementsClient } from '../chain/ElementsClient';
 import WalletLiquid from '../wallet/WalletLiquid';
 import WalletManager, { Currency } from '../wallet/WalletManager';
 import Errors from './Errors';
@@ -74,7 +74,7 @@ class ElementsService {
 
     return {
       wallet,
-      chainClient: currency.chainClient! as ElementsClient,
+      chainClient: currency.chainClient! as IElementsClient,
     };
   };
 }

--- a/lib/service/cooperative/DeferredClaimer.ts
+++ b/lib/service/cooperative/DeferredClaimer.ts
@@ -22,7 +22,7 @@ import {
   getLightningCurrency,
   splitPairId,
 } from '../../Utils';
-import ChainClient from '../../chain/ChainClient';
+import { IChainClient } from '../../chain/ChainClient';
 import { SwapUpdateEvent, SwapVersion } from '../../consts/Enums';
 import TypedEventEmitter from '../../consts/TypedEventEmitter';
 import ChannelCreation from '../../db/models/ChannelCreation';
@@ -364,7 +364,7 @@ class DeferredClaimer extends TypedEventEmitter<{
   };
 
   private constructClaimDetails = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
     toClaim: SwapToClaim,
     cooperative: boolean = false,

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -28,7 +28,7 @@ import {
   getRate,
   splitPairId,
 } from '../Utils';
-import ChainClient from '../chain/ChainClient';
+import { IChainClient } from '../chain/ChainClient';
 import { LegacyReverseSwapOutputType, etherDecimals } from '../consts/Consts';
 import { CurrencyType, SwapUpdateEvent, SwapVersion } from '../consts/Enums';
 import TypedEventEmitter from '../consts/TypedEventEmitter';
@@ -674,7 +674,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
   };
 
   private lockupUtxo = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
     lightningClient: LightningClient,
     reverseSwap: ReverseSwap,
@@ -845,7 +845,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
   };
 
   private claimUtxo = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
     swap: Swap,
     transaction: Transaction | LiquidTransaction,

--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -20,7 +20,7 @@ import {
   transactionHashToId,
   transactionSignalsRbfExplicitly,
 } from '../Utils';
-import ChainClient from '../chain/ChainClient';
+import { IChainClient } from '../chain/ChainClient';
 import { CurrencyType, SwapUpdateEvent, SwapVersion } from '../consts/Enums';
 import TypedEventEmitter from '../consts/TypedEventEmitter';
 import ReverseSwap from '../db/models/ReverseSwap';
@@ -87,7 +87,7 @@ class UtxoNursery extends TypedEventEmitter<{
     });
   };
 
-  private listenTransactions = (chainClient: ChainClient, wallet: Wallet) => {
+  private listenTransactions = (chainClient: IChainClient, wallet: Wallet) => {
     chainClient.on('transaction', async ({ transaction, confirmed }) => {
       await Promise.all([
         this.checkSwapOutputs(chainClient, wallet, transaction, confirmed),
@@ -104,7 +104,7 @@ class UtxoNursery extends TypedEventEmitter<{
   };
 
   private checkSwapOutputs = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
     transaction: Transaction | LiquidTransaction,
     confirmed: boolean,
@@ -141,7 +141,7 @@ class UtxoNursery extends TypedEventEmitter<{
   };
 
   private checkReverseSwapClaims = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     transaction: Transaction | LiquidTransaction,
   ) => {
     for (let vin = 0; vin < transaction.ins.length; vin += 1) {
@@ -177,7 +177,7 @@ class UtxoNursery extends TypedEventEmitter<{
   };
 
   private checkReverseSwapLockupsConfirmed = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
     transaction: Transaction | LiquidTransaction,
     confirmed: boolean,
@@ -206,7 +206,7 @@ class UtxoNursery extends TypedEventEmitter<{
     );
   };
 
-  private listenBlocks = (chainClient: ChainClient, wallet: Wallet) => {
+  private listenBlocks = (chainClient: IChainClient, wallet: Wallet) => {
     chainClient.on('block', async (height) => {
       await Promise.all([
         this.checkSwapMempoolTransactions(chainClient, wallet),
@@ -219,7 +219,7 @@ class UtxoNursery extends TypedEventEmitter<{
   };
 
   private checkSwapMempoolTransactions = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
   ) => {
     await this.lock.acquire(UtxoNursery.swapLockupLock, async () => {
@@ -273,7 +273,7 @@ class UtxoNursery extends TypedEventEmitter<{
 
   // This method is a fallback for "checkReverseSwapLockupsConfirmed" because that method sometimes misses transactions on mainnet for an unknown reason
   private checkReverseSwapMempoolTransactions = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
   ) => {
     await this.lock.acquire(
@@ -316,7 +316,7 @@ class UtxoNursery extends TypedEventEmitter<{
   };
 
   private checkExpiredSwaps = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     height: number,
   ) => {
     const expirableSwaps = await SwapRepository.getSwapsExpirable(height);
@@ -342,7 +342,7 @@ class UtxoNursery extends TypedEventEmitter<{
   };
 
   private checkExpiredReverseSwaps = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     height: number,
   ) => {
     const expirableReverseSwaps =
@@ -375,7 +375,7 @@ class UtxoNursery extends TypedEventEmitter<{
   };
 
   private reverseSwapLockupConfirmed = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
     reverseSwap: ReverseSwap,
     transaction: Transaction | LiquidTransaction,
@@ -400,7 +400,7 @@ class UtxoNursery extends TypedEventEmitter<{
 
   private checkSwapTransaction = async (
     swap: Swap,
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
     transaction: Transaction | LiquidTransaction,
     confirmed: boolean,
@@ -533,7 +533,7 @@ class UtxoNursery extends TypedEventEmitter<{
    * Detects whether the transaction signals RBF explicitly or inherently
    */
   private transactionSignalsRbf = async (
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     transaction: Transaction | LiquidTransaction,
   ) => {
     // Check for explicit signalling
@@ -564,7 +564,7 @@ class UtxoNursery extends TypedEventEmitter<{
 
   private getPreviousAddresses = async (
     transaction: Transaction | LiquidTransaction,
-    chainClient: ChainClient,
+    chainClient: IChainClient,
     wallet: Wallet,
   ) => {
     const inputTxsIds = this.chunkArray(
@@ -596,7 +596,10 @@ class UtxoNursery extends TypedEventEmitter<{
       );
   };
 
-  private getTransactions = async (chainClient: ChainClient, ids: string[]) => {
+  private getTransactions = async (
+    chainClient: IChainClient,
+    ids: string[],
+  ) => {
     const txs: string[] = [];
 
     for (const id of ids) {

--- a/lib/wallet/WalletManager.ts
+++ b/lib/wallet/WalletManager.ts
@@ -3,13 +3,13 @@ import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from 'bip39';
 import { Network } from 'bitcoinjs-lib';
 import { Provider } from 'ethers';
 import fs from 'fs';
-import ElementsClient from 'lib/chain/ElementsClient';
+import { IElementsClient } from 'lib/chain/ElementsClient';
 import { SLIP77Factory, Slip77Interface } from 'slip77';
 import * as ecc from 'tiny-secp256k1';
 import { CurrencyConfig } from '../Config';
 import Logger from '../Logger';
 import { splitDerivationPath } from '../Utils';
-import ChainClient from '../chain/ChainClient';
+import { IChainClient } from '../chain/ChainClient';
 import { CurrencyType } from '../consts/Enums';
 import { KeyProviderType } from '../db/models/KeyProvider';
 import KeyRepository from '../db/repositories/KeyRepository';
@@ -42,7 +42,7 @@ type Currency = {
   network?: Network;
   lndClient?: LndClient;
   clnClient?: ClnClient;
-  chainClient?: ChainClient;
+  chainClient?: IChainClient;
 
   // Needed for Ether and tokens on Ethereum
   provider?: Provider;
@@ -115,7 +115,7 @@ class WalletManager {
         } else {
           walletProvider = new ElementsWalletProvider(
             this.logger,
-            currency.chainClient! as ElementsClient,
+            currency.chainClient! as IElementsClient,
           );
         }
 

--- a/lib/wallet/providers/CoreWalletProvider.ts
+++ b/lib/wallet/providers/CoreWalletProvider.ts
@@ -1,7 +1,10 @@
 import { Transaction } from 'bitcoinjs-lib';
 import Logger from '../../Logger';
 import { transactionHashToId } from '../../Utils';
-import ChainClient, { AddressType } from '../../chain/ChainClient';
+import ChainClient, {
+  AddressType,
+  IChainClient,
+} from '../../chain/ChainClient';
 import WalletProviderInterface, {
   SentTransaction,
   WalletBalance,
@@ -12,7 +15,7 @@ class CoreWalletProvider implements WalletProviderInterface {
 
   constructor(
     public logger: Logger,
-    public chainClient: ChainClient,
+    public chainClient: IChainClient,
   ) {
     this.symbol = chainClient.symbol;
 

--- a/lib/wallet/providers/ElementsWalletProvider.ts
+++ b/lib/wallet/providers/ElementsWalletProvider.ts
@@ -2,7 +2,7 @@ import { parseTransaction } from '../../Core';
 import Logger from '../../Logger';
 import { getHexBuffer } from '../../Utils';
 import ChainClient from '../../chain/ChainClient';
-import ElementsClient from '../../chain/ElementsClient';
+import { IElementsClient } from '../../chain/ElementsClient';
 import { CurrencyType } from '../../consts/Enums';
 import WalletProviderInterface, {
   SentTransaction,
@@ -17,7 +17,7 @@ class ElementsWalletProvider implements WalletProviderInterface {
 
   constructor(
     public logger: Logger,
-    public chainClient: ElementsClient,
+    public chainClient: IElementsClient,
   ) {
     this.symbol = chainClient.symbol;
 

--- a/lib/wallet/providers/LndWalletProvider.ts
+++ b/lib/wallet/providers/LndWalletProvider.ts
@@ -1,6 +1,6 @@
 import { Transaction } from 'bitcoinjs-lib';
 import Logger from '../../Logger';
-import ChainClient from '../../chain/ChainClient';
+import { IChainClient } from '../../chain/ChainClient';
 import LndClient from '../../lightning/LndClient';
 import { AddressType } from '../../proto/lnd/rpc_pb';
 import WalletProviderInterface, {
@@ -14,7 +14,7 @@ class LndWalletProvider implements WalletProviderInterface {
   constructor(
     public logger: Logger,
     public lndClient: LndClient,
-    public chainClient: ChainClient,
+    public chainClient: IChainClient,
   ) {
     this.symbol = chainClient.symbol;
 

--- a/test/integration/Core.spec.ts
+++ b/test/integration/Core.spec.ts
@@ -368,7 +368,7 @@ describe('Core', () => {
         chainClient: bitcoinClient,
         type: CurrencyType.BitcoinLike,
         network: Networks.bitcoinRegtest,
-      } as Currency,
+      } as unknown as Currency,
       spendTx,
       0,
     );

--- a/test/integration/Nodes.ts
+++ b/test/integration/Nodes.ts
@@ -23,11 +23,15 @@ export const bitcoinClient = new ChainClient(
   'BTC',
 );
 
-export const elementsClient = new ElementsClient(Logger.disabledLogger, {
+export const elementsConfig = {
   host,
   port: 18884,
   cookie: `${cookieBasePath}/.elements-cookie`,
-});
+};
+export const elementsClient = new ElementsClient(
+  Logger.disabledLogger,
+  elementsConfig,
+);
 
 export const lndDataPath = `${resolve(
   __dirname,

--- a/test/integration/chain/ElementsWrapper.spec.ts
+++ b/test/integration/chain/ElementsWrapper.spec.ts
@@ -146,17 +146,21 @@ describe('ElementsWrapper', () => {
     });
   });
 
-  test('should rescan only with public client', async () => {
+  test.each`
+    name
+    ${'rescanChain'}
+    ${'sendRawTransaction'}
+  `('should call $name only with public client', async ({ name }) => {
     const mockFnPublic = jest.fn();
     const mockFnLowball = jest.fn();
-    wrapper['publicClient']()['rescanChain'] = mockFnPublic;
-    wrapper['lowballClient']()!['rescanChain'] = mockFnLowball;
+    wrapper['publicClient']()[name] = mockFnPublic;
+    wrapper['lowballClient']()![name] = mockFnLowball;
 
-    const startHeight = (await wrapper.getBlockchainInfo()).blocks - 1;
-    await wrapper.rescanChain(startHeight);
+    const param = 123;
+    await wrapper[name](param);
 
     expect(mockFnPublic).toHaveBeenCalledTimes(1);
-    expect(mockFnPublic).toHaveBeenCalledWith(startHeight);
+    expect(mockFnPublic).toHaveBeenCalledWith(param);
     expect(mockFnLowball).toHaveBeenCalledTimes(0);
   });
 
@@ -222,7 +226,6 @@ describe('ElementsWrapper', () => {
   describe.each`
     name
     ${'getRawTransaction'}
-    ${'sendRawTransaction'}
     ${'getRawTransactionVerbose'}
   `('allSettled handling of $name', ({ name }) => {
     test('should call both clients', async () => {

--- a/test/integration/chain/ElementsWrapper.spec.ts
+++ b/test/integration/chain/ElementsWrapper.spec.ts
@@ -1,0 +1,277 @@
+import { Transaction } from 'liquidjs-lib';
+import Logger from '../../../lib/Logger';
+import ElementsWrapper from '../../../lib/chain/ElementsWrapper';
+import { ClientStatus, CurrencyType } from '../../../lib/consts/Enums';
+import { elementsConfig } from '../Nodes';
+
+jest.mock('../../../lib/db/repositories/ChainTipRepository');
+
+describe('ElementsWrapper', () => {
+  const wrapper = new ElementsWrapper(Logger.disabledLogger, {
+    ...elementsConfig,
+    lowball: elementsConfig,
+  });
+
+  beforeAll(async () => {
+    await wrapper.connect();
+  });
+
+  beforeEach(() => {
+    wrapper.removeAllListeners();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    wrapper.disconnect();
+  });
+
+  test('should have currenType', () => {
+    expect(wrapper.currencyType).toEqual(CurrencyType.Liquid);
+  });
+
+  test('should have symbol', () => {
+    expect(wrapper.symbol).toEqual('L-BTC');
+  });
+
+  test('should have serviceName', () => {
+    expect(wrapper.serviceName()).toEqual('ElementsWrapper');
+  });
+
+  describe('constructor', () => {
+    test('should construct with lowball node', () => {
+      expect(wrapper['clients']).toHaveLength(2);
+      expect(wrapper['publicClient']()).not.toBeUndefined();
+      expect(wrapper['walletClient']()).not.toBeUndefined();
+      expect(wrapper['lowballClient']()).not.toBeUndefined();
+    });
+
+    test('should construct with just public node', () => {
+      const oneWrapper = new ElementsWrapper(
+        Logger.disabledLogger,
+        elementsConfig,
+      );
+
+      expect(oneWrapper['clients']).toHaveLength(1);
+      expect(oneWrapper['publicClient']()).not.toBeUndefined();
+      expect(oneWrapper['walletClient']()).not.toBeUndefined();
+      expect(oneWrapper['lowballClient']()).toBeUndefined();
+    });
+  });
+
+  test('should bubble up status change of public client', () => {
+    expect.assertions(1);
+
+    const newStatus = ClientStatus.Connected;
+
+    wrapper.on('status.changed', (status) => {
+      expect(status).toEqual(newStatus);
+    });
+    wrapper['publicClient']()['setClientStatus'](newStatus);
+  });
+
+  test('should emit on block', async () => {
+    const blockPromise = new Promise<void>((resolve) => {
+      wrapper.on('block', async (height) => {
+        expect(height).toEqual((await wrapper.getBlockchainInfo()).blocks);
+        resolve();
+      });
+    });
+
+    await wrapper['clients'][0].generate(1);
+    await blockPromise;
+  });
+
+  describe('transaction emitter', () => {
+    const testTx = 'i am a real tx' as unknown as Transaction;
+
+    test('should emit confirmed transactions from public client', async () => {
+      expect.assertions(2);
+
+      wrapper.on('transaction', ({ transaction, confirmed }) => {
+        expect(transaction).toEqual(testTx);
+        expect(confirmed).toEqual(true);
+      });
+
+      wrapper['publicClient']()['emit']('transaction', {
+        transaction: testTx,
+        confirmed: true,
+      });
+      wrapper['lowballClient']()!['emit']('transaction', {
+        transaction: testTx,
+        confirmed: true,
+      });
+    });
+
+    test('should emit unconfirmed transactions from lowball client', async () => {
+      expect.assertions(2);
+
+      wrapper.on('transaction', ({ transaction, confirmed }) => {
+        expect(transaction).toEqual(testTx);
+        expect(confirmed).toEqual(false);
+      });
+
+      wrapper['publicClient']()['emit']('transaction', {
+        transaction: testTx,
+        confirmed: false,
+      });
+      wrapper['lowballClient']()!['emit']('transaction', {
+        transaction: testTx,
+        confirmed: false,
+      });
+    });
+
+    test('should emit confirmed and unconfirmed transaction from public node if no lowball client is configued', async () => {
+      const oneWrapper = new ElementsWrapper(
+        Logger.disabledLogger,
+        elementsConfig,
+      );
+      await oneWrapper.connect();
+
+      expect.assertions(2);
+
+      oneWrapper.on('transaction', ({ transaction }) => {
+        expect(transaction).toEqual(testTx);
+      });
+
+      oneWrapper['publicClient']()['emit']('transaction', {
+        transaction: testTx,
+        confirmed: true,
+      });
+      oneWrapper['publicClient']()['emit']('transaction', {
+        transaction: testTx,
+        confirmed: false,
+      });
+
+      oneWrapper.disconnect();
+    });
+  });
+
+  test('should rescan only with public client', async () => {
+    const mockFnPublic = jest.fn();
+    const mockFnLowball = jest.fn();
+    wrapper['publicClient']()['rescanChain'] = mockFnPublic;
+    wrapper['lowballClient']()!['rescanChain'] = mockFnLowball;
+
+    const startHeight = (await wrapper.getBlockchainInfo()).blocks - 1;
+    await wrapper.rescanChain(startHeight);
+
+    expect(mockFnPublic).toHaveBeenCalledTimes(1);
+    expect(mockFnPublic).toHaveBeenCalledWith(startHeight);
+    expect(mockFnLowball).toHaveBeenCalledTimes(0);
+  });
+
+  test.each`
+    name
+    ${'addInputFilter'}
+    ${'addOutputFilter'}
+    ${'removeOutputFilter'}
+    ${'removeInputFilter'}
+  `('should call $name on both clients', ({ name }) => {
+    const mockFnPublic = jest.fn();
+    const mockFnLowball = jest.fn();
+    wrapper['publicClient']()[name] = mockFnPublic;
+    wrapper['lowballClient']()![name] = mockFnLowball;
+
+    const param = 'data';
+    wrapper[name](param);
+
+    expect(mockFnPublic).toHaveBeenCalledTimes(1);
+    expect(mockFnPublic).toHaveBeenCalledTimes(1);
+    expect(mockFnLowball).toHaveBeenCalledTimes(1);
+    expect(mockFnLowball).toHaveBeenCalledWith(param);
+  });
+
+  test.each`
+    name
+    ${'getNetworkInfo'}
+    ${'getBlockchainInfo'}
+  `('should annotate lowball info for $name', async ({ name }) => {
+    const res = await wrapper[name]();
+
+    const realRes = await wrapper['clients'][0][name]();
+    expect(res).toEqual({
+      ...realRes,
+      lowball: realRes,
+    });
+  });
+
+  test.each`
+    name
+    ${'getNetworkInfo'}
+    ${'getBlockchainInfo'}
+  `(
+    'should not annotate lowball info for $name when lowball is not configured',
+    async ({ name }) => {
+      const oneWrapper = new ElementsWrapper(
+        Logger.disabledLogger,
+        elementsConfig,
+      );
+      await oneWrapper.connect();
+
+      const res = await oneWrapper[name]();
+
+      expect(res).toEqual({
+        ...(await wrapper['clients'][0][name]()),
+        lowball: undefined,
+      });
+
+      oneWrapper.disconnect();
+    },
+  );
+
+  describe.each`
+    name
+    ${'getRawTransaction'}
+    ${'sendRawTransaction'}
+    ${'getRawTransactionVerbose'}
+  `('allSettled handling of $name', ({ name }) => {
+    test('should call both clients', async () => {
+      const mockFnPublic = jest.fn().mockResolvedValue(1);
+      const mockFnLowball = jest.fn().mockResolvedValue(2);
+      wrapper['publicClient']()[name] = mockFnPublic;
+      wrapper['lowballClient']()![name] = mockFnLowball;
+
+      await expect(wrapper[name]()).resolves.toEqual(1);
+
+      expect(mockFnPublic).toHaveBeenCalledTimes(1);
+      expect(mockFnLowball).toHaveBeenCalledTimes(1);
+    });
+
+    test('should return when one client throws', async () => {
+      const mockFnPublic = jest.fn().mockRejectedValue('no go');
+      const mockFnLowball = jest.fn().mockResolvedValue(1);
+      wrapper['publicClient']()[name] = mockFnPublic;
+      wrapper['lowballClient']()![name] = mockFnLowball;
+
+      await expect(wrapper[name]()).resolves.toEqual(1);
+
+      expect(mockFnPublic).toHaveBeenCalledTimes(1);
+      expect(mockFnLowball).toHaveBeenCalledTimes(1);
+    });
+
+    test('should throw when both clients throw', async () => {
+      const mockFnPublic = jest.fn().mockRejectedValue('no go');
+      const mockFnLowball = jest.fn().mockRejectedValue('still not');
+      wrapper['publicClient']()[name] = mockFnPublic;
+      wrapper['lowballClient']()![name] = mockFnLowball;
+
+      await expect(wrapper[name]()).rejects.toEqual('no go');
+    });
+  });
+
+  test.each`
+    name
+    ${'listUnspent'}
+    ${'getAddressInfo'}
+    ${'getBalances'}
+    ${'getNewAddress'}
+    ${'dumpBlindingKey'}
+    ${'sendToAddress'}
+  `('should use wallet client for $name', async ({ name }) => {
+    const res = 'data';
+
+    wrapper['walletClient']()[name] = jest.fn().mockResolvedValue(res);
+
+    await expect(wrapper[name]()).resolves.toEqual(res);
+  });
+});

--- a/test/integration/chain/ElementsWrapper.spec.ts
+++ b/test/integration/chain/ElementsWrapper.spec.ts
@@ -25,7 +25,7 @@ describe('ElementsWrapper', () => {
     wrapper.disconnect();
   });
 
-  test('should have currenType', () => {
+  test('should have currencyType', () => {
     expect(wrapper.currencyType).toEqual(CurrencyType.Liquid);
   });
 

--- a/test/integration/service/TimeoutDeltaProvider.spec.ts
+++ b/test/integration/service/TimeoutDeltaProvider.spec.ts
@@ -42,7 +42,7 @@ describe('TimeoutDeltaProvider', () => {
         {
           chainClient: bitcoinClient,
           lndClient: bitcoinLndClient,
-        } as Currency,
+        } as unknown as Currency,
       ],
       [
         'L-BTC',

--- a/test/integration/service/cooperative/DeferredClaimer.spec.ts
+++ b/test/integration/service/cooperative/DeferredClaimer.spec.ts
@@ -75,7 +75,7 @@ describe('DeferredClaimer', () => {
     chainClient: bitcoinClient,
     lndClient: bitcoinLndClient,
     type: CurrencyType.BitcoinLike,
-  } as Currency;
+  } as unknown as Currency;
 
   const btcWallet = new Wallet(
     Logger.disabledLogger,

--- a/test/integration/service/cooperative/MusigSigner.spec.ts
+++ b/test/integration/service/cooperative/MusigSigner.spec.ts
@@ -55,7 +55,7 @@ describe('MusigSigner', () => {
     chainClient: bitcoinClient,
     lndClient: bitcoinLndClient,
     type: CurrencyType.BitcoinLike,
-  } as Currency;
+  } as unknown as Currency;
 
   const btcWallet = {} as Wallet;
   const walletManager = {

--- a/test/integration/wallet/ethereum/ContractEventHandler.spec.ts
+++ b/test/integration/wallet/ethereum/ContractEventHandler.spec.ts
@@ -105,9 +105,10 @@ describe('ContractEventHandler', () => {
   });
 
   test('should listen to EtherSwap claim events', async () => {
-    const tx = await contracts.etherSwap
-      .connect(setup.etherBase)
-      .claim(preimage, amount, await setup.signer.getAddress(), timelock);
+    const tx = await contracts.etherSwap.connect(setup.etherBase)[
+      // eslint-disable-next-line no-unexpected-multiline
+      'claim(bytes32,uint256,address,uint256)'
+    ](preimage, amount, await setup.signer.getAddress(), timelock);
     transactions.etherSwap.claim = tx.hash;
 
     const claimPromise = new Promise<void>((resolve) => {
@@ -198,15 +199,10 @@ describe('ContractEventHandler', () => {
   });
 
   test('should listen to ERC20Swap claim events', async () => {
-    const tx = await contracts.erc20Swap
-      .connect(setup.etherBase)
-      .claim(
-        preimage,
-        amount,
-        await contracts.token.getAddress(),
-        await setup.signer.getAddress(),
-        timelock,
-      );
+    const tx = await contracts.erc20Swap.connect(setup.etherBase)[
+      // eslint-disable-next-line no-unexpected-multiline
+      'claim(bytes32,uint256,address,address,uint256)'
+    ](preimage, amount, await contracts.token.getAddress(), await setup.signer.getAddress(), timelock);
     transactions.erc20Swap.claim = tx.hash;
 
     const claimPromise = new Promise<void>((resolve) => {

--- a/test/unit/PromiseUtils.spec.ts
+++ b/test/unit/PromiseUtils.spec.ts
@@ -1,54 +1,118 @@
-import { racePromise } from '../../lib/PromiseUtils';
+import {
+  allSettled,
+  allSettledFirst,
+  racePromise,
+} from '../../lib/PromiseUtils';
 
 describe('PromiseUtils', () => {
   beforeAll(() => {
     jest.useFakeTimers();
   });
 
-  test.each`
-    name                              | promise                                                 | expected
-    ${'Promises'}                     | ${new Promise<string>((resolve) => resolve('promise'))} | ${'promise'}
-    ${'functions returning Promises'} | ${async () => 'func'}                                   | ${'func'}
-  `('should resolve $name correctly', async ({ promise, expected }) => {
-    await expect(
-      racePromise(
-        promise,
-        () => {
-          throw 'error callback called';
-        },
+  describe('racePromise', () => {
+    test.each`
+      name                              | promise                                                 | expected
+      ${'Promises'}                     | ${new Promise<string>((resolve) => resolve('promise'))} | ${'promise'}
+      ${'functions returning Promises'} | ${async () => 'func'}                                   | ${'func'}
+    `('should resolve $name correctly', async ({ promise, expected }) => {
+      await expect(
+        racePromise(
+          promise,
+          () => {
+            throw 'error callback called';
+          },
+          1000,
+        ),
+      ).resolves.toEqual(expected);
+    });
+
+    test('should call raceHandler after timeout', async () => {
+      const rejectionMessage = 'rejected after timeout';
+      const raceHandler = jest
+        .fn()
+        .mockImplementation((reject) => reject(rejectionMessage));
+
+      const promise = racePromise(
+        new Promise<void>(() => {}),
+        raceHandler,
         1000,
-      ),
-    ).resolves.toEqual(expected);
+      );
+      jest.runOnlyPendingTimers();
+
+      await expect(promise).rejects.toEqual(rejectionMessage);
+      expect(raceHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not call raceHandler when promise throws', async () => {
+      const raceMessage = 'rejected after timeout';
+      const raceHandler = jest
+        .fn()
+        .mockImplementation((reject) => reject(raceMessage));
+
+      const promiseRejection = 'promise threw';
+      const promise = racePromise(
+        new Promise<void>((_, reject) => reject(promiseRejection)),
+        raceHandler,
+        1000,
+      );
+      await expect(promise).rejects.toEqual(promiseRejection);
+
+      jest.runOnlyPendingTimers();
+      expect(raceHandler).toHaveBeenCalledTimes(0);
+    });
   });
 
-  test('should call raceHandler after timeout', async () => {
-    const rejectionMessage = 'rejected after timeout';
-    const raceHandler = jest
-      .fn()
-      .mockImplementation((reject) => reject(rejectionMessage));
+  describe('allSettled', () => {
+    test('should return all settled promises', async () => {
+      await expect(
+        allSettled([
+          new Promise((resolve) => resolve(1)),
+          new Promise((resolve) => resolve(2)),
+          new Promise((resolve) => resolve(3)),
+        ]),
+      ).resolves.toEqual([1, 2, 3]);
+    });
 
-    const promise = racePromise(new Promise<void>(() => {}), raceHandler, 1000);
-    jest.runOnlyPendingTimers();
+    test('should return only settled promises', async () => {
+      await expect(
+        allSettled([
+          new Promise((resolve) => resolve(1)),
+          new Promise((_, reject) => reject('no')),
+          new Promise((resolve) => resolve(3)),
+        ]),
+      ).resolves.toEqual([1, 3]);
+    });
 
-    await expect(promise).rejects.toEqual(rejectionMessage);
-    expect(raceHandler).toHaveBeenCalledTimes(1);
+    test('should throw when all throw', async () => {
+      await expect(
+        allSettled([
+          new Promise((_, reject) => reject('error 1')),
+          new Promise((_, reject) => reject('error 2')),
+          new Promise((_, reject) => reject('error 3')),
+        ]),
+      ).rejects.toEqual('error 1');
+    });
   });
 
-  test('should not call raceHandler when promise throws', async () => {
-    const raceMessage = 'rejected after timeout';
-    const raceHandler = jest
-      .fn()
-      .mockImplementation((reject) => reject(raceMessage));
+  describe('allSettledFirst', () => {
+    test('should return only first resolved promise result', async () => {
+      await expect(
+        allSettledFirst([
+          new Promise((resolve) => resolve(1)),
+          new Promise((resolve) => resolve(2)),
+          new Promise((resolve) => resolve(3)),
+        ]),
+      ).resolves.toEqual(1);
+    });
 
-    const promiseRejection = 'promise threw';
-    const promise = racePromise(
-      new Promise<void>((_, reject) => reject(promiseRejection)),
-      raceHandler,
-      1000,
-    );
-    await expect(promise).rejects.toEqual(promiseRejection);
-
-    jest.runOnlyPendingTimers();
-    expect(raceHandler).toHaveBeenCalledTimes(0);
+    test('should throw when all throw', async () => {
+      await expect(
+        allSettled([
+          new Promise((_, reject) => reject('error 1')),
+          new Promise((_, reject) => reject('error 2')),
+          new Promise((_, reject) => reject('error 3')),
+        ]),
+      ).rejects.toEqual('error 1');
+    });
   });
 });

--- a/test/unit/api/Utils.spec.ts
+++ b/test/unit/api/Utils.spec.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'crypto';
 import Logger from '../../../lib/Logger';
 import { getHexBuffer } from '../../../lib/Utils';
 import {
+  ApiArgument,
   checkPreimageHashLength,
   errorResponse,
   markSwap,
@@ -21,14 +22,14 @@ describe('Utils', () => {
   });
 
   test('should validate requests', () => {
-    const checks = [
+    const checks: ApiArgument[] = [
       {
         name: 'test',
         type: 'string',
       },
     ];
 
-    const hexChecks = [
+    const hexChecks: ApiArgument[] = [
       {
         name: 'test',
         type: 'string',
@@ -36,7 +37,7 @@ describe('Utils', () => {
       },
     ];
 
-    const optionalChecks = [
+    const optionalChecks: ApiArgument[] = [
       {
         name: 'test',
         type: 'string',


### PR DESCRIPTION
This PR refactors the codebase use `IChainClient` for interacting with UTXO based chains. Based on that `ElementsWrapper` is implemented which handles two `ElementsClient`s. One is publicly reachable, the other one lowball.

Right now we use lowball only for checking unconfirmed transactions. RPC calls of `ElementsWrapper` are adjusted to handle two clients (eg when getting a raw transaction, call both clients and use the one that has the info).

Some minor type fixes of tests are also in this PR.