### PR TITLE
feat: nested extra fees

### DIFF
--- a/lib/api/Errors.ts
+++ b/lib/api/Errors.ts
@@ -9,4 +9,6 @@ export default {
     `${symbol} does not support ${argName}`,
   INVALID_SWAP_STATUS: (status: string): string =>
     `invalid swap status: ${status}`,
+  INVALID_EXTRA_FEES_PERCENTAGE: (percentage: number): string =>
+    `invalid extra fees percentage: ${percentage}`,
 };

--- a/lib/api/v2/routers/ReferralRouter.ts
+++ b/lib/api/v2/routers/ReferralRouter.ts
@@ -3,6 +3,7 @@ import Logger from '../../../Logger';
 import ReferralStats from '../../../data/ReferralStats';
 import Stats from '../../../data/Stats';
 import Referral from '../../../db/models/Referral';
+import ExtraFeeRepository from '../../../db/repositories/ExtraFeeRepository';
 import Bouncer from '../../Bouncer';
 import { errorResponse, successResponse } from '../../Utils';
 import RouterBase from './RouterBase';
@@ -203,6 +204,8 @@ class ReferralRouter extends RouterBase {
      */
     router.get('/stats', this.handleError(this.getStats));
 
+    router.get('/stats/extra', this.handleError(this.getExtraFees));
+
     return router;
   };
 
@@ -231,6 +234,15 @@ class ReferralRouter extends RouterBase {
     }
 
     successResponse(res, await Stats.generate(0, 0, referral.id));
