### PR TITLE
refactor: tracking of pending invoice payments

### DIFF
--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -544,7 +544,7 @@ export const getPrepayMinerFeeInvoiceMemo = (
 export const formatError = (error: unknown): string => {
   if (typeof error === 'string') {
     return error;
-  } else if ('message' in (error as any)) {
+  } else if (typeof error === 'object' && 'message' in (error as any)) {
     return (error as any)['message'];
   } else {
     return JSON.stringify(error);

--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -10,6 +10,7 @@ import ChainTip from './models/ChainTip';
 import ChannelCreation from './models/ChannelCreation';
 import DatabaseVersion from './models/DatabaseVersion';
 import KeyProvider from './models/KeyProvider';
+import PendingPayment from './models/LightningPayment';
 import MarkedSwap from './models/MarkedSwap';
 import Pair from './models/Pair';
 import PendingEthereumTransaction from './models/PendingEthereumTransaction';
@@ -118,6 +119,7 @@ class Database {
     await Promise.all([
       MarkedSwap.sync(),
       ChainSwapData.sync(),
+      PendingPayment.sync(),
       ChannelCreation.sync(),
       ReverseRoutingHint.sync(),
       PendingLockupTransaction.sync(),
@@ -136,6 +138,7 @@ class Database {
     Pair.load(Database.sequelize);
     Referral.load(Database.sequelize);
     Swap.load(Database.sequelize);
+    PendingPayment.load(Database.sequelize);
     ChainSwap.load(Database.sequelize);
     ChainSwapData.load(Database.sequelize);
     ChainTip.load(Database.sequelize);

--- a/lib/db/models/LightningPayment.ts
+++ b/lib/db/models/LightningPayment.ts
@@ -1,0 +1,76 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { NodeType } from './ReverseSwap';
+import Swap from './Swap';
+
+enum LightningPaymentStatus {
+  Pending = 0,
+  Success = 1,
+  PermanentFailure = 2,
+  TemporaryFailure = 3,
+}
+
+type LightningPaymentType = {
+  preimageHash: string;
+  node: NodeType;
+  status: LightningPaymentStatus;
+};
+
+class LightningPayment extends Model implements LightningPaymentType {
+  public preimageHash!: string;
+  public node!: NodeType;
+  public status!: LightningPaymentStatus;
+
+  public createdAt!: Date;
+  public updatedAt!: Date;
+
+  public static load = (sequelize: Sequelize) => {
+    LightningPayment.init(
+      {
+        preimageHash: {
+          type: new DataTypes.STRING(64),
+          allowNull: false,
+          primaryKey: true,
+        },
+        node: {
+          type: new DataTypes.INTEGER(),
+          allowNull: false,
+          primaryKey: true,
+          validate: {
+            isIn: [
+              Object.values(NodeType).filter((val) => typeof val === 'number'),
+            ],
+          },
+        },
+        status: {
+          type: new DataTypes.INTEGER(),
+          allowNull: false,
+          validate: {
+            isIn: [
+              Object.values(LightningPaymentStatus).filter(
+                (val) => typeof val === 'number',
+              ),
+            ],
+          },
+        },
+      },
+      {
+        sequelize,
+        tableName: 'lightningPayments',
+        indexes: [
+          {
+            unique: false,
+            fields: ['preimageHash'],
+          },
+        ],
+      },
+    );
+
+    LightningPayment.belongsTo(Swap, {
+      targetKey: 'preimageHash',
+      foreignKey: 'preimageHash',
+    });
+  };
+}
+
+export default LightningPayment;
+export { LightningPaymentStatus, LightningPaymentType };

--- a/lib/db/models/ReverseSwap.ts
+++ b/lib/db/models/ReverseSwap.ts
@@ -228,5 +228,15 @@ class ReverseSwap extends Model implements ReverseSwapType {
   }
 }
 
+const nodeTypeToPrettyString = (type: NodeType) => {
+  switch (type) {
+    case NodeType.LND:
+      return 'LND';
+
+    case NodeType.CLN:
+      return 'CLN';
+  }
+};
+
 export default ReverseSwap;
-export { ReverseSwapType, NodeType };
+export { ReverseSwapType, NodeType, nodeTypeToPrettyString };

--- a/lib/db/models/Swap.ts
+++ b/lib/db/models/Swap.ts
@@ -1,4 +1,5 @@
 import { DataTypes, Model, Sequelize } from 'sequelize';
+import { getLightningCurrency, splitPairId } from '../../Utils';
 import { SwapType as SwapKindType, SwapVersion } from '../../consts/Enums';
 import { InsufficientAmountDetails } from '../../consts/Types';
 import Pair from './Pair';
@@ -176,6 +177,11 @@ class Swap extends Model implements SwapType {
 
   get theirPublicKey() {
     return this.refundPublicKey;
+  }
+
+  get lightningCurrency() {
+    const { base, quote } = splitPairId(this.pair);
+    return getLightningCurrency(base, quote, this.orderSide, false);
   }
 
   get failureDetails(): InsufficientAmountDetails | undefined {

--- a/lib/db/repositories/LightningPaymentRepository.ts
+++ b/lib/db/repositories/LightningPaymentRepository.ts
@@ -1,0 +1,57 @@
+import LightningPayment, {
+  LightningPaymentStatus,
+  LightningPaymentType,
+} from '../models/LightningPayment';
+import { NodeType } from '../models/ReverseSwap';
+import Swap from '../models/Swap';
+
+class LightningPaymentRepository {
+  public static create = async (data: Omit<LightningPaymentType, 'status'>) => {
+    const existing = await LightningPayment.findOne({
+      where: {
+        node: data.node,
+        preimageHash: data.preimageHash,
+      },
+    });
+    if (existing === null) {
+      return LightningPayment.create({
+        ...data,
+        status: LightningPaymentStatus.Pending,
+      });
+    }
+
+    if (existing.status !== LightningPaymentStatus.TemporaryFailure) {
+      throw 'payment exists already';
+    }
+
+    return existing.update({
+      status: LightningPaymentStatus.Pending,
+    });
+  };
+
+  public static setStatus = (
+    preimageHash: string,
+    node: NodeType,
+    status: LightningPaymentStatus,
+  ) =>
+    LightningPayment.update(
+      { status },
+      {
+        where: {
+          preimageHash,
+          node,
+        },
+      },
+    );
+
+  public static findByPreimageHash = (preimageHash: string) =>
+    LightningPayment.findAll({ where: { preimageHash } });
+
+  public static findByStatus = (status: LightningPaymentStatus) =>
+    LightningPayment.findAll({
+      where: { status },
+      include: Swap,
+    }) as Promise<(LightningPayment & { Swap: Swap })[]>;
+}
+
+export default LightningPaymentRepository;

--- a/lib/lightning/LightningClient.ts
+++ b/lib/lightning/LightningClient.ts
@@ -1,6 +1,7 @@
 import BaseClient from '../BaseClient';
 import { decodeInvoiceAmount } from '../Utils';
 import { ClientStatus } from '../consts/Enums';
+import { NodeType } from '../db/models/ReverseSwap';
 import * as lndrpc from '../proto/lnd/rpc_pb';
 import { BalancerFetcher } from '../wallet/providers/WalletProviderInterface';
 
@@ -96,6 +97,7 @@ type EventTypes = {
 
 interface LightningClient extends BalancerFetcher, BaseClient<EventTypes> {
   symbol: string;
+  type: NodeType;
 
   isConnected(): boolean;
   setClientStatus(status: ClientStatus): void;

--- a/lib/lightning/PendingPaymentTracker.ts
+++ b/lib/lightning/PendingPaymentTracker.ts
@@ -1,0 +1,253 @@
+import Logger from '../Logger';
+import { racePromise } from '../PromiseUtils';
+import { decodeInvoice, getHexBuffer } from '../Utils';
+import DefaultMap from '../consts/DefaultMap';
+import LightningPayment, {
+  LightningPaymentStatus,
+} from '../db/models/LightningPayment';
+import { NodeType, nodeTypeToPrettyString } from '../db/models/ReverseSwap';
+import LightningPaymentRepository from '../db/repositories/LightningPaymentRepository';
+import { Currency } from '../wallet/WalletManager';
+import { LightningClient, PaymentResponse } from './LightningClient';
+import LndClient from './LndClient';
+import ClnClient from './cln/ClnClient';
+import ClnPendingPaymentTracker from './paymentTrackers/ClnPendingPaymentTracker';
+import LndPendingPaymentTracker from './paymentTrackers/LndPendingPaymentTracker';
+import NodePendingPendingTracker from './paymentTrackers/NodePendingPaymentTrackers';
+
+type LightningNodes = Record<NodeType, LightningClient | undefined>;
+
+class PendingPaymentTracker {
+  private static readonly raceTimeout = 15;
+  private static readonly timeoutError = 'payment timed out';
+
+  public readonly lightningTrackers: Record<
+    NodeType,
+    NodePendingPendingTracker
+  >;
+
+  private readonly lightningNodes = new DefaultMap<string, LightningNodes>(
+    () => ({
+      [NodeType.LND]: undefined,
+      [NodeType.CLN]: undefined,
+    }),
+  );
+
+  constructor(private readonly logger: Logger) {
+    this.lightningTrackers = {
+      [NodeType.LND]: new LndPendingPaymentTracker(this.logger),
+      [NodeType.CLN]: new ClnPendingPaymentTracker(this.logger),
+    };
+  }
+
+  public init = async (currencies: Currency[]) => {
+    currencies.forEach((currency) => {
+      this.lightningNodes.set(currency.symbol, {
+        [NodeType.LND]: currency.lndClient,
+        [NodeType.CLN]: currency.clnClient,
+      });
+    });
+
+    for (const payment of await LightningPaymentRepository.findByStatus(
+      LightningPaymentStatus.Pending,
+    )) {
+      const client = this.lightningNodes.get(payment.Swap.lightningCurrency)[
+        payment.node
+      ];
+      if (client === undefined) {
+        this.logger.warn(
+          `Could not track payment ${payment.preimageHash}: ${payment.Swap.lightningCurrency} ${nodeTypeToPrettyString(payment.node)} is not available`,
+        );
+        continue;
+      }
+
+      this.logger.debug(
+        `Watching pending ${client.symbol} ${nodeTypeToPrettyString(client.type)} payment: ${payment.preimageHash}`,
+      );
+      this.lightningTrackers[payment.node].watchPayment(
+        client,
+        payment.Swap.invoice!,
+        payment.preimageHash,
+      );
+    }
+  };
+
+  public sendPayment = async (
+    lightningClient: LightningClient,
+    invoice: string,
+    cltvLimit?: number,
+    outgoingChannelId?: string,
+  ): Promise<PaymentResponse | undefined> => {
+    const preimageHash = decodeInvoice(invoice).paymentHash!;
+
+    const payments =
+      await LightningPaymentRepository.findByPreimageHash(preimageHash);
+
+    for (const status of [
+      LightningPaymentStatus.Pending,
+      LightningPaymentStatus.Success,
+      LightningPaymentStatus.PermanentFailure,
+    ]) {
+      const relevant = payments.find((p) => p.status === status);
+      if (relevant === undefined) {
+        continue;
+      }
+
+      switch (status) {
+        case LightningPaymentStatus.Pending:
+          this.logger.verbose(
+            `Invoice payment of ${preimageHash} still pending with node ${nodeTypeToPrettyString(relevant.node)}`,
+          );
+          return undefined;
+
+        case LightningPaymentStatus.Success:
+          return this.getSuccessfulPaymentDetails(
+            relevant,
+            lightningClient.symbol,
+            preimageHash,
+            invoice,
+          );
+
+        case LightningPaymentStatus.PermanentFailure:
+          return await this.getPermanentFailureDetails(
+            relevant,
+            lightningClient.symbol,
+            preimageHash,
+          );
+      }
+    }
+
+    return this.sendPaymentWithNode(
+      lightningClient,
+      preimageHash,
+      invoice,
+      cltvLimit,
+      outgoingChannelId,
+    );
+  };
+
+  private sendPaymentWithNode = async (
+    lightningClient: LightningClient,
+    preimageHash: string,
+    invoice: string,
+    cltvLimit?: number,
+    outgoingChannelId?: string,
+  ) => {
+    await LightningPaymentRepository.create({
+      preimageHash,
+      node: lightningClient.type,
+    });
+
+    let paymentPromise: Promise<PaymentResponse> | undefined = undefined;
+    try {
+      paymentPromise = lightningClient.sendPayment(
+        invoice,
+        cltvLimit,
+        outgoingChannelId,
+      );
+      const res = await racePromise(
+        paymentPromise,
+        (reject) => reject(PendingPaymentTracker.timeoutError),
+        PendingPaymentTracker.raceTimeout * 1_000,
+      );
+      await LightningPaymentRepository.setStatus(
+        preimageHash,
+        lightningClient.type,
+        LightningPaymentStatus.Success,
+      );
+
+      return res;
+    } catch (e) {
+      if (
+        e === PendingPaymentTracker.timeoutError &&
+        paymentPromise !== undefined
+      ) {
+        this.lightningTrackers[lightningClient.type].trackPayment(
+          preimageHash,
+          paymentPromise,
+        );
+        this.logger.verbose(
+          `Invoice payment ${preimageHash} is still pending with node ${nodeTypeToPrettyString(lightningClient.type)} after ${PendingPaymentTracker.raceTimeout} seconds`,
+        );
+        return undefined;
+      }
+
+      await LightningPaymentRepository.setStatus(
+        preimageHash,
+        lightningClient.type,
+        this.lightningTrackers[lightningClient.type].isPermanentError(e)
+          ? LightningPaymentStatus.PermanentFailure
+          : LightningPaymentStatus.TemporaryFailure,
+      );
+
+      throw e;
+    }
+  };
+
+  private getSuccessfulPaymentDetails = async (
+    payment: LightningPayment,
+    symbol: string,
+    preimageHash: string,
+    invoice: string,
+  ): Promise<PaymentResponse | undefined> => {
+    this.logger.verbose(
+      `Invoice payment of ${preimageHash} has already succeeded on node ${symbol} ${nodeTypeToPrettyString(payment.node)}`,
+    );
+
+    const nodeThatPaid = this.lightningNodes.get(symbol)[payment.node];
+    if (nodeThatPaid === undefined) {
+      this.logger.warn(
+        `Could not resolve payment ${preimageHash}: ${symbol} ${nodeTypeToPrettyString(payment.node)} is not available`,
+      );
+      return undefined;
+    }
+
+    switch (nodeThatPaid.type) {
+      case NodeType.LND: {
+        const trackedPayment = await (nodeThatPaid as LndClient).trackPayment(
+          getHexBuffer(preimageHash),
+        );
+        return {
+          feeMsat: trackedPayment.feeMsat,
+          preimage: getHexBuffer(trackedPayment.paymentPreimage),
+        };
+      }
+
+      case NodeType.CLN:
+        return (nodeThatPaid as ClnClient).checkPayStatus(invoice);
+    }
+  };
+
+  private getPermanentFailureDetails = async (
+    payment: LightningPayment,
+    symbol: string,
+    preimageHash: string,
+  ) => {
+    this.logger.verbose(
+      `Invoice payment of ${preimageHash} has failed with a permanent error on node ${symbol} ${nodeTypeToPrettyString(payment.node)}`,
+    );
+
+    const nodeThatFailed = this.lightningNodes.get(symbol)[payment.node];
+    if (nodeThatFailed === undefined) {
+      this.logger.warn(
+        `Could not get permanent payment error of ${preimageHash}: ${symbol} ${nodeTypeToPrettyString(payment.node)} is not available`,
+      );
+      return undefined;
+    }
+
+    switch (nodeThatFailed.type) {
+      case NodeType.LND:
+        throw (
+          await (nodeThatFailed as LndClient).trackPayment(
+            getHexBuffer(preimageHash),
+          )
+        ).failureReason;
+
+      case NodeType.CLN:
+        // TODO: fetch actual error when mpay starts saving details of errors
+        throw 'WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS';
+    }
+  };
+}
+
+export default PendingPaymentTracker;

--- a/lib/lightning/cln/ClnClient.ts
+++ b/lib/lightning/cln/ClnClient.ts
@@ -13,6 +13,7 @@ import {
   getHexString,
 } from '../../Utils';
 import { ClientStatus } from '../../consts/Enums';
+import { NodeType } from '../../db/models/ReverseSwap';
 import { NodeClient } from '../../proto/cln/node_grpc_pb';
 import * as noderpc from '../../proto/cln/node_pb';
 import { ListfundsOutputs, ListpaysPays } from '../../proto/cln/node_pb';
@@ -57,6 +58,8 @@ class ClnClient
   public static readonly serviceName = 'CLN';
   public static readonly serviceNameHold = 'hold';
   public static readonly moddedVersionSuffix = '-modded';
+
+  public static readonly paymentPendingError = 'payment already pending';
 
   public readonly mpay?: Mpay;
 
@@ -104,6 +107,10 @@ class ClnClient
         `Mpay not configured for ${ClnClient.serviceName} ${this.symbol}; using pay`,
       );
     }
+  }
+
+  public get type() {
+    return NodeType.CLN;
   }
 
   public static isRpcError = (error: any): boolean => {
@@ -752,7 +759,7 @@ class ClnClient
         );
 
       if (hasPendingHtlc) {
-        throw 'payment already pending';
+        throw ClnClient.paymentPendingError;
       }
     }
 

--- a/lib/lightning/cln/MpayClient.ts
+++ b/lib/lightning/cln/MpayClient.ts
@@ -103,6 +103,12 @@ class Mpay extends BaseClient {
     };
   };
 
+  public resetPathMemory = () =>
+    this.unaryNodeCall<
+      mpayrpc.ResetPathMemoryRequest,
+      mpayrpc.ResetPathMemoryResponse
+    >('resetPathMemory', new mpayrpc.ResetPathMemoryRequest());
+
   private unaryNodeCall = <T, U>(
     methodName: keyof MpayClient,
     params: T,

--- a/lib/lightning/paymentTrackers/ClnPendingPaymentTracker.ts
+++ b/lib/lightning/paymentTrackers/ClnPendingPaymentTracker.ts
@@ -1,0 +1,86 @@
+import Logger from '../../Logger';
+import { formatError } from '../../Utils';
+import { NodeType } from '../../db/models/ReverseSwap';
+import LightningNursery from '../../swap/LightningNursery';
+import { LightningClient } from '../LightningClient';
+import ClnClient from '../cln/ClnClient';
+import NodePendingPendingTracker from './NodePendingPaymentTrackers';
+
+class ClnPendingPaymentTracker extends NodePendingPendingTracker {
+  private static readonly checkInterval = 15;
+
+  private readonly checkInterval: NodeJS.Timer;
+
+  private readonly paymentsToWatch = new Map<
+    string,
+    { invoice: string; client: ClnClient }
+  >();
+
+  constructor(logger: Logger) {
+    super(logger, NodeType.CLN);
+    // CLN does not have streaming for existing pending payments
+    // We have to poll on interval
+    this.logger.debug(
+      `Checking for updates on pending CLN payments every ${ClnPendingPaymentTracker.checkInterval} seconds`,
+    );
+    this.checkInterval = setInterval(
+      this.checkPendingPayments,
+      ClnPendingPaymentTracker.checkInterval * 1_000,
+    );
+  }
+
+  public stop = () => {
+    clearInterval(this.checkInterval);
+  };
+
+  public watchPayment = (
+    client: LightningClient,
+    invoice: string,
+    preimageHash: string,
+  ) => {
+    this.paymentsToWatch.set(preimageHash, {
+      invoice,
+      client: client as ClnClient,
+    });
+  };
+
+  public isPermanentError = (error: unknown) => {
+    const errorMessage = this.parseErrorMessage(error);
+    return (
+      ClnClient.errIsIncorrectPaymentDetails(errorMessage) ||
+      LightningNursery.errIsInvoiceExpired(errorMessage)
+    );
+  };
+
+  private checkPendingPayments = async () => {
+    for (const [
+      preimageHash,
+      { client, invoice },
+    ] of this.paymentsToWatch.entries()) {
+      try {
+        const res = await client.checkPayStatus(invoice);
+        if (res === undefined) {
+          continue;
+        }
+
+        await this.handleSucceededPayment(preimageHash, res);
+      } catch (e) {
+        // Ignore when the payment is pending; it's not a payment error
+        if (e === ClnClient.paymentPendingError) {
+          continue;
+        }
+
+        await this.handleFailedPayment(preimageHash, e);
+      }
+
+      this.paymentsToWatch.delete(preimageHash);
+    }
+  };
+
+  private parseErrorMessage = (error: unknown) =>
+    ClnClient.isRpcError(error)
+      ? ClnClient.formatPaymentFailureReason(error as any)
+      : formatError(error);
+}
+
+export default ClnPendingPaymentTracker;

--- a/lib/lightning/paymentTrackers/LndPendingPaymentTracker.ts
+++ b/lib/lightning/paymentTrackers/LndPendingPaymentTracker.ts
@@ -1,0 +1,53 @@
+import Logger from '../../Logger';
+import { formatError, getHexBuffer } from '../../Utils';
+import { NodeType, nodeTypeToPrettyString } from '../../db/models/ReverseSwap';
+import { Payment, PaymentFailureReason } from '../../proto/lnd/rpc_pb';
+import LightningNursery from '../../swap/LightningNursery';
+import { LightningClient } from '../LightningClient';
+import LndClient from '../LndClient';
+import NodePendingPendingTracker from './NodePendingPaymentTrackers';
+
+class LndPendingPaymentTracker extends NodePendingPendingTracker {
+  constructor(logger: Logger) {
+    super(logger, NodeType.LND);
+  }
+
+  public watchPayment = (
+    client: LightningClient,
+    _: string,
+    preimageHash: string,
+  ) => {
+    (client as LndClient)
+      .trackPayment(getHexBuffer(preimageHash), true)
+      .then(async (res) => {
+        switch (res.status) {
+          case Payment.PaymentStatus.SUCCEEDED:
+            await this.handleSucceededPayment(preimageHash, {
+              feeMsat: res.feeMsat,
+              preimage: getHexBuffer(res.paymentPreimage),
+            });
+            break;
+
+          case Payment.PaymentStatus.FAILED:
+            await this.handleFailedPayment(preimageHash, res.failureReason);
+            break;
+        }
+      })
+      .catch((error) => {
+        this.logger.warn(
+          `Tracking payment ${preimageHash} with ${client.symbol} ${nodeTypeToPrettyString(this.nodeType)} failed: ${this.parseErrorMessage(error)}`,
+        );
+      });
+  };
+
+  public isPermanentError = (error: unknown) =>
+    error === PaymentFailureReason.FAILURE_REASON_INCORRECT_PAYMENT_DETAILS ||
+    LightningNursery.errIsInvoiceExpired(this.parseErrorMessage(error));
+
+  private parseErrorMessage = (error: unknown) =>
+    typeof error === 'number'
+      ? LndClient.formatPaymentFailureReason(error as any)
+      : formatError(error);
+}
+
+export default LndPendingPaymentTracker;

--- a/lib/lightning/paymentTrackers/NodePendingPaymentTrackers.ts
+++ b/lib/lightning/paymentTrackers/NodePendingPaymentTrackers.ts
@@ -1,0 +1,71 @@
+import Logger from '../../Logger';
+import { formatError, getHexString, stringify } from '../../Utils';
+import { LightningPaymentStatus } from '../../db/models/LightningPayment';
+import { NodeType, nodeTypeToPrettyString } from '../../db/models/ReverseSwap';
+import LightningPaymentRepository from '../../db/repositories/LightningPaymentRepository';
+import { LightningClient, PaymentResponse } from '../LightningClient';
+import LndClient from '../LndClient';
+
+abstract class NodePendingPendingTracker {
+  protected constructor(
+    protected readonly logger: Logger,
+    protected readonly nodeType: NodeType,
+  ) {}
+
+  public abstract watchPayment(
+    client: LightningClient,
+    invoice: string,
+    preimageHash: string,
+  ): void;
+
+  public abstract isPermanentError(err: unknown): boolean;
+
+  public trackPayment = (
+    preimageHash: string,
+    promise: Promise<PaymentResponse>,
+  ) => {
+    promise
+      .then((result) => this.handleSucceededPayment(preimageHash, result))
+      .catch((error) => this.handleFailedPayment(preimageHash, error));
+  };
+
+  protected handleSucceededPayment = async (
+    preimageHash: string,
+    result: PaymentResponse,
+  ) => {
+    this.logger.debug(
+      `${nodeTypeToPrettyString(this.nodeType)} paid invoice ${preimageHash}: ${stringify(
+        {
+          feeMsat: result.feeMsat,
+          preimage: getHexString(result.preimage),
+        },
+      )}`,
+    );
+    await LightningPaymentRepository.setStatus(
+      preimageHash,
+      this.nodeType,
+      LightningPaymentStatus.Success,
+    );
+  };
+
+  protected handleFailedPayment = async (preimageHash: string, error: any) => {
+    const isPermanent = this.isPermanentError(error);
+
+    const errorMsg =
+      typeof error === 'number' && this.nodeType === NodeType.LND
+        ? LndClient.formatPaymentFailureReason(error)
+        : formatError(error);
+    this.logger.debug(
+      `${nodeTypeToPrettyString(this.nodeType)} payment ${preimageHash} failed ${isPermanent ? 'permanently' : 'temporarily'}: ${errorMsg}`,
+    );
+    await LightningPaymentRepository.setStatus(
+      preimageHash,
+      this.nodeType,
+      isPermanent
+        ? LightningPaymentStatus.PermanentFailure
+        : LightningPaymentStatus.TemporaryFailure,
+    );
+  };
+}
+
+export default NodePendingPendingTracker;

--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -170,10 +170,8 @@ class EthereumNursery extends TypedEventEmitter<{
           }),
         ]);
 
-        for (const swap of swaps.filter(
-          (s): s is ReverseSwap | ChainSwapInfo => s !== null,
-        )) {
-          await this.checkEtherSwapLockup(swap, transaction, etherSwapValues);
+        for (const swap of swaps.filter((s) => s !== null)) {
+          await this.checkEtherSwapLockup(swap!, transaction, etherSwapValues);
         }
       },
     );
@@ -229,10 +227,8 @@ class EthereumNursery extends TypedEventEmitter<{
           }),
         ]);
 
