### PR TITLE
refactor: swap status cache

### DIFF
--- a/lib/Boltz.ts
+++ b/lib/Boltz.ts
@@ -159,18 +159,19 @@ class Boltz {
         new GrpcService(this.logger, this.service),
       );
 
-      this.prometheus = new Prometheus(
-        this.logger,
-        this.config.prometheus,
-        this.config.pairs,
-      );
-
       this.countryCodes = new CountryCodes(this.logger, this.config.marking);
       this.api = new Api(
         this.logger,
         this.config.api,
         this.service,
         this.countryCodes,
+      );
+
+      this.prometheus = new Prometheus(
+        this.logger,
+        this.api,
+        this.config.prometheus,
+        this.config.pairs,
       );
     } catch (error) {
       this.logger.error(`Could not start Boltz: ${formatError(error)}`);

--- a/lib/PromiseUtils.ts
+++ b/lib/PromiseUtils.ts
@@ -46,3 +46,11 @@ export const allSettled = async <T>(promises: Promise<T>[]): Promise<T[]> => {
 
 export const allSettledFirst = async <T>(promises: Promise<T>[]): Promise<T> =>
   (await allSettled(promises))[0];
+
+export const filterAsync = async <T>(
+  arr: T[],
+  predicate: (p: T) => Promise<boolean>,
+): Promise<T[]> => {
+  const results = await Promise.all(arr.map(predicate));
+  return arr.filter((_, index) => results[index]);
+};

--- a/lib/api/Api.ts
+++ b/lib/api/Api.ts
@@ -11,9 +11,9 @@ import ApiV2 from './v2/ApiV2';
 import WebSocketHandler from './v2/WebSocketHandler';
 
 class Api {
-  private app: Application;
+  public readonly swapInfos: SwapInfos;
 
-  private readonly swapInfos: SwapInfos;
+  private app: Application;
 
   private readonly websocket: WebSocketHandler;
   private readonly controller: Controller;
@@ -81,8 +81,6 @@ class Api {
   }
 
   public init = async (): Promise<void> => {
-    await this.swapInfos.init();
-
     await new Promise<void>((resolve) => {
       const server = this.app.listen(this.config.port, this.config.host, () => {
         this.logger.info(

--- a/lib/api/Controller.ts
+++ b/lib/api/Controller.ts
@@ -161,7 +161,7 @@ class Controller {
         { name: 'id', type: 'string' },
       ]);
 
-      const response = this.swapInfos.get(id);
+      const response = await this.swapInfos.get(id);
 
       if (response) {
         successResponse(res, response);
@@ -432,7 +432,10 @@ class Controller {
   };
 
   // EventSource streams
-  public streamSwapStatus = (req: Request, res: Response): void => {
+  public streamSwapStatus = async (
+    req: Request,
+    res: Response,
+  ): Promise<void> => {
     try {
       const { id } = validateRequest(req.query, [
         { name: 'id', type: 'string' },
@@ -447,7 +450,7 @@ class Controller {
 
       res.setTimeout(0);
 
-      const lastUpdate = this.swapInfos.get(id);
+      const lastUpdate = await this.swapInfos.get(id);
       if (lastUpdate) {
         this.writeToSse(res, lastUpdate);
       }

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -1977,12 +1977,12 @@ class SwapRouter extends RouterBase {
     });
   };
 
-  private getSwapStatus = (req: Request, res: Response) => {
+  private getSwapStatus = async (req: Request, res: Response) => {
     const { id } = validateRequest(req.params, [
       { name: 'id', type: 'string' },
     ]);
 
-    const response = this.swapInfos.get(id);
+    const response = await this.swapInfos.get(id);
 
     if (response) {
       successResponse(res, response);

--- a/test/integration/chain/ElementsWrapper.spec.ts
+++ b/test/integration/chain/ElementsWrapper.spec.ts
@@ -160,7 +160,7 @@ describe('ElementsWrapper', () => {
 
     expect(mockFnPublic).toHaveBeenCalledTimes(1);
     expect(mockFnPublic).toHaveBeenCalledWith(param);
-    expect(mockFnLowball).toHaveBeenCalledTimes(0);
+    expect(mockFnLowball).not.toHaveBeenCalled();
   });
 
   describe('sendRawTransaction', () => {
@@ -209,7 +209,7 @@ describe('ElementsWrapper', () => {
 
       expect(mockFnPublic).toHaveBeenCalledTimes(1);
       expect(mockFnPublic).toHaveBeenCalledWith(param);
-      expect(mockFnLowball).toHaveBeenCalledTimes(0);
+      expect(mockFnLowball).not.toHaveBeenCalled();
     });
   });
 

--- a/test/integration/rates/LockupTransactionTracker.spec.ts
+++ b/test/integration/rates/LockupTransactionTracker.spec.ts
@@ -289,7 +289,7 @@ describe('LockupTransactionTracker', () => {
 
         expect(
           PendingLockupTransactionRepository.destroy,
-        ).toHaveBeenCalledTimes(0);
+        ).not.toHaveBeenCalled();
       },
     );
 

--- a/test/unit/BaseClient.spec.ts
+++ b/test/unit/BaseClient.spec.ts
@@ -60,6 +60,6 @@ describe('BaseClient', () => {
 
     client.setClientStatus(ClientStatus.Disconnected);
 
-    expect(spy).toHaveBeenCalledTimes(0);
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/PromiseUtils.spec.ts
+++ b/test/unit/PromiseUtils.spec.ts
@@ -1,6 +1,7 @@
 import {
   allSettled,
   allSettledFirst,
+  filterAsync,
   racePromise,
 } from '../../lib/PromiseUtils';
 
@@ -113,6 +114,16 @@ describe('PromiseUtils', () => {
           new Promise((_, reject) => reject('error 3')),
         ]),
       ).rejects.toEqual('error 1');
+    });
+  });
+
+  describe('filterAsync', () => {
+    test('should filter with Promise predicates', async () => {
+      const arr = [1, 2, 3, 4];
+
+      await expect(
+        filterAsync(arr, async (param) => param % 2 === 0),
+      ).resolves.toEqual([2, 4]);
     });
   });
 });

--- a/test/unit/PromiseUtils.spec.ts
+++ b/test/unit/PromiseUtils.spec.ts
@@ -59,7 +59,7 @@ describe('PromiseUtils', () => {
       await expect(promise).rejects.toEqual(promiseRejection);
 
       jest.runOnlyPendingTimers();
-      expect(raceHandler).toHaveBeenCalledTimes(0);
+      expect(raceHandler).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/api/Controller.spec.ts
+++ b/test/unit/api/Controller.spec.ts
@@ -179,7 +179,7 @@ const mockedService = <jest.Mock<Service>>(<any>Service);
 jest.mock('../../../lib/api/SwapInfos', () => {
   return jest.fn().mockImplementation(() => {
     return {
-      get: jest.fn().mockImplementation((id: string) => {
+      get: jest.fn().mockImplementation(async (id: string) => {
         if (swap.id === id) {
           return {
             status: swap.status,
@@ -969,11 +969,11 @@ describe('Controller', () => {
     expect(res.end).toHaveBeenCalledTimes(1);
   });
 
-  test('should stream swap status updates', () => {
+  test('should stream swap status updates', async () => {
     // No id provided in request
     const res = mockResponse();
 
-    controller.streamSwapStatus(mockRequest({}, {}), res);
+    await controller.streamSwapStatus(mockRequest({}, {}), res);
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({
@@ -983,7 +983,7 @@ describe('Controller', () => {
     // Successful request
     const id = 'id';
 
-    controller.streamSwapStatus(
+    await controller.streamSwapStatus(
       mockRequest(
         {},
         {

--- a/test/unit/api/SwapInfos.spec.ts
+++ b/test/unit/api/SwapInfos.spec.ts
@@ -60,9 +60,9 @@ describe('SwapInfos', () => {
 
       await expect(swapInfos.get(id)).resolves.toEqual(status);
 
-      expect(SwapRepository.getSwap).toHaveBeenCalledTimes(0);
-      expect(ReverseSwapRepository.getReverseSwap).toHaveBeenCalledTimes(0);
-      expect(ChainSwapRepository.getChainSwap).toHaveBeenCalledTimes(0);
+      expect(SwapRepository.getSwap).not.toHaveBeenCalled();
+      expect(ReverseSwapRepository.getReverseSwap).not.toHaveBeenCalled();
+      expect(ChainSwapRepository.getChainSwap).not.toHaveBeenCalled();
     });
 
     test('should return undefined when swap cannot be found', async () => {

--- a/test/unit/api/Utils.spec.ts
+++ b/test/unit/api/Utils.spec.ts
@@ -207,6 +207,6 @@ describe('Utils', () => {
     expect(countryCodes.isRelevantCountry).toHaveBeenCalledTimes(1);
     expect(countryCodes.isRelevantCountry).toHaveBeenCalledWith('TOR');
 
-    expect(MarkedSwapRepository.addMarkedSwap).toHaveBeenCalledTimes(0);
+    expect(MarkedSwapRepository.addMarkedSwap).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -135,9 +135,12 @@ describe('SwapRouter', () => {
     }),
   } as unknown as Service;
 
-  const swapInfos = new Map([
-    ['swapId', { some: 'statusData' }],
-  ]) as unknown as SwapInfos;
+  const swapInfosData = new Map([['swapId', { some: 'statusData' }]]);
+  const swapInfos = {
+    get: async (id: string) => {
+      return swapInfosData.get(id);
+    },
+  } as unknown as SwapInfos;
 
   const countryCodes = {
     isRelevantCountry: jest.fn().mockReturnValue(true),
@@ -264,31 +267,37 @@ describe('SwapRouter', () => {
     ${'invalid parameter: id'}   | ${{ id: 1 }}
   `(
     'should not get status of swaps with invalid parameters ($error)',
-    ({ params, error }) => {
-      expect(() =>
+    async ({ params, error }) => {
+      await expect(
         swapRouter['getSwapStatus'](
           mockRequest(undefined, undefined, params),
           mockResponse(),
         ),
-      ).toThrow(error);
+      ).rejects.toEqual(error);
     },
   );
 
-  test('should get status of swaps', () => {
+  test('should get status of swaps', async () => {
     const id = 'swapId';
 
     const res = mockResponse();
-    swapRouter['getSwapStatus'](mockRequest(undefined, undefined, { id }), res);
+    await swapRouter['getSwapStatus'](
+      mockRequest(undefined, undefined, { id }),
+      res,
+    );
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(swapInfos.get(id));
+    expect(res.json).toHaveBeenCalledWith(await swapInfos.get(id));
   });
 
-  test('should return 404 as status when swap id cannot be found', () => {
+  test('should return 404 as status when swap id cannot be found', async () => {
     const id = 'notFound';
 
     const res = mockResponse();
-    swapRouter['getSwapStatus'](mockRequest(undefined, undefined, { id }), res);
+    await swapRouter['getSwapStatus'](
+      mockRequest(undefined, undefined, { id }),
+      res,
+    );
 
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({

--- a/test/unit/notifications/BalanceChecker.spec.ts
+++ b/test/unit/notifications/BalanceChecker.spec.ts
@@ -249,7 +249,7 @@ describe('BalanceChecker', () => {
     );
 
     expect(checker['walletBalanceAlerts'].size).toEqual(0);
-    expect(mockSendMessage).toHaveBeenCalledTimes(0);
+    expect(mockSendMessage).not.toHaveBeenCalled();
 
     // Should send message when getting out of bounds
     checkBalance(
@@ -532,7 +532,7 @@ describe('BalanceChecker', () => {
       false,
     );
 
-    expect(mockSendMessage).toHaveBeenCalledTimes(0);
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
   test('should check for max unused wallet balance for unused wallets', async () => {

--- a/test/unit/notifications/CommandHandler.spec.ts
+++ b/test/unit/notifications/CommandHandler.spec.ts
@@ -239,7 +239,7 @@ describe('CommandHandler', () => {
     sendMessage('clearly not a command');
     await wait(5);
 
-    expect(mockSendMessage).toHaveBeenCalledTimes(0);
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
   test('should deal with commands that are not all lower case', async () => {

--- a/test/unit/notifications/DiskUsageChecker.spec.ts
+++ b/test/unit/notifications/DiskUsageChecker.spec.ts
@@ -100,7 +100,7 @@ describe('DiskUsageChecker', () => {
     await checker.checkUsage();
 
     expect(checker['alertSent']).toBeFalsy();
-    expect(mockSendMessage).toHaveBeenCalledTimes(0);
+    expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
   test('should send warnings only once', async () => {

--- a/test/unit/swap/EthereumNursery.spec.ts
+++ b/test/unit/swap/EthereumNursery.spec.ts
@@ -472,7 +472,7 @@ describe('EthereumNursery', () => {
     });
 
     expect(mockGetSwap).toHaveBeenCalledTimes(1);
-    expect(mockSetLockupTransaction).toHaveBeenCalledTimes(0);
+    expect(mockSetLockupTransaction).not.toHaveBeenCalled();
 
     expect(lockupEmitted).toEqual(false);
     expect(lockupFailed).toEqual(0);
@@ -486,7 +486,7 @@ describe('EthereumNursery', () => {
     });
 
     expect(mockGetSwap).toHaveBeenCalledTimes(2);
-    expect(mockSetLockupTransaction).toHaveBeenCalledTimes(0);
+    expect(mockSetLockupTransaction).not.toHaveBeenCalled();
 
     expect(lockupEmitted).toEqual(false);
     expect(lockupFailed).toEqual(0);
@@ -759,7 +759,7 @@ describe('EthereumNursery', () => {
     });
 
     expect(mockGetSwap).toHaveBeenCalledTimes(1);
-    expect(mockSetLockupTransaction).toHaveBeenCalledTimes(0);
+    expect(mockSetLockupTransaction).not.toHaveBeenCalled();
 
     expect(lockupEmitted).toEqual(false);
     expect(lockupFailed).toEqual(0);
@@ -773,7 +773,7 @@ describe('EthereumNursery', () => {
     });
 
     expect(mockGetSwap).toHaveBeenCalledTimes(2);
-    expect(mockSetLockupTransaction).toHaveBeenCalledTimes(0);
+    expect(mockSetLockupTransaction).not.toHaveBeenCalled();
 
     expect(lockupEmitted).toEqual(false);
     expect(lockupFailed).toEqual(0);

--- a/test/unit/swap/LightningNursery.spec.ts
+++ b/test/unit/swap/LightningNursery.spec.ts
@@ -201,8 +201,8 @@ describe('LightningNursery', () => {
 
     await emitHtlcAccepted(invoice);
 
-    expect(mockLookupHoldInvoice).toHaveBeenCalledTimes(0);
-    expect(mockSettleHoldInvoice).toHaveBeenCalledTimes(0);
+    expect(mockLookupHoldInvoice).not.toHaveBeenCalled();
+    expect(mockSettleHoldInvoice).not.toHaveBeenCalled();
     expect(mockGetReverseSwap).toHaveBeenCalledTimes(1);
 
     expect(eventsEmitted).toEqual(1);
@@ -237,7 +237,7 @@ describe('LightningNursery', () => {
       getHexBuffer(decodeInvoice(invoice).paymentHash!),
     );
 
-    expect(mockSettleHoldInvoice).toHaveBeenCalledTimes(0);
+    expect(mockSettleHoldInvoice).not.toHaveBeenCalled();
     expect(mockGetReverseSwap).toHaveBeenCalledTimes(1);
 
     nursery.on('invoice.paid', (reverseSwap) => {
@@ -288,7 +288,7 @@ describe('LightningNursery', () => {
 
     expect(eventsEmitted).toEqual(0);
 
-    expect(mockSettleHoldInvoice).toHaveBeenCalledTimes(0);
+    expect(mockSettleHoldInvoice).not.toHaveBeenCalled();
     expect(mockGetReverseSwap).toHaveBeenCalledTimes(1);
 
     nursery.on('minerfee.invoice.paid', (reverseSwap) => {

--- a/test/unit/swap/NodeFallback.spec.ts
+++ b/test/unit/swap/NodeFallback.spec.ts
@@ -91,7 +91,7 @@ describe('NodeFallback', () => {
       holdInvoiceAmount,
       undefined,
     );
-    expect(routingHints.getRoutingHints).toHaveBeenCalledTimes(0);
+    expect(routingHints.getRoutingHints).not.toHaveBeenCalled();
     expect(
       nodeForReverseSwap.lightningClient.addHoldInvoice,
     ).toHaveBeenCalledTimes(1);
@@ -265,7 +265,7 @@ describe('NodeFallback', () => {
     expect(res.lightningClient).toEqual(nodeForReverseSwap.lightningClient);
 
     expect(nodeSwitch.getNodeForReverseSwap).toHaveBeenCalledTimes(2);
-    expect(routingHints.getRoutingHints).toHaveBeenCalledTimes(0);
+    expect(routingHints.getRoutingHints).not.toHaveBeenCalled();
   });
 
   test('should throw non timeout related errors', async () => {

--- a/test/unit/swap/PaymentHandler.spec.ts
+++ b/test/unit/swap/PaymentHandler.spec.ts
@@ -107,7 +107,7 @@ describe('PaymentHandler', () => {
       undefined,
     );
 
-    expect(mockedEmit).toHaveBeenCalledTimes(0);
+    expect(mockedEmit).not.toHaveBeenCalled();
     expect(btcCurrency.lndClient!.trackPayment).toHaveBeenCalledTimes(1);
     expect(btcCurrency.lndClient!.trackPayment).toHaveBeenCalledWith(
       getHexBuffer(swap.preimageHash),
@@ -130,8 +130,8 @@ describe('PaymentHandler', () => {
       undefined,
     );
 
-    expect(mockedEmit).toHaveBeenCalledTimes(0);
-    expect(btcCurrency.lndClient!.resetMissionControl).toHaveBeenCalledTimes(0);
+    expect(mockedEmit).not.toHaveBeenCalled();
+    expect(btcCurrency.lndClient!.resetMissionControl).not.toHaveBeenCalled();
     expect(btcCurrency.lndClient!.trackPayment).toHaveBeenCalledTimes(1);
     expect(btcCurrency.lndClient!.trackPayment).toHaveBeenCalledWith(
       getHexBuffer(swap.preimageHash),
@@ -145,9 +145,9 @@ describe('PaymentHandler', () => {
       status: Payment.PaymentStatus.FAILED,
     };
 
-    expect(mockedEmit).toHaveBeenCalledTimes(0);
-    expect(btcCurrency.lndClient!.resetMissionControl).toHaveBeenCalledTimes(0);
-    expect(btcCurrency.lndClient!.trackPayment).toHaveBeenCalledTimes(0);
+    expect(mockedEmit).not.toHaveBeenCalled();
+    expect(btcCurrency.lndClient!.resetMissionControl).not.toHaveBeenCalled();
+    expect(btcCurrency.lndClient!.trackPayment).not.toHaveBeenCalled();
 
     await expect(handler.payInvoice(swap, null, undefined)).resolves.toEqual(
       undefined,

--- a/test/unit/swap/UtxoNursery.spec.ts
+++ b/test/unit/swap/UtxoNursery.spec.ts
@@ -334,7 +334,7 @@ describe('UtxoNursery', () => {
 
     expect(mockGetSwap).toHaveBeenCalledTimes(1);
     expect(mockEncodeAddress).toHaveBeenCalledTimes(1);
-    expect(mockSetLockupTransaction).toHaveBeenCalledTimes(0);
+    expect(mockSetLockupTransaction).not.toHaveBeenCalled();
   });
 
   test('should handle confirmed Swap outputs via block events', async () => {
@@ -455,7 +455,7 @@ describe('UtxoNursery', () => {
     expect(mockGetSwap).toHaveBeenCalledTimes(1);
     expect(mockEncodeAddress).toHaveBeenCalledTimes(4);
     expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
-    expect(mockRemoveOutputFilter).toHaveBeenCalledTimes(0);
+    expect(mockRemoveOutputFilter).not.toHaveBeenCalled();
 
     jest.clearAllMocks();
 
@@ -485,7 +485,7 @@ describe('UtxoNursery', () => {
     expect(mockGetSwap).toHaveBeenCalledTimes(1);
     expect(mockEncodeAddress).toHaveBeenCalledTimes(4);
     expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
-    expect(mockRemoveOutputFilter).toHaveBeenCalledTimes(0);
+    expect(mockRemoveOutputFilter).not.toHaveBeenCalled();
 
     jest.clearAllMocks();
 
@@ -522,7 +522,7 @@ describe('UtxoNursery', () => {
       '62af53c6dcda51c4ebac3309b85ce2ca043a912f127250c51e19b1de82299730',
     );
 
-    expect(mockRemoveOutputFilter).toHaveBeenCalledTimes(0);
+    expect(mockRemoveOutputFilter).not.toHaveBeenCalled();
   });
 
   test('should reject 0-conf transactions when the lockup transaction tracker does not allow for 0-conf', async () => {
@@ -695,7 +695,7 @@ describe('UtxoNursery', () => {
     await checkReverseSwapsClaims(btcChainClient, transaction);
 
     expect(mockGetReverseSwap).toHaveBeenCalledTimes(1);
-    expect(mockRemoveInputFilter).toHaveBeenCalledTimes(0);
+    expect(mockRemoveInputFilter).not.toHaveBeenCalled();
   });
 
   test('should handle confirmed Reverse Swap lockups via block events', async () => {
@@ -901,7 +901,7 @@ describe('UtxoNursery', () => {
       await nursery['transactionSignalsRbf'](btcChainClient, transaction),
     ).toEqual(true);
 
-    expect(mockGetRawTransactionVerbose).toHaveBeenCalledTimes(0);
+    expect(mockGetRawTransactionVerbose).not.toHaveBeenCalled();
   });
 
   test('should detect when transactions signal RBF inherently', async () => {


### PR DESCRIPTION
Fetching the status of all swaps on startup takes a couple seconds and is not necessary. Almost all swaps in the database are already done and their status will never be fetched again.
Therefore, we only fetch the swap status as needed and cache after fetching.