### PR TITLE
chore: optimize backend Dockerfile

### DIFF
--- a/docker/boltz/Dockerfile
+++ b/docker/boltz/Dockerfile
@@ -24,6 +24,8 @@ RUN sed -i "/grpc-tools/d" package.json
 RUN npm install -g npm
 RUN npm install --force
 RUN npm run compile
+# We do not need dev dependencies in the final image
+RUN rm -rf node_modules && npm install --force --omit dev
 
 FROM node:${NODE_VERSION} AS final
 


### PR DESCRIPTION
Saves 80MB in the final image by not including NPM dev dependencies.