### PR TITLE
chore: remove Rust Nightly from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         node-version: [20]
-        rust-version: [stable, nightly]
+        rust-version: [stable]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Was causing issues because clippy from Rust Nightly wants changes that are unstable in the Rust Stable version