### PR TITLE
fix: bump Liquid claim transaction size estimation

### DIFF
--- a/lib/rates/FeeProvider.ts
+++ b/lib/rates/FeeProvider.ts
@@ -80,7 +80,7 @@ class FeeProvider {
       [SwapVersion.Taproot]: {
         normalClaim: 1337,
         reverseLockup: 2503,
-        reverseClaim: 1297,
+        reverseClaim: 1309,
       },
       [SwapVersion.Legacy]: {
         normalClaim: 1333,


### PR DESCRIPTION
Was causing trouble in edge cases like claiming to Taproot or unblinded addresses