### PR TITLE
feat: log failed HTTP requests in sidecar

### DIFF
--- a/boltzr/src/api/errors.rs
+++ b/boltzr/src/api/errors.rs
@@ -6,6 +6,9 @@ use axum::http::header::CONTENT_TYPE;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+const API_ERROR_BODY_SIZE: usize = 1024 * 32;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ApiError {
@@ -37,43 +40,82 @@ where
 
 pub async fn error_middleware(request: Request<Body>, next: Next) -> Response<Body> {
     let response = next.run(request).await;
-
-    if response.status().is_server_error() || response.status().is_client_error() {
-        let is_json = match response.headers().get(CONTENT_TYPE) {
-            Some(content_type) => content_type == "application/json",
-            None => false,
-        };
-        if is_json {
-            return response;
-        }
-
-        let (parts, body) = response.into_parts();
-        let body_str = match axum::body::to_bytes(body, 1024 * 32).await {
-            Ok(bytes) => {
-                if !bytes.is_empty() {
-                    match std::str::from_utf8(&bytes) {
-                        Ok(str) => str.to_string(),
-                        Err(_) => return Response::from_parts(parts, Body::from(bytes)),
-                    }
-                } else {
-                    return Response::from_parts(parts, Body::from(bytes));
-                }
-            }
-            Err(err) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ApiError {
-                        error: format!("could not handle body: {}", err),
-                    }),
-                )
-                    .into_response();
-            }
-        };
-
-        return (parts.status, Json(ApiError { error: body_str })).into_response();
+    if !response.status().is_server_error() && !response.status().is_client_error() {
+        return response;
     }
 
-    response
+    // No need to convert to JSON if the response is JSON already
+    if match response.headers().get(CONTENT_TYPE) {
+        Some(content_type) => content_type == "application/json",
+        None => false,
+    } {
+        return response;
+    }
+
+    let (parts, body) = response.into_parts();
+    let body_str = match axum::body::to_bytes(body, API_ERROR_BODY_SIZE).await {
+        Ok(bytes) => {
+            if !bytes.is_empty() {
+                match std::str::from_utf8(&bytes) {
+                    Ok(str) => str.to_string(),
+                    Err(_) => return Response::from_parts(parts, Body::from(bytes)),
+                }
+            } else {
+                return Response::from_parts(parts, Body::from(bytes));
+            }
+        }
+        Err(err) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError {
+                    error: format!("could not handle body: {}", err),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    (parts.status, Json(ApiError { error: body_str })).into_response()
+}
+
+pub async fn logging_middleware(request: Request<Body>, next: Next) -> Response<Body> {
+    let request_uri = request.uri().clone();
+    let response = next.run(request).await;
+    if !response.status().is_server_error() && !response.status().is_client_error() {
+        return response;
+    }
+
+    let (parts, body) = response.into_parts();
+    let body_bytes = match axum::body::to_bytes(body, API_ERROR_BODY_SIZE).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError {
+                    error: format!("could not handle body: {}", err),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    if !body_bytes.is_empty() {
+        let body_str = match std::str::from_utf8(&body_bytes) {
+            Ok(str) => str.to_string(),
+            Err(_) => "unreadable body".to_string(),
+        };
+        warn!(
+            status = parts.status.as_u16(),
+            "Request to {} failed with {}: {}", request_uri, parts.status, body_str,
+        );
+    } else {
+        warn!(
+            status = parts.status.as_u16(),
+            "Request to {} failed with {}", request_uri, parts.status
+        );
+    }
+
+    Response::from_parts(parts, Body::from(body_bytes))
 }
 
 #[cfg(test)]

--- a/boltzr/src/api/mod.rs
+++ b/boltzr/src/api/mod.rs
@@ -1,4 +1,4 @@
-use crate::api::errors::error_middleware;
+use crate::api::errors::{error_middleware, logging_middleware};
 use crate::api::rescue::swap_rescue;
 use crate::api::sse::sse_handler;
 use crate::api::stats::get_stats;
@@ -139,6 +139,7 @@ where
                 post(lightning::bolt12_fetch::<S, M>),
             )
             .layer(axum::middleware::from_fn(error_middleware))
+            .layer(axum::middleware::from_fn(logging_middleware))
     }
 }
 


### PR DESCRIPTION
```
2025-03-30T14:19:17.492906Z  WARN boltzr::api::errors: src/api/errors.rs:107: Request to /v2/lightning/BTC/node/asdf failed with 400 Bad Request: {"error":"invalid node: invalid character 's' at position 1"} status=400
```