### PR TITLE
Docker regtest fixes

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -108,7 +108,7 @@ IMAGES: dict[str, Image] = {
         ],
     ),
     "regtest": Image(
-        tag="4.8.4",
+        tag="4.8.5",
         arguments=[
             UBUNTU_VERSION,
             BITCOIN_BUILD_ARG,

--- a/docker/docker-scripts.sh
+++ b/docker/docker-scripts.sh
@@ -4,9 +4,7 @@
 boltzDir=$(pwd)
 boltzDataDir="$boltzDir/docker/regtest/data"
 
-cookieDir="$boltzDataDir/core/cookies"
-
-alias bitcoin-cli-sim='bitcoin-cli --regtest --rpccookiefile=$cookieDir/.bitcoin-cookie'
+alias bitcoin-cli-sim='bitcoin-cli --regtest -rpcuser=boltz -rpcpassword=anoVB0m1KvX0SmpPxvaLVADg0UQVLQTEx3jCD3qtuRI'
 
 lndCert="$boltzDataDir/lnd/certificates/tls.cert"
 lndMacaroon="$boltzDataDir/lnd/macaroons/admin.macaroon"

--- a/docker/regtest/startRegtest.sh
+++ b/docker/regtest/startRegtest.sh
@@ -28,7 +28,7 @@ docker run \
   -p 9735:9735 \
   -p 9293:9293 \
   -p 9292:9292 \
-  boltz/regtest:4.8.4
+  boltz/regtest:4.8.5
 
 docker exec regtest bash -c "cp /root/.lightning/regtest/*.pem /root/.lightning/regtest/certs"
 docker exec regtest chmod -R 777 /root/.lightning/regtest/certs


### PR DESCRIPTION
I couldn't fetch the regtest docker image on 4.8.4 due to not being available for arm64 (for Apple Silicon). I also noticed a spot in docker-scripts.sh that still used cookie authentication despite it being removed in #943 