-        for (const swap of swaps.filter(
-          (s): s is ReverseSwap | ChainSwapInfo => s !== null,
-        )) {
-          await this.checkErc20SwapLock(swap, transaction, erc20SwapValues);
+        for (const swap of swaps.filter((s) => s !== null)) {
+          await this.checkErc20SwapLock(swap!, transaction, erc20SwapValues);
         }
       },
     );

--- a/lib/swap/LightningNursery.ts
+++ b/lib/swap/LightningNursery.ts
@@ -54,7 +54,10 @@ class LightningNursery extends TypedEventEmitter<{
   };
 
   public static errIsInvoiceExpired = (error: string): boolean => {
-    return error.toLowerCase().includes('invoice expired');
+    return (
+      error === 'InvoiceExpiredError()' ||
+      error.toLowerCase().includes('invoice expired')
+    );
   };
 
   public static cancelReverseInvoices = async (

--- a/test/integration/db/repositories/Fixtures.ts
+++ b/test/integration/db/repositories/Fixtures.ts
@@ -1,5 +1,9 @@
 import { randomBytes } from 'crypto';
-import { generateId, getHexString } from '../../../../lib/Utils';
+import {
+  generateId,
+  generateSwapId,
+  getHexString,
+} from '../../../../lib/Utils';
 import {
   OrderSide,
   SwapUpdateEvent,
@@ -9,6 +13,17 @@ import ChainSwapData from '../../../../lib/db/models/ChainSwapData';
 import { NodeType } from '../../../../lib/db/models/ReverseSwap';
 import ChainSwapRepository from '../../../../lib/db/repositories/ChainSwapRepository';
 import ReverseSwapRepository from '../../../../lib/db/repositories/ReverseSwapRepository';
+
+export const createSubmarineSwapData = () => ({
+  pair: 'BTC/BTC',
+  lockupAddress: 'bc1',
+  timeoutBlockHeight: 1,
+  orderSide: OrderSide.BUY,
+  version: SwapVersion.Taproot,
+  status: SwapUpdateEvent.SwapCreated,
+  id: generateSwapId(SwapVersion.Taproot),
+  preimageHash: getHexString(randomBytes(32)),
+});
 
 export const createReverseSwap = async (
   status = SwapUpdateEvent.ChannelCreated,

--- a/test/integration/db/repositories/LightningPaymentRepository.spec.ts
+++ b/test/integration/db/repositories/LightningPaymentRepository.spec.ts
@@ -1,0 +1,149 @@
+import Logger from '../../../../lib/Logger';
+import Database from '../../../../lib/db/Database';
+import LightningPayment, {
+  LightningPaymentStatus,
+} from '../../../../lib/db/models/LightningPayment';
+import { NodeType } from '../../../../lib/db/models/ReverseSwap';
+import Swap from '../../../../lib/db/models/Swap';
+import LightningPaymentRepository from '../../../../lib/db/repositories/LightningPaymentRepository';
+import PairRepository from '../../../../lib/db/repositories/PairRepository';
+import { createSubmarineSwapData } from './Fixtures';
+
+describe('LightningPaymentRepository', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    db = new Database(Logger.disabledLogger, Database.memoryDatabase);
+    await db.init();
+
+    await PairRepository.addPair({
+      id: 'BTC/BTC',
+      base: 'BTC',
+      quote: 'BTC',
+    });
+  });
+
+  beforeEach(async () => {
+    await LightningPayment.truncate();
+    await Swap.truncate();
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  describe('create', () => {
+    test('should create new lightning payments', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      const payment = await LightningPaymentRepository.create({
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+      });
+      expect(payment.node).toEqual(NodeType.LND);
+      expect(payment.preimageHash).toEqual(swap.preimageHash);
+      expect(payment.status).toEqual(LightningPaymentStatus.Pending);
+    });
+
+    test.each`
+      status
+      ${LightningPaymentStatus.Pending}
+      ${LightningPaymentStatus.Success}
+      ${LightningPaymentStatus.PermanentFailure}
+    `('should not create when status is $status', async ({ status }) => {
+      const swap = await Swap.create(createSubmarineSwapData());
+      await LightningPayment.create({
+        status,
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+      });
+
+      await expect(
+        LightningPaymentRepository.create({
+          node: NodeType.LND,
+          preimageHash: swap.preimageHash,
+        }),
+      ).rejects.toEqual('payment exists already');
+    });
+
+    test(`should update when payment with status ${LightningPaymentStatus.TemporaryFailure} exists already`, async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+      const existing = await LightningPayment.create({
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+        status: LightningPaymentStatus.TemporaryFailure,
+      });
+
+      const payment = await LightningPaymentRepository.create({
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+      });
+      expect(payment.node).toEqual(NodeType.LND);
+      expect(payment.preimageHash).toEqual(swap.preimageHash);
+      expect(payment.status).toEqual(LightningPaymentStatus.Pending);
+
+      await existing.reload();
+      expect(existing.status).toEqual(LightningPaymentStatus.Pending);
+    });
+  });
+
+  describe('setStatus', () => {
+    test('should set status', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+      const payment = await LightningPaymentRepository.create({
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+      });
+
+      await expect(
+        LightningPaymentRepository.setStatus(
+          swap.preimageHash,
+          NodeType.LND,
+          LightningPaymentStatus.Success,
+        ),
+      ).resolves.toEqual([1]);
+
+      await payment.reload();
+      expect(payment.status).toEqual(LightningPaymentStatus.Success);
+    });
+  });
+
+  describe('findByPreimageHash', () => {
+    test('should find by preimage hash', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await LightningPaymentRepository.create({
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+      });
+      await LightningPaymentRepository.create({
+        node: NodeType.CLN,
+        preimageHash: swap.preimageHash,
+      });
+
+      await expect(
+        LightningPaymentRepository.findByPreimageHash(swap.preimageHash),
+      ).resolves.toHaveLength(2);
+    });
+  });
+
+  describe('findByStatus', () => {
+    test('should find by status', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+      await LightningPaymentRepository.create({
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+      });
+
+      const res = await LightningPaymentRepository.findByStatus(
+        LightningPaymentStatus.Pending,
+      );
+
+      expect(res).toHaveLength(1);
+      expect(res[0].preimageHash).toEqual(swap.preimageHash);
+      expect(res[0].status).toEqual(LightningPaymentStatus.Pending);
+
+      expect(res[0].Swap.id).toEqual(swap.id);
+    });
+  });
+});

