### PR TITLE
feat: invoice timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,9 @@ dist/
 # Yarn Integrity file
 .yarn-integrity
 
-#  Webstorm config
+#  Editor config
 .idea/
+.cursor/
 
 # typedoc
 typedoc/

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -172,6 +172,8 @@ type SwapConfig = {
   minSwapSizeMultipliers?: MinSwapSizeMultipliersConfig;
 
   overpayment?: OverPaymentConfig;
+
+  paymentTimeoutMinutes?: number;
 };
 
 type ConfigType = {

--- a/lib/lightning/Errors.ts
+++ b/lib/lightning/Errors.ts
@@ -15,4 +15,8 @@ export default {
     message: 'no route found',
     code: concatErrorCode(ErrorCodePrefix.Lightning, 2),
   }),
+  PAYMENT_TIMED_OUT: (): Error => ({
+    message: 'invoice payment timed out',
+    code: concatErrorCode(ErrorCodePrefix.Lightning, 3),
+  }),
 };

--- a/lib/lightning/PendingPaymentTracker.ts
+++ b/lib/lightning/PendingPaymentTracker.ts
@@ -46,6 +46,19 @@ class PendingPaymentTracker {
       [NodeType.LND]: new LndPendingPaymentTracker(this.logger),
       [NodeType.CLN]: new ClnPendingPaymentTracker(this.logger),
     };
+
+    if (
+      this.paymentTimeoutMinutes === undefined ||
+      typeof this.paymentTimeoutMinutes !== 'number'
+    ) {
+      this.paymentTimeoutMinutes = undefined;
+      this.logger.info('Payment timeout not configured');
+      return;
+    }
+
+    this.logger.info(
+      `Payment timeout configured: ${this.paymentTimeoutMinutes} minutes`,
+    );
   }
 
   public init = async (currencies: Currency[]) => {

--- a/lib/swap/LightningNursery.ts
+++ b/lib/swap/LightningNursery.ts
@@ -8,6 +8,7 @@ import TypedEventEmitter from '../consts/TypedEventEmitter';
 import ReverseSwap from '../db/models/ReverseSwap';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
 import WrappedSwapRepository from '../db/repositories/WrappedSwapRepository';
+import LightningErrors from '../lightning/Errors';
 import { InvoiceState, LightningClient } from '../lightning/LightningClient';
 import LndClient from '../lightning/LndClient';
 import ClnClient from '../lightning/cln/ClnClient';
@@ -62,6 +63,11 @@ class LightningNursery extends TypedEventEmitter<{
       error === 'InvoiceExpiredError()' ||
       error.toLowerCase().includes('invoice expired')
     );
+  };
+  public static errIsPaymentTimedOut = (error: string): boolean => {
+    return error
+      .toLowerCase()
+      .includes(LightningErrors.PAYMENT_TIMED_OUT().message.toLowerCase());
   };
 
   public static cancelReverseInvoices = async (

--- a/lib/swap/LightningNursery.ts
+++ b/lib/swap/LightningNursery.ts
@@ -64,10 +64,9 @@ class LightningNursery extends TypedEventEmitter<{
       error.toLowerCase().includes('invoice expired')
     );
   };
+
   public static errIsPaymentTimedOut = (error: string): boolean => {
-    return error
-      .toLowerCase()
-      .includes(LightningErrors.PAYMENT_TIMED_OUT().message.toLowerCase());
+    return error === LightningErrors.PAYMENT_TIMED_OUT().message;
   };
 
   public static cancelReverseInvoices = async (

--- a/lib/swap/PaymentHandler.ts
+++ b/lib/swap/PaymentHandler.ts
@@ -242,7 +242,8 @@ class PaymentHandler {
         LndClient.formatPaymentFailureReason(
           PaymentFailureReason.FAILURE_REASON_INCORRECT_PAYMENT_DETAILS,
         ) ||
-      LightningNursery.errIsInvoiceExpired(errorMessage)
+      LightningNursery.errIsInvoiceExpired(errorMessage) ||
+      LightningNursery.errIsPaymentTimedOut(errorMessage)
     ) {
       await this.abandonSwap(swap, errorMessage);
       return undefined;
@@ -306,7 +307,8 @@ class PaymentHandler {
 
     if (
       ClnClient.errIsIncorrectPaymentDetails(errorMessage) ||
-      LightningNursery.errIsInvoiceExpired(errorMessage)
+      LightningNursery.errIsInvoiceExpired(errorMessage) ||
+      LightningNursery.errIsPaymentTimedOut(errorMessage)
     ) {
       await this.abandonSwap(swap, errorMessage);
       return undefined;

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -222,6 +222,7 @@ class SwapManager {
       this.chainSwapSigner,
       lockupTransactionTracker,
       swapConfig.overpayment,
+      swapConfig.paymentTimeoutMinutes,
     );
 
     this.renegotiator = new Renegotiator(

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -137,6 +137,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     private readonly chainSwapSigner: ChainSwapSigner,
     lockupTransactionTracker: LockupTransactionTracker,
     overPaymentConfig?: OverPaymentConfig,
+    paymentTimeoutMinutes?: number,
   ) {
     super();
 
@@ -175,6 +176,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     this.pendingPaymentTracker = new PendingPaymentTracker(
       this.logger,
       this.sidecar,
+      paymentTimeoutMinutes,
     );
     this.paymentHandler = new PaymentHandler(
       this.logger,

--- a/test/unit/lightning/PendingPaymentTracker.spec.ts
+++ b/test/unit/lightning/PendingPaymentTracker.spec.ts
@@ -25,6 +25,57 @@ describe('PendingPaymentTracker', () => {
     {} as any,
   );
 
+  describe('constructor', () => {
+    let mockLogger: any;
+
+    beforeEach(() => {
+      mockLogger = {
+        info: jest.fn(),
+        debug: jest.fn(),
+      };
+    });
+
+    test('should set paymentTimeoutMinutes when a valid number is provided', () => {
+      const validTimeout = 45;
+      const numericTracker = new PendingPaymentTracker(
+        mockLogger,
+        {} as any,
+        validTimeout,
+      );
+
+      expect(numericTracker['paymentTimeoutMinutes']).toBe(validTimeout);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        `Payment timeout configured: ${validTimeout} minutes`,
+      );
+    });
+
+    test('should not set paymentTimeoutMinutes when undefined is provided', () => {
+      const undefinedTracker = new PendingPaymentTracker(
+        mockLogger,
+        {} as any,
+        undefined,
+      );
+
+      expect(undefinedTracker['paymentTimeoutMinutes']).toBeUndefined();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Payment timeout not configured',
+      );
+    });
+
+    test('should not set paymentTimeoutMinutes when non-numeric value is provided', () => {
+      const stringTracker = new PendingPaymentTracker(
+        mockLogger,
+        {} as any,
+        '60' as any,
+      );
+
+      expect(stringTracker['paymentTimeoutMinutes']).toBeUndefined();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Payment timeout not configured',
+      );
+    });
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
Closes #609

Adds a global invoice timeout after which backend won't attempt new payments and considers the payment as permanently failed.