### PR TITLE
fix: make preimage optional in chain swap claim endpoint

### DIFF
--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -1320,7 +1320,6 @@ class SwapRouter extends RouterBase {
      *       properties:
      *         preimage:
      *           type: string
-     *           required: true
      *           description: Preimage of the Chain Swap, encoded as HEX
      *         signature:
      *           $ref: '#/components/schemas/PartialSignature'

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -2579,7 +2579,6 @@
         "properties": {
           "preimage": {
             "type": "string",
-            "required": true,
             "description": "Preimage of the Chain Swap, encoded as HEX"
           },
           "signature": {


### PR DESCRIPTION
It is not required because when a swap is already settled from our perspective, we do not require the preimage to be sent to create a partial signature.