--- a/test/integration/lightning/PendingPaymentTracker.spec.ts
+++ b/test/integration/lightning/PendingPaymentTracker.spec.ts
@@ -1,0 +1,415 @@
+import { crypto } from 'bitcoinjs-lib';
+import { randomBytes } from 'crypto';
+import Logger from '../../../lib/Logger';
+import { decodeInvoice, getHexBuffer, getHexString } from '../../../lib/Utils';
+import Database from '../../../lib/db/Database';
+import LightningPayment, {
+  LightningPaymentStatus,
+} from '../../../lib/db/models/LightningPayment';
+import { NodeType } from '../../../lib/db/models/ReverseSwap';
+import Swap from '../../../lib/db/models/Swap';
+import LightningPaymentRepository from '../../../lib/db/repositories/LightningPaymentRepository';
+import PairRepository from '../../../lib/db/repositories/PairRepository';
+import PendingPaymentTracker from '../../../lib/lightning/PendingPaymentTracker';
+import { Currency } from '../../../lib/wallet/WalletManager';
+import { createInvoice } from '../../unit/swap/InvoiceUtils';
+import { bitcoinLndClient, clnClient } from '../Nodes';
+import { createSubmarineSwapData } from '../db/repositories/Fixtures';
+
+jest.mock(
+  '../../../lib/lightning/paymentTrackers/ClnPendingPaymentTracker',
+  () =>
+    jest.fn().mockImplementation(() => ({
+      trackPayment: jest.fn(),
+      watchPayment: jest.fn(),
+      isPermanentError: jest.fn().mockReturnValue(true),
+    })),
+);
+jest.mock(
+  '../../../lib/lightning/paymentTrackers/LndPendingPaymentTracker',
+  () =>
+    jest.fn().mockImplementation(() => ({
+      trackPayment: jest.fn(),
+      watchPayment: jest.fn(),
+      isPermanentError: jest.fn().mockReturnValue(true),
+    })),
+);
+
+describe('PendingPaymentTracker', () => {
+  let db: Database;
+  const tracker = new PendingPaymentTracker(Logger.disabledLogger);
+
+  const currencies = [
+    {
+      clnClient,
+      symbol: 'BTC',
+      lndClient: bitcoinLndClient,
+    },
+  ] as Currency[];
+
+  beforeAll(async () => {
+    db = new Database(Logger.disabledLogger, Database.memoryDatabase);
+
+    await Promise.all([
+      db.init(),
+      clnClient.connect(true),
+      bitcoinLndClient.connect(false),
+    ]);
+
+    await PairRepository.addPair({
+      id: 'BTC/BTC',
+      base: 'BTC',
+      quote: 'BTC',
+    });
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    await LightningPayment.truncate();
+    await Swap.truncate();
+
+    await tracker.init(currencies);
+    await clnClient['mpay']?.resetPathMemory();
+  });
+
+  afterAll(async () => {
+    await db.close();
+    await clnClient['mpay']?.resetPathMemory();
+
+    clnClient.disconnect();
+    bitcoinLndClient.disconnect();
+  });
+
+  describe('init', () => {
+    test('should populate lightning nodes', async () => {
+      await tracker.init(currencies);
+
+      expect(tracker['lightningNodes'].size).toEqual(1);
+      expect(tracker['lightningNodes'].get('BTC')).toEqual({
+        [NodeType.CLN]: clnClient,
+        [NodeType.LND]: bitcoinLndClient,
+      });
+    });
+
+    test('should watch pending lightning payments', async () => {
+      const swap = await Swap.create({
+        ...createSubmarineSwapData(),
+        invoice: 'lnbc1',
+      });
+      await LightningPaymentRepository.create({
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+      });
+
+      await tracker.init(currencies);
+
+      expect(
+        tracker.lightningTrackers[NodeType.CLN].watchPayment,
+      ).not.toHaveBeenCalled();
+
+      expect(
+        tracker.lightningTrackers[NodeType.LND].watchPayment,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        tracker.lightningTrackers[NodeType.LND].watchPayment,
+      ).toHaveBeenCalledWith(bitcoinLndClient, swap.invoice, swap.preimageHash);
+    });
+
+    test('should not watch pending lightning payments when the client with the pending payment is not available', async () => {
+      const swap = await Swap.create({
+        ...createSubmarineSwapData(),
+        invoice: 'lnbc1',
+      });
+      await LightningPaymentRepository.create({
+        node: NodeType.LND,
+        preimageHash: swap.preimageHash,
+      });
+
+      await tracker.init([
+        {
+          ...currencies[0],
+          lndClient: undefined,
+        },
+      ]);
+
+      expect(
+        tracker.lightningTrackers[NodeType.LND].watchPayment,
+      ).not.toHaveBeenCalled();
+      expect(
+        tracker.lightningTrackers[NodeType.CLN].watchPayment,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendPayment', () => {
+    test('should send payments', async () => {
+      const invoiceRes = await bitcoinLndClient.addInvoice(1);
+      const preimageHash = decodeInvoice(
+        invoiceRes.paymentRequest,
+      ).paymentHash!;
+      await Swap.create({
+        ...createSubmarineSwapData(),
+        preimageHash,
+        invoice: invoiceRes.paymentRequest,
+      });
+
+      const res = await tracker.sendPayment(
+        clnClient,
+        invoiceRes.paymentRequest,
+      );
+      expect(res).not.toBeUndefined();
+      expect(typeof res!.feeMsat).toEqual('number');
+      expect(res!.preimage).toEqual(
+        Buffer.from(
+          (await bitcoinLndClient.lookupInvoice(getHexBuffer(preimageHash)))
+            .rPreimage as string,
+          'base64',
+        ),
+      );
+
+      const payments =
+        await LightningPaymentRepository.findByPreimageHash(preimageHash);
+      expect(payments).toHaveLength(1);
+      expect(payments[0].node).toEqual(NodeType.CLN);
+      expect(payments[0].status).toEqual(LightningPaymentStatus.Success);
+    });
+
+    test('should bubble up error when payment cannot be sent', async () => {
+      const invoiceRes = await bitcoinLndClient.addInvoice(1);
+      const preimageHash = decodeInvoice(
+        invoiceRes.paymentRequest,
+      ).paymentHash!;
+
+      await bitcoinLndClient.cancelHoldInvoice(getHexBuffer(preimageHash));
+      await Swap.create({
+        ...createSubmarineSwapData(),
+        preimageHash,
+        invoice: invoiceRes.paymentRequest,
+      });
+
+      await expect(
+        tracker.sendPayment(clnClient, invoiceRes.paymentRequest),
+      ).rejects.toEqual(expect.anything());
+
+      const payments =
+        await LightningPaymentRepository.findByPreimageHash(preimageHash);
+      expect(payments).toHaveLength(1);
+      expect(payments[0].node).toEqual(NodeType.CLN);
+      expect(payments[0].status).toEqual(
+        LightningPaymentStatus.PermanentFailure,
+      );
+    });
+
+    test('should keep track of pending payments in background', async () => {
+      const preimageHash = randomBytes(32);
+      const invoice = await bitcoinLndClient.addHoldInvoice(1, preimageHash);
+
+      await Swap.create({
+        ...createSubmarineSwapData(),
+        invoice,
+        preimageHash: getHexString(preimageHash),
+      });
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      PendingPaymentTracker['raceTimeout'] = 2;
+      await expect(tracker.sendPayment(clnClient, invoice)).resolves.toEqual(
+        undefined,
+      );
+      await bitcoinLndClient.cancelHoldInvoice(preimageHash);
+
+      expect(
+        tracker.lightningTrackers[NodeType.CLN].trackPayment,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        tracker.lightningTrackers[NodeType.CLN].trackPayment,
+      ).toHaveBeenCalledWith(getHexString(preimageHash), expect.any(Promise));
+
+      const payments = await LightningPaymentRepository.findByPreimageHash(
+        getHexString(preimageHash),
+      );
+      expect(payments).toHaveLength(1);
+      expect(payments[0].node).toEqual(NodeType.CLN);
+      expect(payments[0].status).toEqual(LightningPaymentStatus.Pending);
+    });
+
+    describe('existing relevant status', () => {
+      test('should not call the nodes when there is a pending payment', async () => {
+        const swapData = createSubmarineSwapData();
+        const swap = await Swap.create({
+          ...swapData,
+          invoice: createInvoice(swapData.preimageHash),
+        });
+        await LightningPaymentRepository.create({
+          node: NodeType.LND,
+          preimageHash: swap.preimageHash,
+        });
+
+        await expect(
+          tracker.sendPayment(bitcoinLndClient, swap.invoice!),
+        ).resolves.toEqual(undefined);
+      });
+
+      describe('success', () => {
+        test('should get success details from LND when the invoice has been paid', async () => {
+          const preimage = randomBytes(32);
+          const preimageHash = crypto.sha256(preimage);
+
+          const invoice = await clnClient.addHoldInvoice(1, preimageHash);
+          clnClient.on('htlc.accepted', async () => {
+            await clnClient.settleHoldInvoice(preimage);
+          });
+
+          const swap = await Swap.create({
+            ...createSubmarineSwapData(),
+            invoice,
+            preimageHash: getHexString(preimageHash),
+          });
+          await LightningPayment.create({
+            node: NodeType.LND,
+            preimageHash: swap.preimageHash,
+            status: LightningPaymentStatus.Success,
+          });
+
+          const paymentRes = await bitcoinLndClient.sendPayment(invoice);
+          await expect(
+            tracker.sendPayment(bitcoinLndClient, invoice),
+          ).resolves.toEqual(paymentRes);
+        });
+
+        test('should get success details from CLN when the invoice has been paid', async () => {
+          const invoiceRes = await bitcoinLndClient.addInvoice(1);
+          const swap = await Swap.create({
+            ...createSubmarineSwapData(),
+            invoice: invoiceRes.paymentRequest,
+            preimageHash: decodeInvoice(invoiceRes.paymentRequest).paymentHash,
+          });
+          await LightningPayment.create({
+            node: NodeType.CLN,
+            preimageHash: swap.preimageHash,
+            status: LightningPaymentStatus.Success,
+          });
+
+          const paymentRes = await clnClient.sendPayment(
+            invoiceRes.paymentRequest,
+          );
+          await expect(
+            tracker.sendPayment(clnClient, invoiceRes.paymentRequest),
+          ).resolves.toEqual(paymentRes);
+        });
+
+        test('should return undefined when node for fetching success details is not available', async () => {
+          const invoiceRes = await bitcoinLndClient.addInvoice(1);
+          const swap = await Swap.create({
+            ...createSubmarineSwapData(),
+            invoice: invoiceRes.paymentRequest,
+            preimageHash: decodeInvoice(invoiceRes.paymentRequest).paymentHash,
+          });
+          await LightningPayment.create({
+            node: NodeType.CLN,
+            preimageHash: swap.preimageHash,
+            status: LightningPaymentStatus.Success,
+          });
+
+          await tracker.init([
+            {
+              ...currencies[0],
+              clnClient: undefined,
+            },
+          ]);
+
+          await clnClient.sendPayment(invoiceRes.paymentRequest);
+          await expect(
+            tracker.sendPayment(clnClient, invoiceRes.paymentRequest),
+          ).resolves.toEqual(undefined);
+        });
+      });
+
+      describe('permanent failure', () => {
+        test('should get permanent failure details from LND', async () => {
+          const preimageHash = crypto.sha256(randomBytes(32));
+          const invoice = await clnClient.addHoldInvoice(1, preimageHash);
+          await clnClient.cancelHoldInvoice(preimageHash);
+
+          const swap = await Swap.create({
+            ...createSubmarineSwapData(),
+            invoice,
+            preimageHash: getHexString(preimageHash),
+          });
+          await LightningPayment.create({
+            node: NodeType.LND,
+            preimageHash: swap.preimageHash,
+            status: LightningPaymentStatus.PermanentFailure,
+          });
+
+          let error: any;
+
+          try {
+            await bitcoinLndClient.sendPayment(invoice);
+          } catch (e) {
+            error = e;
+          }
+
+          await expect(
+            tracker.sendPayment(bitcoinLndClient, invoice),
+          ).rejects.toEqual(error);
+        });
+
+        test('should get permanent failure details from CLN', async () => {
+          const preimageHash = crypto.sha256(randomBytes(32));
+          const invoice = await bitcoinLndClient.addHoldInvoice(
+            1,
+            preimageHash,
+          );
+          await bitcoinLndClient.cancelHoldInvoice(preimageHash);
+
+          const swap = await Swap.create({
+            ...createSubmarineSwapData(),
+            invoice,
+            preimageHash: getHexString(preimageHash),
+          });
+          await LightningPayment.create({
+            node: NodeType.CLN,
+            preimageHash: swap.preimageHash,
+            status: LightningPaymentStatus.PermanentFailure,
+          });
+
+          await expect(clnClient.sendPayment(invoice)).rejects.toEqual(
+            expect.anything(),
+          );
+
+          await expect(tracker.sendPayment(clnClient, invoice)).rejects.toEqual(
+            'WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS',
+          );
+        });
+
+        test('should return undefined when node for fetching permanent failure details is not available', async () => {
+          const invoiceRes = await bitcoinLndClient.addInvoice(1);
+          const swap = await Swap.create({
+            ...createSubmarineSwapData(),
+            invoice: invoiceRes.paymentRequest,
+            preimageHash: decodeInvoice(invoiceRes.paymentRequest).paymentHash,
+          });
+          await LightningPayment.create({
+            node: NodeType.LND,
+            preimageHash: swap.preimageHash,
+            status: LightningPaymentStatus.PermanentFailure,
+          });
+
+          await tracker.init([
+            {
+              ...currencies[0],
+              lndClient: undefined,
+            },
+          ]);
+
+          await clnClient.sendPayment(invoiceRes.paymentRequest);
+          await expect(
+            tracker.sendPayment(clnClient, invoiceRes.paymentRequest),
+          ).resolves.toEqual(undefined);
+        });
+      });
+    });
+  });
+});

--- a/test/integration/lightning/paymentTrackers/ClnPendingPaymentTracker.spec.ts
+++ b/test/integration/lightning/paymentTrackers/ClnPendingPaymentTracker.spec.ts
@@ -1,0 +1,144 @@
+import { crypto } from 'bitcoinjs-lib';
+import { randomBytes } from 'crypto';
+import Logger from '../../../../lib/Logger';
+import {
+  decodeInvoice,
+  getHexBuffer,
+  getHexString,
+} from '../../../../lib/Utils';
+import { LightningPaymentStatus } from '../../../../lib/db/models/LightningPayment';
+import { NodeType } from '../../../../lib/db/models/ReverseSwap';
+import LightningPaymentRepository from '../../../../lib/db/repositories/LightningPaymentRepository';
+import ClnPendingPaymentTracker from '../../../../lib/lightning/paymentTrackers/ClnPendingPaymentTracker';
+import { createInvoice } from '../../../unit/swap/InvoiceUtils';
+import { bitcoinLndClient, clnClient } from '../../Nodes';
+
+jest.mock('../../../../lib/db/repositories/LightningPaymentRepository', () => ({
+  setStatus: jest.fn(),
+}));
+
+describe('ClnPendingPaymentTracker', () => {
+  const tracker = new ClnPendingPaymentTracker(Logger.disabledLogger);
+
+  const newPreimage = () => {
+    const preimage = randomBytes(32);
+    return {
+      preimage,
+      preimageHash: crypto.sha256(preimage),
+    };
+  };
+
+  beforeAll(async () => {
+    await Promise.all([
+      clnClient.connect(false),
+      bitcoinLndClient.connect(false),
+    ]);
+
+    await clnClient['mpay']?.resetPathMemory();
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(async () => {
+    tracker.stop();
+
+    await clnClient['mpay']?.resetPathMemory();
+
+    clnClient.disconnect();
+    bitcoinLndClient.disconnect();
+  });
+
+  describe('trackPayment', () => {
+    test('should handle successful payments', async () => {
+      const { paymentRequest } = await bitcoinLndClient.addInvoice(1);
+      const preimageHash = decodeInvoice(paymentRequest).paymentHash!;
+
+      const promise = clnClient.sendPayment(paymentRequest);
+
+      tracker.trackPayment(preimageHash, promise);
+      await promise;
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        preimageHash,
+        NodeType.CLN,
+        LightningPaymentStatus.Success,
+      );
+    });
+
+    test('should handle permanently failed payments', async () => {
+      const { paymentRequest } = await bitcoinLndClient.addInvoice(1);
+      const preimageHash = decodeInvoice(paymentRequest).paymentHash!;
+      await bitcoinLndClient.cancelHoldInvoice(getHexBuffer(preimageHash));
+
+      const promise = clnClient.sendPayment(paymentRequest);
+
+      tracker.trackPayment(preimageHash, promise);
+      await expect(promise).rejects.toEqual(expect.anything());
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        preimageHash,
+        NodeType.CLN,
+        LightningPaymentStatus.PermanentFailure,
+      );
+    });
+
+    test('should handle temporarily failed payments', async () => {
+      // Create an invoice ourselves with a random node as destination so that a "no route" error is thrown
+      const invoice = createInvoice();
+      const preimageHash = decodeInvoice(invoice).paymentHash!;
+
+      const promise = clnClient.sendPayment(invoice);
+      tracker.trackPayment(preimageHash, promise);
+      await expect(promise).rejects.toEqual(expect.anything());
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        preimageHash,
+        NodeType.CLN,
+        LightningPaymentStatus.TemporaryFailure,
+      );
+    });
+  });
+
+  describe('watchPayment', () => {
+    test('should watch for successful payments', async () => {
+      const { preimage, preimageHash } = newPreimage();
+      const invoice = await bitcoinLndClient.addHoldInvoice(1, preimageHash);
+      bitcoinLndClient.subscribeSingleInvoice(preimageHash);
+      bitcoinLndClient.on('htlc.accepted', async () => {
+        await bitcoinLndClient.settleHoldInvoice(preimage);
+      });
+
+      const paymentPromise = clnClient.sendPayment(invoice);
+      tracker.watchPayment(clnClient, invoice, getHexString(preimageHash));
+      await paymentPromise;
+
+      await tracker['checkPendingPayments']();
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        getHexString(preimageHash),
+        NodeType.CLN,
+        LightningPaymentStatus.Success,
+      );
+    });
+  });
+
+  describe('parseErrorMessage', () => {
+    test.each`
+      error                                                                                                                                                              | expected
+      ${'InvoiceExpiredError()'}                                                                                                                                         | ${true}
+      ${'Permanent error WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS at node 1 (03c5fae1d507150bfb2f82b113e76f0ae2d05fde5b8463bffa15c4e0e4c3b6fc9f) in channel 124x1x0/0'} | ${true}
+      ${'something that can be retried'}                                                                                                                                 | ${false}
+    `(
+      'should check if $error is a permanent error',
+      async ({ error, expected }) => {
+        expect(tracker.isPermanentError(error)).toEqual(expected);
+      },
+    );
+  });
+});

--- a/test/integration/lightning/paymentTrackers/LndPendingPaymentTracker.spec.ts
+++ b/test/integration/lightning/paymentTrackers/LndPendingPaymentTracker.spec.ts
@@ -1,0 +1,181 @@
+import { crypto } from 'bitcoinjs-lib';
+import { randomBytes } from 'crypto';
+import Logger from '../../../../lib/Logger';
+import {
+  decodeInvoice,
+  getHexBuffer,
+  getHexString,
+} from '../../../../lib/Utils';
+import { LightningPaymentStatus } from '../../../../lib/db/models/LightningPayment';
+import { NodeType } from '../../../../lib/db/models/ReverseSwap';
+import LightningPaymentRepository from '../../../../lib/db/repositories/LightningPaymentRepository';
+import LndPendingPaymentTracker from '../../../../lib/lightning/paymentTrackers/LndPendingPaymentTracker';
+import { PaymentFailureReason } from '../../../../lib/proto/lnd/rpc_pb';
+import { wait } from '../../../Utils';
+import { createInvoice } from '../../../unit/swap/InvoiceUtils';
+import { bitcoinLndClient, bitcoinLndClient2 } from '../../Nodes';
+
+jest.mock('../../../../lib/db/repositories/LightningPaymentRepository', () => ({
+  setStatus: jest.fn(),
+}));
+
+describe('LndPendingPaymentTracker', () => {
+  const tracker = new LndPendingPaymentTracker(Logger.disabledLogger);
+
+  const newPreimage = () => {
+    const preimage = randomBytes(32);
+    return {
+      preimage,
+      preimageHash: crypto.sha256(preimage),
+    };
+  };
+
+  beforeAll(async () => {
+    await Promise.all([
+      bitcoinLndClient.connect(false),
+      bitcoinLndClient2.connect(false),
+    ]);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    bitcoinLndClient.disconnect();
+    bitcoinLndClient2.disconnect();
+  });
+
+  describe('trackPayment', () => {
+    test('should handle successful payments', async () => {
+      const { paymentRequest } = await bitcoinLndClient2.addInvoice(1);
+      const preimageHash = decodeInvoice(paymentRequest).paymentHash!;
+
+      const promise = bitcoinLndClient.sendPayment(paymentRequest);
+
+      tracker.trackPayment(preimageHash, promise);
+      await promise;
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        preimageHash,
+        NodeType.LND,
+        LightningPaymentStatus.Success,
+      );
+    });
+
+    test('should handle permanently failed payments', async () => {
+      const { paymentRequest } = await bitcoinLndClient2.addInvoice(1);
+      const preimageHash = decodeInvoice(paymentRequest).paymentHash!;
+      await bitcoinLndClient2.cancelHoldInvoice(getHexBuffer(preimageHash));
+
+      const promise = bitcoinLndClient.sendPayment(paymentRequest);
+
+      tracker.trackPayment(preimageHash, promise);
+      await expect(promise).rejects.toEqual(
+        PaymentFailureReason.FAILURE_REASON_INCORRECT_PAYMENT_DETAILS,
+      );
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        preimageHash,
+        NodeType.LND,
+        LightningPaymentStatus.PermanentFailure,
+      );
+    });
+
+    test('should handle temporarily failed payments', async () => {
+      // Create an invoice ourselves with a random node as destination so that a "no route" error is thrown
+      const invoice = createInvoice();
+      const preimageHash = decodeInvoice(invoice).paymentHash!;
+
+      const promise = bitcoinLndClient.sendPayment(invoice);
+      tracker.trackPayment(preimageHash, promise);
+      await expect(promise).rejects.toEqual(
+        PaymentFailureReason.FAILURE_REASON_NO_ROUTE,
+      );
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        preimageHash,
+        NodeType.LND,
+        LightningPaymentStatus.TemporaryFailure,
+      );
+    });
+  });
+
+  describe('watchPayment', () => {
+    test('should watch for successful payments', async () => {
+      const { preimage, preimageHash } = newPreimage();
+      const invoice = await bitcoinLndClient2.addHoldInvoice(1, preimageHash);
+      bitcoinLndClient2.subscribeSingleInvoice(preimageHash);
+      bitcoinLndClient2.on('htlc.accepted', async () => {
+        await bitcoinLndClient2.settleHoldInvoice(preimage);
+      });
+
+      const paymentPromise = bitcoinLndClient.sendPayment(invoice);
+      await wait(50);
+
+      tracker.watchPayment(
+        bitcoinLndClient,
+        invoice,
+        getHexString(preimageHash),
+      );
+      await paymentPromise;
+
+      await wait(50);
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        getHexString(preimageHash),
+        NodeType.LND,
+        LightningPaymentStatus.Success,
+      );
+    });
+
+    test('should watch for failed payments', async () => {
+      const { preimageHash } = newPreimage();
+      const invoice = await bitcoinLndClient2.addHoldInvoice(1, preimageHash);
+      bitcoinLndClient2.subscribeSingleInvoice(preimageHash);
+      bitcoinLndClient2.on('htlc.accepted', async () => {
+        await bitcoinLndClient2.cancelHoldInvoice(preimageHash);
+      });
+
+      const paymentPromise = bitcoinLndClient.sendPayment(invoice);
+      await wait(50);
+
+      tracker.watchPayment(
+        bitcoinLndClient,
+        invoice,
+        getHexString(preimageHash),
+      );
+      await expect(paymentPromise).rejects.toEqual(
+        PaymentFailureReason.FAILURE_REASON_INCORRECT_PAYMENT_DETAILS,
+      );
+
+      await wait(50);
+
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledTimes(1);
+      expect(LightningPaymentRepository.setStatus).toHaveBeenCalledWith(
+        getHexString(preimageHash),
+        NodeType.LND,
+        LightningPaymentStatus.PermanentFailure,
+      );
+    });
+  });
+
+  describe('isPermanentError', () => {
+    test.each`
+      error                                                                                 | expected
+      ${PaymentFailureReason.FAILURE_REASON_INCORRECT_PAYMENT_DETAILS}                      | ${true}
+      ${PaymentFailureReason.FAILURE_REASON_NO_ROUTE}                                       | ${false}
+      ${'code = Unknown desc = invoice expired. Valid until 2024-06-08 13:45:16 +0000 UTC'} | ${true}
+      ${'something that can be retried'}                                                    | ${false}
+    `(
+      'should check if $error is a permanent error',
+      async ({ error, expected }) => {
+        expect(tracker.isPermanentError(error)).toEqual(expected);
+      },
+    );
+  });
+});