+  };
+
+  private getExtraFees = async (req: Request, res: Response) => {
+    const referral = await this.checkAuthentication(req, res);
+    if (referral === undefined) {
+      return;
+    }
+
+    successResponse(res, await ExtraFeeRepository.getStats(referral.id));
   };
 
   private checkAuthentication = async (

--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -9,6 +9,7 @@ import ChainSwapData from './models/ChainSwapData';
 import ChainTip from './models/ChainTip';
 import ChannelCreation from './models/ChannelCreation';
 import DatabaseVersion from './models/DatabaseVersion';
+import ExtraFee from './models/ExtraFee';
 import KeyProvider from './models/KeyProvider';
 import LightningPayment from './models/LightningPayment';
 import MarkedSwap from './models/MarkedSwap';
@@ -96,6 +97,7 @@ class Database {
       Pair.sync(),
       ChainTip.sync(),
       Referral.sync(),
+      ExtraFee.sync(),
       KeyProvider.sync(),
       Rebroadcast.sync(),
       DatabaseVersion.sync(),
@@ -130,6 +132,7 @@ class Database {
 
   private loadModels = () => {
     Pair.load(Database.sequelize);
+    ExtraFee.load(Database.sequelize);
     Referral.load(Database.sequelize);
     Swap.load(Database.sequelize);
     TransactionLabel.load(Database.sequelize);

--- a/lib/db/models/ExtraFee.ts
+++ b/lib/db/models/ExtraFee.ts
@@ -1,0 +1,55 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+
+type ExtraFeeType = {
+  swapId: string;
+  id: string;
+  fee: number;
+  percentage: number;
+};
+
+class ExtraFee extends Model implements ExtraFeeType {
+  public swapId!: string;
+  public id!: string;
+  public fee!: number;
+  public percentage!: number;
+
+  public createdAt!: Date;
+  public updatedAt!: Date;
+
+  public static load = (sequelize: Sequelize): void => {
+    ExtraFee.init(
+      {
+        swapId: {
+          type: new DataTypes.STRING(255),
+          primaryKey: true,
+          allowNull: false,
+        },
+        id: {
+          type: new DataTypes.STRING(255),
+          allowNull: false,
+        },
+        fee: {
+          type: new DataTypes.BIGINT(),
+          allowNull: true,
+        },
+        percentage: {
+          type: new DataTypes.DECIMAL(),
+          allowNull: false,
+        },
+      },
+      {
+        sequelize,
+        tableName: 'extra_fees',
+        indexes: [
+          {
+            unique: false,
+            fields: ['id'],
+          },
+        ],
+      },
+    );
+  };
+}
+
+export default ExtraFee;
+export { ExtraFeeType };

--- a/lib/db/repositories/ExtraFeeRepository.ts
+++ b/lib/db/repositories/ExtraFeeRepository.ts
@@ -1,0 +1,78 @@
+import { QueryTypes } from 'sequelize';
+import { SwapUpdateEvent } from '../../consts/Enums';
+import { getNestedObject } from '../../data/Utils';
+import Database from '../Database';
+import ExtraFee, { ExtraFeeType } from '../models/ExtraFee';
+
+type GroupedByYearMonth<T> = Record<string, Record<string, T>>;
+
+class ExtraFeeRepository {
+  private static readonly statsQuery = `
+WITH successful AS (SELECT id, status, referral, "createdAt"
+                    FROm swaps
+                    WHERE status = ?
+                    UNION ALL
+                    SELECT id, status, referral, "createdAt"
+                    FROM "reverseSwaps"
+                    WHERE status = ?
+                    UNION ALL
+                    SELECT id, status, referral, "createdAt"
+                    FROM "chainSwaps"
+                    WHERE status = ?),
+     successful_extra AS (SELECT e.id AS id, e.fee AS fee, e."createdAt"
+                          FROM successful s
+                                   RIGHT JOIN extra_fees e on s.id = e."swapId"
+                          WHERE referral = ?)
+SELECT EXTRACT(YEAR FROM "createdAt") AS year, EXTRACT(MONTH FROM "createdAt") AS month, id, SUM(fee) AS fee
+FROM successful_extra
+GROUP BY year, month, id
+ORDER BY year, month, id;
+`;
+
+  public static create = async (
+    extraFee: Omit<ExtraFeeType, 'fee'> & { fee?: number },
+  ): Promise<void> => {
+    await ExtraFee.create(extraFee);
+  };
+
+  public static get = async (id: string): Promise<ExtraFeeType | null> => {
+    return await ExtraFee.findByPk(id);
+  };
+
+  public static setFee = async (id: string, fee: number): Promise<void> => {
+    await ExtraFee.update({ fee }, { where: { swapId: id } });
+  };
+
+  public static getStats = async (
+    id: string,
+  ): Promise<GroupedByYearMonth<number>> => {
+    const stats = (await Database.sequelize.query(
+      {
+        query: ExtraFeeRepository.statsQuery,
+        values: [
+          SwapUpdateEvent.TransactionClaimed,
+          SwapUpdateEvent.InvoiceSettled,
+          SwapUpdateEvent.TransactionClaimed,
+          id,
+        ],
+      },
+      {
+        type: QueryTypes.SELECT,
+      },
+    )) as { year: number; month: number; id: string; fee: number }[];
+
+    const res = {};
+
+    stats.forEach((stat) => {
+      const monthObj = getNestedObject(
+        getNestedObject(res, stat.year),
+        stat.month,
+      );
+      monthObj[stat.id] = Number(stat.fee);
+    });
+
+    return res;
+  };
+}
+
+export default ExtraFeeRepository;

--- a/test/integration/db/repositories/ExtraFeeRepository.spec.ts
+++ b/test/integration/db/repositories/ExtraFeeRepository.spec.ts
@@ -1,0 +1,47 @@
+import Logger from '../../../../lib/Logger';
+import Database from '../../../../lib/db/Database';
+import ExtraFee from '../../../../lib/db/models/ExtraFee';
+import ExtraFeeRepository from '../../../../lib/db/repositories/ExtraFeeRepository';
+
+describe('ExtraFeeRepository', () => {
+  const extraFeeFixture = {
+    swapId: 'swapId',
+    id: 'ref',
+    fee: 1000,
+    percentage: 0.123,
+  };
+
+  let database: Database;
+
+  beforeAll(async () => {
+    database = new Database(Logger.disabledLogger, Database.memoryDatabase);
+    await database.init();
+  });
+
+  beforeEach(async () => {
+    await ExtraFee.destroy({
+      truncate: true,
+    });
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  test('should create', async () => {
+    await ExtraFeeRepository.create(extraFeeFixture);
+
+    const fetched = await ExtraFeeRepository.get(extraFeeFixture.swapId);
+    expect(fetched).not.toBeNull();
+    expect(fetched).toMatchObject(extraFeeFixture);
+  });
+
+  test('should set fee', async () => {
+    await ExtraFeeRepository.create(extraFeeFixture);
+    await ExtraFeeRepository.setFee(extraFeeFixture.swapId, 2000);
+
+    const fetched = await ExtraFeeRepository.get(extraFeeFixture.swapId);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.fee).toEqual(2000);
+  });
+});

--- a/test/unit/api/v2/routers/ReferralRouter.spec.ts
+++ b/test/unit/api/v2/routers/ReferralRouter.spec.ts
@@ -4,6 +4,7 @@ import Bouncer from '../../../../../lib/api/Bouncer';
 import ReferralRouter from '../../../../../lib/api/v2/routers/ReferralRouter';
 import ReferralStats from '../../../../../lib/data/ReferralStats';
 import Stats from '../../../../../lib/data/Stats';
+import ExtraFeeRepository from '../../../../../lib/db/repositories/ExtraFeeRepository';
 import { mockRequest, mockResponse } from '../../Utils';
 
 const mockedRouter = {
@@ -58,10 +59,14 @@ describe('ReferralRouter', () => {
 
     expect(Router).toHaveBeenCalledTimes(1);
 
-    expect(mockedRouter.get).toHaveBeenCalledTimes(3);
+    expect(mockedRouter.get).toHaveBeenCalledTimes(4);
     expect(mockedRouter.get).toHaveBeenCalledWith('/', expect.anything());
     expect(mockedRouter.get).toHaveBeenCalledWith('/fees', expect.anything());
     expect(mockedRouter.get).toHaveBeenCalledWith('/stats', expect.anything());
+    expect(mockedRouter.get).toHaveBeenCalledWith(
+      '/stats/extra',
+      expect.anything(),
+    );
   });
 
   test('should get name of referral id', async () => {
@@ -106,6 +111,27 @@ describe('ReferralRouter', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(await Stats.generate(0, 0, ''));
+  });
+
+  test('should get extra fees of referral id', async () => {
+    ExtraFeeRepository.getStats = jest.fn().mockResolvedValue({
+      some: 'data',
+    });
+
+    mockValidateAuthResult = { id: 'partner', other: 'data' };
+
+    const res = mockResponse();
+    await referralRouter['getExtraFees'](mockRequest(), res);
+
+    expect(ExtraFeeRepository.getStats).toHaveBeenCalledTimes(1);
+    expect(ExtraFeeRepository.getStats).toHaveBeenCalledWith(
+      mockValidateAuthResult.id,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      await ExtraFeeRepository.getStats(''),
+    );
   });
 
   test.each`


### PR DESCRIPTION
Allow clients to add extra fees to swaps by passing these parameters when creating swaps:
```json
{
    ...
    "extraFees": {
        "id": "gm",
        "percentage": 1
    }
}
```

Those extra fees added can be queried with API keys via `/v2/referral/stats/extra`:

```json
{
  "2025": {
    "2": {
      "gm": 13000
    }
  }
}
```

Do we want to allow this for every referral?