### PR TITLE
chore: bump chain swap timeout buffer to 50%

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -2055,7 +2055,7 @@ class Service {
     const receivingTimeoutBlockDelta = TimeoutDeltaProvider.convertBlocks(
       sending,
       receiving,
-      sendingTimeoutBlockDelta * 1.25,
+      sendingTimeoutBlockDelta * 1.5,
     );
 
     const rate = getRate(pairRate, side, true);


### PR DESCRIPTION
Closes #810

When Bitcoin blocks come in faster or slower than expected, the 25% buffer for timeout block heights of chain swaps could not be enough. This commit bumps that buffer to 50%. The UX will not suffer from it because cooperative refunds are possible when the timelock did not expire yet.