### PR TITLE
feat: sign cooperative EVM refund by preimage hash

### DIFF
--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -432,7 +432,7 @@ class SwapRouter extends RouterBase {
      *         required: true
      *         schema:
      *           type: string
-     *         description: ID of the Swap
+     *         description: ID or preimage hash of the Swap
      *     responses:
      *       '200':
      *         description: EIP-712 signature

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -1020,7 +1020,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "ID of the Swap"
+            "description": "ID or preimage hash of the Swap"
           }
         ],
         "responses": {


### PR DESCRIPTION
When a client scans the contract event logs to find refundable swaps, it does not know the swap id. We need to use a different identifier in that scenario, and the only other option is the preimage hash.