--- a/test/unit/Utils.spec.ts
+++ b/test/unit/Utils.spec.ts
@@ -361,6 +361,7 @@ describe('Utils', () => {
     expect(utils.formatError(test)).toEqual(test);
     expect(utils.formatError(object)).toEqual(JSON.stringify(object));
     expect(utils.formatError(objectMessage)).toEqual(test);
+    expect(utils.formatError(4)).toEqual('4');
   });
 
   test('should get version', () => {

--- a/test/unit/swap/InvoiceUtils.ts
+++ b/test/unit/swap/InvoiceUtils.ts
@@ -1,4 +1,5 @@
-import bolt11 from '@boltz/bolt11';
+import { networks } from 'bitcoinjs-lib';
+import bolt11 from 'bolt11';
 import { randomBytes } from 'crypto';
 import { ECPair } from '../../../lib/ECPairHelper';
 import { getHexString, getUnixTime } from '../../../lib/Utils';
@@ -10,8 +11,13 @@ export const createInvoice = (
   timestamp?: number,
   expiry?: number,
   satoshis?: number,
+  network = networks.regtest,
 ): string => {
   const invoiceEncode = bolt11.encode({
+    network: {
+      ...network,
+      validWitnessVersions: [0, 1],
+    },
     satoshis: satoshis || 100,
     timestamp: timestamp || getUnixTime(),
     payeeNodeKey: getHexString(invoiceSigningKeys.publicKey),

--- a/test/unit/swap/PaymentHandler.spec.ts
+++ b/test/unit/swap/PaymentHandler.spec.ts
@@ -2,6 +2,7 @@ import Logger from '../../../lib/Logger';
 import { getHexBuffer } from '../../../lib/Utils';
 import { SwapUpdateEvent } from '../../../lib/consts/Enums';
 import Swap from '../../../lib/db/models/Swap';
+import { LightningClient } from '../../../lib/lightning/LightningClient';
 import LndClient from '../../../lib/lightning/LndClient';
 import { Payment } from '../../../lib/proto/lnd/rpc_pb';
 import TimeoutDeltaProvider from '../../../lib/service/TimeoutDeltaProvider';
@@ -89,6 +90,24 @@ describe('PaymentHandler', () => {
     new Map<string, Currency>([['BTC', btcCurrency]]),
     MockedChannelNursery(),
     MockedTimeoutDeltaProvider(),
+    {
+      sendPayment: jest
+        .fn()
+        .mockImplementation(
+          (
+            _: LightningClient,
+            invoice: string,
+            cltvLimit?: number,
+            outgoingChannelId?: string,
+          ) => {
+            return btcCurrency.lndClient!.sendPayment(
+              invoice,
+              cltvLimit,
+              outgoingChannelId,
+            );
+          },
+        ),
+    } as any,
     mockedEmit,
   );
 

--- a/tools/plugins/mpay/mpay.py
+++ b/tools/plugins/mpay/mpay.py
@@ -174,6 +174,7 @@ def mpay_list(request: Request, bolt11: str = "", payment_hash: str = "") -> dic
 )
 @thread_method(executor=executor)
 def mpay_reset(request: Request) -> dict[str, Any]:
+    mpay.reset_excludes()
     return {"deleted": routes.reset().to_dict()}
 
 

--- a/tools/plugins/mpay/pay/excludes.py
+++ b/tools/plugins/mpay/pay/excludes.py
@@ -13,11 +13,18 @@ class Excludes:
         """Check if the exclude list includes a channel."""
         return channel in self._excludes
 
+    def __len__(self) -> int:
+        """Return the number of entries in the cache."""
+        return len(self._excludes)
+
     def add(self, channel: str) -> None:
         self._excludes[channel] = True
 
     def to_set(self) -> set[str]:
         return set(self._excludes.keys())
+
+    def reset(self) -> None:
+        self._excludes.clear()
 
 
 class ExcludesPayment:

--- a/tools/plugins/mpay/pay/mpay.py
+++ b/tools/plugins/mpay/pay/mpay.py
@@ -41,6 +41,9 @@ class MPay:
         self._network_info.init()
         self._invoice_checker.init()
 
+    def reset_excludes(self) -> None:
+        self._excludes.reset()
+
     def pay(
         self,
         bolt11: str,

--- a/tools/plugins/mpay/pay/tests/test_excludes.py
+++ b/tools/plugins/mpay/pay/tests/test_excludes.py
@@ -6,6 +6,10 @@ from plugins.mpay.pay.excludes import Excludes, ExcludesPayment
 class TestExcludes:
     excludes = Excludes()
 
+    @pytest.fixture(autouse=True)
+    def _before_each(self) -> None:
+        self.excludes = Excludes()
+
     @pytest.mark.parametrize("channel", ["1/1", "0/0", "123x123x123/0"])
     def test_add(self, channel: str) -> None:
         self.excludes.add(channel)
@@ -17,6 +21,13 @@ class TestExcludes:
             self.excludes.add(exclude)
 
         assert self.excludes.to_set() == set(excludes)
+
+    def test_reset(self) -> None:
+        self.excludes.add("1/1")
+        assert len(self.excludes) == 1
+
+        self.excludes.reset()
+        assert len(self.excludes) == 0
 
 
 class TestExcludesPayment:

--- a/tools/plugins/mpay/rpc/server.py
+++ b/tools/plugins/mpay/rpc/server.py
@@ -110,6 +110,7 @@ class MpayService(MpayServicer):
         context: grpc.ServicerContext,  # noqa: ARG002
     ) -> ResetPathMemoryResponse:
         res = self._routes.reset()
+        self._mpay.reset_excludes()
 
         return ResetPathMemoryResponse(
             payments=res.payments,


### PR DESCRIPTION
To reduce load on the lightning nodes, reduce the risk of paying an invoice twice when a node goes offline and have a better insight into the payment success metrics of nodes, the way we track payments of lightning invoices is refactored.
Instead of asking the node directly if it still has a pending payment, we save that information in our database and keep track of the payment call to node in the background without blocking any locks or background tasks that retry paying invoices.