### PR TITLE
Add websocket app-level ping/pong support

### DIFF
--- a/boltzr/src/api/ws/status.rs
+++ b/boltzr/src/api/ws/status.rs
@@ -65,6 +65,8 @@ enum WsRequest {
     Subscribe(SubscribeRequest),
     #[serde(rename = "unsubscribe")]
     Unsubscribe(UnsubscribeRequest),
+    #[serde(rename = "ping")]
+    Ping,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -100,6 +102,8 @@ enum WsResponse {
     Unsubscribe(UnsubscribeResponse),
     #[serde(rename = "update")]
     Update(UpdateResponse),
+    #[serde(rename = "pong")]
+    Pong,
 }
 
 #[derive(Debug, Clone)]
@@ -365,6 +369,7 @@ where
                     args: subscribed_ids.iter().cloned().collect(),
                 })))
             }
+            WsRequest::Ping => Ok(Some(WsResponse::Pong)),
         }
     }
 

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -83,6 +83,25 @@ is still subscribed to.
 }
 ```
 
+To ensure the connection is alive, besides the native WebSocket pings, Boltz API
+will also respond to application-level pings, which is useful when the WebSocket
+client cannot control the low-level WebSocket connection (like on browsers). To
+send a ping, send a message like below.
+
+```json
+{
+  "op": "ping"
+}
+```
+
+The backend will respond with a `pong` message.
+
+```json
+{
+  "event": "pong"
+}
+```
+
 ## Examples
 
 Below are some examples covering the flow of a given swap type from beginning to


### PR DESCRIPTION
In the browser (e.g. WASM clients), it isn't possible to manage WebSocket ping/pong frames directly. 

This PR introduces app-level ping/pong messages to the WebSocket status stream so that clients can implement a consistent keep-alive mechanism that works across native and WASM builds.