### PR TITLE
feat: add EVM address to swapinfo command

### DIFF
--- a/lib/db/repositories/ReverseRoutingHintRepository.ts
+++ b/lib/db/repositories/ReverseRoutingHintRepository.ts
@@ -14,14 +14,21 @@ class ReverseRoutingHintRepository {
       },
     });
 
-  public static getHints = (swapIds: string[]) =>
-    ReverseRoutingHint.findAll({
+  public static getHints = async (
+    swapIds: string[],
+  ): Promise<ReverseRoutingHint[]> => {
+    if (swapIds.length === 0) {
+      return [];
+    }
+
+    return await ReverseRoutingHint.findAll({
       where: {
         swapId: {
           [Op.in]: swapIds,
         },
       },
     });
+  };
 }
 
 export default ReverseRoutingHintRepository;


### PR DESCRIPTION
When calling "swapinfo" with an EVM address, it will query all swaps that have coins locked that can be claimed by that address.