### PR TITLE
feat: include max routing fee in submarine pairs when queried with ref

### DIFF
--- a/lib/db/models/Referral.ts
+++ b/lib/db/models/Referral.ts
@@ -95,6 +95,17 @@ class Referral extends Model implements ReferralType {
     );
   };
 
+  public maxRoutingFeeRatioForPairs = (pairs: string[]): number | undefined => {
+    for (const pair of pairs) {
+      const ratio = this.config?.pairs?.[pair]?.maxRoutingFee;
+      if (ratio !== undefined) {
+        return ratio;
+      }
+    }
+
+    return this.config?.maxRoutingFee;
+  };
+
   public limits = (pair: string, type: SwapType): Limits | undefined => {
     return (
       this.config?.pairs?.[pair]?.limits?.[type] || this.config?.limits?.[type]

--- a/lib/lightning/LightningClient.ts
+++ b/lib/lightning/LightningClient.ts
@@ -99,6 +99,8 @@ interface LightningClient extends BalancerFetcher, BaseClient<EventTypes> {
   symbol: string;
   type: NodeType;
 
+  readonly maxPaymentFeeRatio: number;
+
   isConnected(): boolean;
 
   setClientStatus(status: ClientStatus): void;

--- a/lib/lightning/LndClient.ts
+++ b/lib/lightning/LndClient.ts
@@ -60,8 +60,9 @@ class LndClient extends BaseClient<EventTypes> implements LightningClient {
   private static readonly paymentTimeout = 300;
   private static readonly paymentTimePreference = 0.9;
 
+  public readonly maxPaymentFeeRatio!: number;
+
   private readonly uri!: string;
-  private readonly maxPaymentFeeRatio!: number;
   private readonly credentials!: ChannelCredentials;
 
   private readonly meta!: Metadata;

--- a/lib/lightning/cln/ClnClient.ts
+++ b/lib/lightning/cln/ClnClient.ts
@@ -53,7 +53,7 @@ class ClnClient
   private static readonly paymentMinFee = 121;
   private static readonly paymentTimeout = 300;
 
-  private readonly maxPaymentFeeRatio!: number;
+  public readonly maxPaymentFeeRatio!: number;
 
   private readonly nodeUri: string;
   private readonly holdUri: string;

--- a/test/integration/db/models/Referral.spec.ts
+++ b/test/integration/db/models/Referral.spec.ts
@@ -65,6 +65,22 @@ describe('Referral', () => {
   });
 
   test.each`
+    pairs                      | expected
+    ${['BTC/BTC']}             | ${referralValues.config!.maxRoutingFee}
+    ${['L-BTC/BTC']}           | ${referralValues.config!.maxRoutingFee}
+    ${['RBTC/BTC']}            | ${referralValues.config!.pairs!['RBTC/BTC']!.maxRoutingFee}
+    ${['BTC/BTC', 'RBTC/BTC']} | ${referralValues.config!.pairs!['RBTC/BTC']!.maxRoutingFee}
+  `(
+    'should get maxRoutingFeeRatioForPairs for pairs $pairs',
+    async ({ pairs, expected }) => {
+      const ref = await ReferralRepository.getReferralById(referralValues.id);
+
+      expect(ref).not.toBeNull();
+      expect(ref!.maxRoutingFeeRatioForPairs(pairs)).toEqual(expected);
+    },
+  );
+
+  test.each`
     pair          | type                         | expected
     ${'BTC/BTC'}  | ${SwapType.ReverseSubmarine} | ${referralValues.config!.limits![SwapType.ReverseSubmarine]}
     ${'BTC/BTC'}  | ${SwapType.Submarine}        | ${undefined}


### PR DESCRIPTION
Needed for https://github.com/BoltzExchange/boltz-web-app/issues/784