### PR TITLE
fix: skip mempool acceptance check on regtest

### DIFF
--- a/lib/chain/ElementsWrapper.ts
+++ b/lib/chain/ElementsWrapper.ts
@@ -61,6 +61,8 @@ class ElementsWrapper
       this.emit('block', blockHeight),
     );
 
+    await this.zeroConfCheck.init();
+
     // If we have a lowball client, bubble up only confirmed transactions
     // of the public client
     const hasLowball = this.lowballClient() !== undefined;

--- a/lib/chain/elements/ZeroConfCheck.ts
+++ b/lib/chain/elements/ZeroConfCheck.ts
@@ -3,5 +3,6 @@ import { Transaction } from 'liquidjs-lib';
 export interface ZeroConfCheck {
   get name(): string;
 
+  init(): Promise<void>;
   checkTransaction(transaction: Transaction): Promise<boolean>;
 }

--- a/lib/chain/elements/ZeroConfTool.ts
+++ b/lib/chain/elements/ZeroConfTool.ts
@@ -75,6 +75,8 @@ class ZeroConfTool
     };
   }
 
+  public init = async (): Promise<void> => {};
+
   public checkTransaction = async (
     transaction: Transaction,
   ): Promise<boolean> => {

--- a/test/integration/chain/ElementsWrapper.spec.ts
+++ b/test/integration/chain/ElementsWrapper.spec.ts
@@ -21,6 +21,7 @@ describe('ElementsWrapper', () => {
     wrapper['zeroConfCheck'] = {
       name: 'test',
       checkTransaction: jest.fn().mockResolvedValue(true),
+      init: jest.fn().mockImplementation(() => Promise.resolve()),
     };
   });
 
@@ -152,6 +153,7 @@ describe('ElementsWrapper', () => {
       oneWrapper['zeroConfCheck'] = {
         name: 'stub',
         checkTransaction: jest.fn().mockResolvedValue(true),
+        init: jest.fn().mockImplementation(() => Promise.resolve()),
       };
 
       await oneWrapper.connect();

--- a/test/integration/chain/elements/TestMempoolAccept.spec.ts
+++ b/test/integration/chain/elements/TestMempoolAccept.spec.ts
@@ -1,0 +1,180 @@
+import { Transaction } from 'liquidjs-lib';
+import Logger from '../../../../lib/Logger';
+import TestMempoolAccept from '../../../../lib/chain/elements/TestMempoolAccept';
+import { elementsClient } from '../../Nodes';
+
+jest.mock('../../../../lib/db/repositories/ChainTipRepository');
+jest.mock('../../../../lib/PromiseUtils', () => ({
+  sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('TestMempoolAccept', () => {
+  let testMempoolAccept: TestMempoolAccept;
+
+  beforeAll(async () => {
+    await elementsClient.connect();
+  });
+
+  afterAll(async () => {
+    elementsClient.disconnect();
+  });
+
+  test('should use default check time', async () => {
+    expect(
+      new TestMempoolAccept(Logger.disabledLogger, elementsClient)[
+        'zeroConfCheckTime'
+      ],
+    ).toEqual(TestMempoolAccept['zeroConfCheckTimeDefault']);
+  });
+
+  test('should construct', async () => {
+    const checkTime = 1000;
+    testMempoolAccept = new TestMempoolAccept(
+      Logger.disabledLogger,
+      elementsClient,
+      checkTime,
+    );
+
+    expect(testMempoolAccept['zeroConfCheckTime']).toEqual(checkTime);
+  });
+
+  test('should get name', () => {
+    expect(testMempoolAccept.name).toEqual('Test mempool acceptance');
+  });
+
+  describe('init', () => {
+    test.each`
+      chain              | isRegtest | description
+      ${'liquidregtest'} | ${true}   | ${'regtest chain'}
+      ${'liquidv1'}      | ${false}  | ${'mainnet chain'}
+      ${'liquidtestnet'} | ${false}  | ${'testnet chain'}
+    `('should detect $description correctly', async ({ chain, isRegtest }) => {
+      const mockGetBlockchainInfo = jest.spyOn(
+        elementsClient,
+        'getBlockchainInfo',
+      );
+      mockGetBlockchainInfo.mockResolvedValueOnce({ chain } as any);
+
+      const instance = new TestMempoolAccept(
+        Logger.disabledLogger,
+        elementsClient,
+      );
+      await instance.init();
+
+      expect(instance['isRegtest']).toEqual(isRegtest);
+      mockGetBlockchainInfo.mockRestore();
+    });
+  });
+
+  describe('checkTransaction', () => {
+    let mockTransaction: Transaction;
+
+    beforeEach(() => {
+      mockTransaction = {
+        getId: jest.fn().mockReturnValue('mocktxid'),
+        toHex: jest.fn().mockReturnValue('mocktxhex'),
+      } as any;
+    });
+
+    test('should return true immediately for regtest', async () => {
+      jest.spyOn(elementsClient, 'testMempoolAccept');
+
+      const instance = new TestMempoolAccept(
+        Logger.disabledLogger,
+        elementsClient,
+      );
+      instance['isRegtest'] = true;
+
+      const result = await instance.checkTransaction(mockTransaction);
+
+      expect(result).toEqual(true);
+      expect(elementsClient.testMempoolAccept).not.toHaveBeenCalled();
+    });
+
+    test('should return true for accepted transaction', async () => {
+      const mockTestMempoolAccept = jest.spyOn(
+        elementsClient,
+        'testMempoolAccept',
+      );
+      mockTestMempoolAccept.mockResolvedValueOnce([
+        {
+          allowed: true,
+          txid: 'mocktxid',
+          wtxid: 'mockwtxid',
+        },
+      ]);
+
+      const instance = new TestMempoolAccept(
+        Logger.disabledLogger,
+        elementsClient,
+      );
+      instance['isRegtest'] = false;
+
+      const result = await instance.checkTransaction(mockTransaction);
+
+      expect(result).toEqual(true);
+      expect(mockTestMempoolAccept).toHaveBeenCalledWith(['mocktxhex']);
+      mockTestMempoolAccept.mockRestore();
+    });
+
+    test('should return true for allowed error reasons', async () => {
+      const mockTestMempoolAccept = jest.spyOn(
+        elementsClient,
+        'testMempoolAccept',
+      );
+
+      for (const errorReason of [
+        'min relay fee not met',
+        'txn-already-in-mempool',
+      ]) {
+        mockTestMempoolAccept.mockResolvedValueOnce([
+          {
+            allowed: false,
+            'reject-reason': errorReason,
+            txid: 'mocktxid',
+            wtxid: 'mockwtxid',
+          },
+        ]);
+
+        const instance = new TestMempoolAccept(
+          Logger.disabledLogger,
+          elementsClient,
+        );
+        instance['isRegtest'] = false;
+
+        const result = await instance.checkTransaction(mockTransaction);
+
+        expect(result).toEqual(true);
+      }
+
+      mockTestMempoolAccept.mockRestore();
+    });
+
+    test('should return false for non-allowed error reasons', async () => {
+      const mockTestMempoolAccept = jest.spyOn(
+        elementsClient,
+        'testMempoolAccept',
+      );
+      mockTestMempoolAccept.mockResolvedValueOnce([
+        {
+          allowed: false,
+          'reject-reason': 'some-other-error',
+          txid: 'mocktxid',
+          wtxid: 'mockwtxid',
+        },
+      ]);
+
+      const instance = new TestMempoolAccept(
+        Logger.disabledLogger,
+        elementsClient,
+      );
+      instance['isRegtest'] = false;
+
+      const result = await instance.checkTransaction(mockTransaction);
+
+      expect(result).toEqual(false);
+      expect(mockTestMempoolAccept).toHaveBeenCalledWith(['mocktxhex']);
+      mockTestMempoolAccept.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
Not needed on regtest and was causing unnecessary delays in E2E tests