### PR TITLE
refactor: handle duplicate transaction labels

### DIFF
--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -21,6 +21,7 @@ import ReverseRoutingHint from './models/ReverseRoutingHint';
 import ReverseSwap from './models/ReverseSwap';
 import Swap from './models/Swap';
 import TransactionLabel from './models/TransactionLabel';
+import TransactionLabelRepository from './repositories/TransactionLabelRepository';
 
 // To make sure that PostgreSQL types are parsed correctly
 types.setTypeParser(types.builtins.INT8, parseInt);
@@ -145,6 +146,8 @@ class Database {
     PendingLockupTransaction.load(Database.sequelize);
     PendingEthereumTransaction.load(Database.sequelize);
     Rebroadcast.load(Database.sequelize);
+
+    TransactionLabelRepository.setLogger(this.logger);
   };
 }
 

--- a/test/integration/db/repositories/TransactionLabelRepository.spec.ts
+++ b/test/integration/db/repositories/TransactionLabelRepository.spec.ts
@@ -21,18 +21,37 @@ describe('TransactionLabelRepository', () => {
     await database.close();
   });
 
-  test('should add labels', async () => {
-    const txId = 'id';
-    const symbol = 'BTC';
-    const label = 'important info';
+  describe('addLabel', () => {
+    test('should add labels', async () => {
+      const txId = 'id';
+      const symbol = 'BTC';
+      const label = 'important info';
 
-    await TransactionLabelRepository.addLabel(txId, symbol, label);
+      await TransactionLabelRepository.addLabel(txId, symbol, label);
 
-    const entry = await TransactionLabelRepository.getLabel(txId);
+      const entry = await TransactionLabelRepository.getLabel(txId);
 
-    expect(entry).not.toBeNull();
-    expect(entry!.id).toEqual(txId);
-    expect(entry!.symbol).toEqual(symbol);
-    expect(entry!.label).toEqual(label);
+      expect(entry).not.toBeNull();
+      expect(entry!.id).toEqual(txId);
+      expect(entry!.symbol).toEqual(symbol);
+      expect(entry!.label).toEqual(label);
+    });
+
+    test('should update existing labels', async () => {
+      const txId = 'id';
+      const symbol = 'BTC';
+      const originalLabel = 'original label';
+      const newLabel = 'updated label';
+
+      await TransactionLabelRepository.addLabel(txId, symbol, originalLabel);
+      await TransactionLabelRepository.addLabel(txId, symbol, newLabel);
+
+      const entry = await TransactionLabelRepository.getLabel(txId);
+
+      expect(entry).not.toBeNull();
+      expect(entry!.id).toEqual(txId);
+      expect(entry!.symbol).toEqual(symbol);
+      expect(entry!.label).toEqual(newLabel);
+    });
   });
 });


### PR DESCRIPTION
Hpapens quite a bit when restarting the regtest containers