### PR TITLE
feat: allow lowball lockup transactions in API

### DIFF
--- a/lib/db/repositories/ChainSwapRepository.ts
+++ b/lib/db/repositories/ChainSwapRepository.ts
@@ -197,6 +197,23 @@ class ChainSwapRepository {
       ]);
     });
 
+  public static disableZeroConf = async (swaps: ChainSwapInfo[]) => {
+    if (swaps.length === 0) {
+      return;
+    }
+
+    await ChainSwap.update(
+      {
+        acceptZeroConf: false,
+      },
+      {
+        where: {
+          id: swaps.map((s) => s.id),
+        },
+      },
+    );
+  };
+
   public static setUserLockupTransaction = (
     swap: ChainSwapInfo,
     lockupTransactionId: string,

--- a/lib/db/repositories/SwapRepository.ts
+++ b/lib/db/repositories/SwapRepository.ts
@@ -44,6 +44,17 @@ class SwapRepository {
     return Swap.create(swap);
   };
 
+  public static disableZeroConf = async (swaps: Swap[]) => {
+    if (swaps.length === 0) {
+      return;
+    }
+
+    await Swap.update(
+      { acceptZeroConf: false },
+      { where: { id: swaps.map((s) => s.id) } },
+    );
+  };
+
   public static setSwapStatus = (
     swap: Swap,
     status: string,

--- a/test/integration/db/repositories/Fixtures.ts
+++ b/test/integration/db/repositories/Fixtures.ts
@@ -14,7 +14,8 @@ import { NodeType } from '../../../../lib/db/models/ReverseSwap';
 import ChainSwapRepository from '../../../../lib/db/repositories/ChainSwapRepository';
 import ReverseSwapRepository from '../../../../lib/db/repositories/ReverseSwapRepository';
 
-export const createSubmarineSwapData = () => ({
+export const createSubmarineSwapData = (acceptZeroConf = false) => ({
+  acceptZeroConf,
   pair: 'BTC/BTC',
   lockupAddress: 'bc1',
   timeoutBlockHeight: 1,
@@ -48,14 +49,15 @@ export const createReverseSwap = async (
 export const createChainSwap = async (
   status = SwapUpdateEvent.SwapCreated,
   sendingTimeoutBlockHeight = 813411,
+  acceptZeroConf = false,
 ) => {
   const chainSwap = {
     status,
+    acceptZeroConf,
+    fee: 123,
     id: generateId(),
     pair: 'L-BTC/BTC',
     orderSide: OrderSide.BUY,
-    fee: 123,
-    acceptZeroConf: false,
     preimageHash: getHexString(randomBytes(32)),
   };
 

--- a/test/integration/db/repositories/SwapRepository.spec.ts
+++ b/test/integration/db/repositories/SwapRepository.spec.ts
@@ -1,0 +1,78 @@
+import Logger from '../../../../lib/Logger';
+import Database from '../../../../lib/db/Database';
+import Pair from '../../../../lib/db/models/Pair';
+import Swap from '../../../../lib/db/models/Swap';
+import SwapRepository from '../../../../lib/db/repositories/SwapRepository';
+import { createSubmarineSwapData } from './Fixtures';
+
+describe('SwapRepository', () => {
+  let database: Database;
+
+  beforeAll(async () => {
+    database = new Database(Logger.disabledLogger, Database.memoryDatabase);
+    await database.init();
+    await Pair.create({
+      base: 'BTC',
+      quote: 'BTC',
+      id: 'BTC/BTC',
+    });
+  });
+
+  beforeEach(async () => {
+    await Swap.destroy({
+      truncate: true,
+    });
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  describe('disableZeroConf', () => {
+    test('should disable 0-conf', async () => {
+      const swaps: Swap[] = [];
+
+      for (let i = 0; i < 3; i++) {
+        swaps.push(await Swap.create(createSubmarineSwapData(true)));
+      }
+
+      expect(swaps.every((s) => s.acceptZeroConf)).toEqual(true);
+
+      await SwapRepository.disableZeroConf([swaps[0], swaps[1]]);
+
+      expect(
+        (await SwapRepository.getSwap({
+          id: swaps[0].id,
+        }))!.acceptZeroConf,
+      ).toEqual(false);
+      expect(
+        (await SwapRepository.getSwap({
+          id: swaps[1].id,
+        }))!.acceptZeroConf,
+      ).toEqual(false);
+      expect(
+        (await SwapRepository.getSwap({
+          id: swaps[2].id,
+        }))!.acceptZeroConf,
+      ).toEqual(true);
+    });
+
+    test('should ignore when no swaps are given as parameter', async () => {
+      const swaps: Swap[] = [];
+
+      for (let i = 0; i < 3; i++) {
+        swaps.push(await Swap.create(createSubmarineSwapData(true)));
+      }
+
+      await SwapRepository.disableZeroConf([]);
+
+      for (const swap of swaps) {
+        expect(
+          (await SwapRepository.getSwap({
+            id: swap.id,
+          }))!.acceptZeroConf,
+        ).toEqual(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #593

We can allow lowball transactions that fund swaps to be broadcasted through our API when we disable 0-conf for them.