### PR TITLE
fix: drop B-Tree indexes on invoices column of swaps

### DIFF
--- a/lib/db/Migration.ts
+++ b/lib/db/Migration.ts
@@ -97,7 +97,7 @@ const decodeInvoice = (
 
 // TODO: integration tests for actual migrations
 class Migration {
-  private static latestSchemaVersion = 16;
+  private static latestSchemaVersion = 17;
 
   private toBackFill: number[] = [];
 
@@ -719,6 +719,16 @@ class Migration {
             type: new DataTypes.TEXT(),
             allowNull: false,
           });
+
+        await this.finishMigration(versionRow.version, currencies);
+        break;
+      }
+
+      case 16: {
+        await this.sequelize.query('DROP INDEX swaps_invoice;');
+        await this.sequelize.query(
+          'ALTER TABLE swaps DROP CONSTRAINT swaps_invoice_key;',
+        );
 
         await this.finishMigration(versionRow.version, currencies);
         break;

--- a/lib/db/models/Swap.ts
+++ b/lib/db/models/Swap.ts
@@ -127,7 +127,6 @@ class Swap extends Model implements SwapType {
         invoice: {
           type: new DataTypes.TEXT(),
           allowNull: true,
-          unique: true,
         },
         invoiceAmount: { type: new DataTypes.BIGINT(), allowNull: true },
         acceptZeroConf: { type: DataTypes.BOOLEAN, allowNull: true },
@@ -162,7 +161,8 @@ class Swap extends Model implements SwapType {
             fields: ['preimageHash'],
           },
           {
-            unique: true,
+            using: 'HASH',
+            unique: false,
             fields: ['invoice'],
           },
           {


### PR DESCRIPTION
Some BOLT12 invoices could be too long for being indexed by a B-Tree, so we have to drop the explicit index and the unique constraint.

The error:
index row size x exceeds btree version 4 maximum 2704 for index