### PR TITLE
fix: chunk batch claim transactions

### DIFF
--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -613,4 +613,18 @@ export const chunkArray = <T>(array: T[], size: number): T[][] => {
   return chunks.filter((chunk) => chunk.length !== 0);
 };
 
+export const arrayToChunks = <T>(array: T[], chunkSize: number): T[][] => {
+  if (chunkSize <= 0) {
+    throw 'invalid chunk size';
+  }
+
+  const chunks: T[][] = [];
+
+  for (let i = 0; i < array.length; i += chunkSize) {
+    chunks.push(array.slice(i, i + chunkSize));
+  }
+
+  return chunks;
+};
+
 export const bigIntMax = (a: bigint, b: bigint) => (a > b ? a : b);

--- a/test/unit/Utils.spec.ts
+++ b/test/unit/Utils.spec.ts
@@ -436,6 +436,19 @@ describe('Utils', () => {
   });
 
   test.each`
+    data            | count | chunks
+    ${[0, 1]}       | ${1}  | ${[[0], [1]]}
+    ${[0, 1, 2, 3]} | ${1}  | ${[[0], [1], [2], [3]]}
+    ${[0, 1, 2, 3]} | ${2}  | ${[[0, 1], [2, 3]]}
+    ${[0, 1, 2, 3]} | ${3}  | ${[[0, 1, 2], [3]]}
+    ${[0, 1, 2, 3]} | ${4}  | ${[[0, 1, 2, 3]]}
+    ${[0, 1, 2, 3]} | ${5}  | ${[[0, 1, 2, 3]]}
+    ${[0, 1, 2, 3]} | ${21} | ${[[0, 1, 2, 3]]}
+  `('should chunk array into pieces', ({ data, count, chunks }) => {
+    expect(utils.arrayToChunks(data, count)).toEqual(chunks);
+  });
+
+  test.each`
     a       | b      | expected
     ${0n}   | ${1n}  | ${1n}
     ${0n}   | ${-1n} | ${0n}


### PR DESCRIPTION
Creating batch claim transactions with more than ~20 inputs on Liquid does not work with Node.js. To work around that, we create multiple batch sweeps with at most 15 inputs each.