### PR TITLE
feat: select node to pay invoices based on routing hints

### DIFF
--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -748,6 +748,7 @@ describe('Service', () => {
         )!.data as string;
 
         return {
+          routingHints: [],
           type: InvoiceType.Bolt11,
           features: new Set<InvoiceFeature>(),
           paymentHash: getHexBuffer(preimageHash),


### PR DESCRIPTION
Workaround until https://github.com/ElementsProject/lightning/issues/8042 is fixed

Might be useful in the future for other scenarios too