### PR TITLE
feat: Add invoice to submarine swap creation hook

### DIFF
--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -1583,6 +1583,8 @@ export namespace SwapCreation {
     export class Submarine extends jspb.Message { 
         getInvoiceAmount(): number;
         setInvoiceAmount(value: number): Submarine;
+        getInvoice(): string;
+        setInvoice(value: string): Submarine;
 
         serializeBinary(): Uint8Array;
         toObject(includeInstance?: boolean): Submarine.AsObject;
@@ -1597,6 +1599,7 @@ export namespace SwapCreation {
     export namespace Submarine {
         export type AsObject = {
             invoiceAmount: number,
+            invoice: string,
         }
     }
 

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -12338,7 +12338,8 @@ proto.boltzrpc.SwapCreation.Submarine.prototype.toObject = function(opt_includeI
  */
 proto.boltzrpc.SwapCreation.Submarine.toObject = function(includeInstance, msg) {
   var f, obj = {
-    invoiceAmount: jspb.Message.getFieldWithDefault(msg, 1, 0)
+    invoiceAmount: jspb.Message.getFieldWithDefault(msg, 1, 0),
+    invoice: jspb.Message.getFieldWithDefault(msg, 2, "")
   };
 
   if (includeInstance) {
@@ -12379,6 +12380,10 @@ proto.boltzrpc.SwapCreation.Submarine.deserializeBinaryFromReader = function(msg
       var value = /** @type {number} */ (reader.readUint64());
       msg.setInvoiceAmount(value);
       break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setInvoice(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -12415,6 +12420,13 @@ proto.boltzrpc.SwapCreation.Submarine.serializeBinaryToWriter = function(message
       f
     );
   }
+  f = message.getInvoice();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
 };
 
 
@@ -12433,6 +12445,24 @@ proto.boltzrpc.SwapCreation.Submarine.prototype.getInvoiceAmount = function() {
  */
 proto.boltzrpc.SwapCreation.Submarine.prototype.setInvoiceAmount = function(value) {
   return jspb.Message.setProto3IntField(this, 1, value);
+};
+
+
+/**
+ * optional string invoice = 2;
+ * @return {string}
+ */
+proto.boltzrpc.SwapCreation.Submarine.prototype.getInvoice = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.boltzrpc.SwapCreation.Submarine} returns this
+ */
+proto.boltzrpc.SwapCreation.Submarine.prototype.setInvoice = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
 };
 
 

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -623,6 +623,7 @@ class SwapManager {
 
     if (
       !(await this.creationHook.hook(swap.type, {
+        invoice,
         invoiceAmount,
         id: swap.id,
         referral: swap.referral,

--- a/lib/swap/hooks/CreationHook.ts
+++ b/lib/swap/hooks/CreationHook.ts
@@ -19,6 +19,7 @@ type RequestParamsBase = {
 
 type RequestParamsSubmarine = RequestParamsBase & {
   invoiceAmount: number;
+  invoice: string;
 };
 
 type RequestParamsReverse = RequestParamsBase & {
@@ -70,6 +71,9 @@ class CreationHook extends Hook<
         submarine.setInvoiceAmount(
           (params as RequestParamsSubmarine).invoiceAmount,
         );
+
+        submarine.setInvoice((params as RequestParamsSubmarine).invoice);
+
         msg.setSubmarine(submarine);
         break;
       }

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -385,6 +385,7 @@ message SwapCreationResponse {
 message SwapCreation {
     message Submarine {
     uint64 invoice_amount = 1;
+    string invoice = 2;
   }
 
   message Reverse {

--- a/test/unit/swap/SwapManager.spec.ts
+++ b/test/unit/swap/SwapManager.spec.ts
@@ -780,6 +780,7 @@ describe('SwapManager', () => {
       symbolSending: 'BTC',
       symbolReceiving: 'BTC',
       referral: swap.referral,
+      invoice,
       invoiceAmount: invoiceEncode.satoshis!,
     });
 

--- a/test/unit/swap/hooks/CreationHook.spec.ts
+++ b/test/unit/swap/hooks/CreationHook.spec.ts
@@ -131,6 +131,7 @@ describe('CreationHook', () => {
         symbolSending: 'BTC',
         symbolReceiving: 'L-BTC',
         invoiceAmount: 1_321,
+        invoice: 'lnbc13210n...',
       };
 
       const promise = hook.hook(SwapType.Submarine, params);
@@ -142,9 +143,10 @@ describe('CreationHook', () => {
       expect(written.getSymbolSending()).toEqual(params.symbolSending);
       expect(written.getSymbolReceiving()).toEqual(params.symbolReceiving);
       expect(written.getReferral()).toEqual(params.referral);
-      expect(written.getSubmarine().getInvoiceAmount()).toEqual(
-        params.invoiceAmount,
-      );
+
+      const submarineMessage = written.getSubmarine();
+      expect(submarineMessage.getInvoiceAmount()).toEqual(params.invoiceAmount);
+      expect(submarineMessage.getInvoice()).toEqual(params.invoice);
     });
 
     test('should send reverse swap creation hook request', async () => {


### PR DESCRIPTION
This added param returned in the `SwapCreation` hook can allow you to reject swaps based on properties encoded in the returned invoice, including node pubkey - in the case of BOLT 11 submarine swaps. 