### PR TITLE
feat: make node preference in invoice payment hook optional

### DIFF
--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -1722,7 +1722,10 @@ export namespace TransactionHookRequest {
 export class InvoicePaymentHookResponse extends jspb.Message { 
     getId(): string;
     setId(value: string): InvoicePaymentHookResponse;
-    getAction(): Node;
+
+    hasAction(): boolean;
+    clearAction(): void;
+    getAction(): Node | undefined;
     setAction(value: Node): InvoicePaymentHookResponse;
 
     serializeBinary(): Uint8Array;
@@ -1738,7 +1741,7 @@ export class InvoicePaymentHookResponse extends jspb.Message {
 export namespace InvoicePaymentHookResponse {
     export type AsObject = {
         id: string,
-        action: Node,
+        action?: Node,
     }
 }
 

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -13553,8 +13553,8 @@ proto.boltzrpc.InvoicePaymentHookResponse.serializeBinaryToWriter = function(mes
       f
     );
   }
-  f = message.getAction();
-  if (f !== 0.0) {
+  f = /** @type {!proto.boltzrpc.Node} */ (jspb.Message.getField(message, 2));
+  if (f != null) {
     writer.writeEnum(
       2,
       f
@@ -13595,7 +13595,25 @@ proto.boltzrpc.InvoicePaymentHookResponse.prototype.getAction = function() {
  * @return {!proto.boltzrpc.InvoicePaymentHookResponse} returns this
  */
 proto.boltzrpc.InvoicePaymentHookResponse.prototype.setAction = function(value) {
-  return jspb.Message.setProto3EnumField(this, 2, value);
+  return jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.boltzrpc.InvoicePaymentHookResponse} returns this
+ */
+proto.boltzrpc.InvoicePaymentHookResponse.prototype.clearAction = function() {
+  return jspb.Message.setField(this, 2, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.boltzrpc.InvoicePaymentHookResponse.prototype.hasAction = function() {
+  return jspb.Message.getField(this, 2) != null;
 };
 
 

--- a/lib/swap/hooks/Hook.ts
+++ b/lib/swap/hooks/Hook.ts
@@ -4,16 +4,12 @@ import type Logger from '../../Logger';
 import { formatError } from '../../Utils';
 import type NotificationClient from '../../notifications/NotificationClient';
 
-interface Action {
-  toString(): string;
-}
-
 interface HookResponse<T> {
   getId(): string;
   getAction(): T;
 }
 
-abstract class Hook<T extends Action, P, Req, Res extends HookResponse<T>> {
+abstract class Hook<T, P, Req, Res extends HookResponse<T>> {
   private readonly pendingHooks = new Map<string, (parsed: P) => void>();
 
   private stream?: ServerDuplexStream<Res, Req> = undefined;
@@ -58,7 +54,7 @@ abstract class Hook<T extends Action, P, Req, Res extends HookResponse<T>> {
 
     this.stream.on('data', (data: Res) => {
       this.logger.silly(
-        `Received gRPC ${this.name} hook response for ${data.getId()}: ${data.getAction().toString()}`,
+        `Received gRPC ${this.name} hook response for ${data.getId()}: ${data.getAction()?.toString() ?? 'undefined'}`,
       );
 
       const hook = this.pendingHooks.get(data.getId());

--- a/lib/swap/hooks/InvoicePaymentHook.ts
+++ b/lib/swap/hooks/InvoicePaymentHook.ts
@@ -6,8 +6,8 @@ import type DecodedInvoice from '../../sidecar/DecodedInvoice';
 import Hook, { type HookResponse } from './Hook';
 
 class InvoicePaymentHook extends Hook<
-  boltzrpc.Node,
-  NodeType,
+  boltzrpc.Node | undefined,
+  NodeType | undefined,
   boltzrpc.InvoicePaymentHookRequest,
   boltzrpc.InvoicePaymentHookResponse
 > {
@@ -38,19 +38,29 @@ class InvoicePaymentHook extends Hook<
 
     const res = await this.sendHook(swapId, msg);
 
-    this.logger.debug(
-      `Invoice payment hook for ${swapId} returned ${nodeTypeToPrettyString(res)}`,
-    );
+    if (res !== undefined) {
+      this.logger.debug(
+        `Invoice payment hook for ${swapId} returned ${nodeTypeToPrettyString(res)}`,
+      );
+    } else {
+      this.logger.debug(
+        `Invoice payment hook for ${swapId} returned without preference`,
+      );
+    }
 
     return res;
   };
 
-  protected parseGrpcAction = (res: HookResponse<boltzrpc.Node>): NodeType => {
+  protected parseGrpcAction = (
+    res: HookResponse<boltzrpc.Node | undefined>,
+  ): NodeType | undefined => {
     switch (res.getAction()) {
       case boltzrpc.Node.CLN:
         return NodeType.CLN;
       case boltzrpc.Node.LND:
         return NodeType.LND;
+      default:
+        return undefined;
     }
   };
 }

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -434,7 +434,7 @@ enum Node {
 
 message InvoicePaymentHookResponse {
   string id = 1;
-  Node action = 2;
+  optional Node action = 2;
 }
 
 message InvoicePaymentHookRequest {

--- a/test/unit/swap/hooks/InvoicePaymentHook.spec.ts
+++ b/test/unit/swap/hooks/InvoicePaymentHook.spec.ts
@@ -35,6 +35,7 @@ describe('InvoicePaymentHook', () => {
       grpcNode             | expectedNodeType
       ${boltzrpc.Node.CLN} | ${NodeType.CLN}
       ${boltzrpc.Node.LND} | ${NodeType.LND}
+      ${undefined}         | ${undefined}
     `(
       'should parse gRPC node $grpcNode to NodeType $expectedNodeType',
       ({ grpcNode, expectedNodeType }) => {


### PR DESCRIPTION
To allow clients to express that they have no preference for which node should be used for the lightning payment