### PR TITLE
chore: bump Bitcoin Core to v28.0

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -37,13 +37,13 @@ NODE_VERSION = BuildArgument(
 
 GOLANG_VERSION = BuildArgument(
     name="GOLANG_VERSION",
-    value="1.22.6-bullseye",
+    value="1.23.2-bullseye",
 )
 
-BITCOIN_VERSION = "27.1"
+BITCOIN_VERSION = "28.0"
 LITECOIN_VERSION = "0.21.3"
 ELEMENTS_VERSION = "23.2.1"
-GETH_VERSION = "1.14.8"
+GETH_VERSION = "1.14.11"
 
 C_LIGHTNING_VERSION = "24.08.1"
 ECLAIR_VERSION = "0.10.0"
@@ -102,7 +102,7 @@ IMAGES: dict[str, Image] = {
         ],
     ),
     "regtest": Image(
-        tag="4.5.6",
+        tag="4.5.7",
         arguments=[
             UBUNTU_VERSION,
             BITCOIN_BUILD_ARG,

--- a/docker/regtest/Dockerfile
+++ b/docker/regtest/Dockerfile
@@ -9,8 +9,8 @@ ARG C_LIGHTNING_VERSION
 FROM boltz/bitcoin-core:${BITCOIN_VERSION} AS bitcoin-core
 FROM ghcr.io/vulpemventures/elements:${ELEMENTS_VERSION} AS elements-core
 
-FROM boltz/lnd:${LND_VERSION} as lnd
-FROM boltz/c-lightning:${C_LIGHTNING_VERSION} as cln
+FROM boltz/lnd:${LND_VERSION} AS lnd
+FROM boltz/c-lightning:${C_LIGHTNING_VERSION} AS cln
 
 FROM ubuntu:${UBUNTU_VERSION}
 

--- a/docker/regtest/data/core/config.conf
+++ b/docker/regtest/data/core/config.conf
@@ -10,5 +10,7 @@ fallbackfee=0.00001
 
 rpcallowip=0.0.0.0/0
 
+deprecatedrpc=warnings
+
 [regtest]
 rpcbind=0.0.0.0

--- a/docker/regtest/startRegtest.sh
+++ b/docker/regtest/startRegtest.sh
@@ -29,7 +29,7 @@ docker run \
   -p 9735:9735 \
   -p 9293:9293 \
   -p 9292:9292 \
-  boltz/regtest:4.5.6
+  boltz/regtest:4.5.7
 
 docker exec regtest bash -c "cp /root/.lightning/regtest/*.pem /root/.lightning/regtest/certs"
 docker exec regtest chmod -R 777 /root/.lightning/regtest/certs

--- a/lib/VersionCheck.ts
+++ b/lib/VersionCheck.ts
@@ -79,7 +79,7 @@ class VersionCheck {
   > = {
     [ChainClient.serviceName]: {
       minimal: 220000,
-      maximal: 270100,
+      maximal: 280000,
     },
     [ClnClient.serviceName]: {
       minimal: '23.05',

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -2428,7 +2428,7 @@
           },
           "description": {
             "type": "string",
-            "description": "Description of the created invoice and magic routing hint. Only ASCII and a maximum length of 40 characters is allowed"
+            "description": "Description of the created invoice and magic routing hint. Only ASCII and a maximum length of 100 characters is allowed"
           },
           "descriptionHash": {
             "type": "string",


### PR DESCRIPTION
LND does not support Bitcoin Core v28.0 yet: https://github.com/lightningnetwork/lnd/pull/9154