### PR TITLE
docs: fix library section hint link

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,8 +1,8 @@
 ---
 description: >-
-  Integrating Boltz API directly is involved and not to be underestimated. To
-  save on time and resources, we highly recommend exploring the different
-  library options for Boltz API below.
+  Integrating Boltz API is involved and not to be underestimated. To save on
+  time and resources, we highly recommend exploring the different library
+  options for Boltz API below.
 ---
 
 # 📙 Libraries
@@ -60,5 +60,4 @@ Used by e.g.: [LNbits](https://github.com/lnbits/boltz)
 Supported currencies: Bitcoin, Lightning, Liquid
 
 {% hint style="info" %} Note: If Python is preferred, we recommend using the
-[Breez SDK - Liquid implementation](https://github.com/breez/breez-sdk-liquid)
-with Python bindings. {% endhint %}
+Breez SDK Liquid with Python bindings. {% endhint %}


### PR DESCRIPTION
Gitbook can't handle embedded links in hints or broke it recently 😠
![Screenshot from 2024-12-19 13-55-31](https://github.com/user-attachments/assets/544ae972-1b19-432e-8418-c2843a576731)
