### PR TITLE
Add extraFee percentage to percentageFee before calculation

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -76,7 +76,6 @@ import {
   GetInfoResponse,
   LightningInfo,
 } from '../proto/boltzrpc_pb';
-import FeeProvider from '../rates/FeeProvider';
 import LockupTransactionTracker from '../rates/LockupTransactionTracker';
 import RateProvider from '../rates/RateProvider';
 import type { PairTypeLegacy } from '../rates/providers/RateProviderLegacy';
@@ -1647,6 +1646,62 @@ class Service {
     }
   };
 
+  private calculateReverseSwapAmounts = (
+    args: {
+      invoiceAmount?: number;
+      onchainAmount?: number;
+    },
+    rate: number,
+    feePercent: number,
+    baseFee: number,
+  ): {
+    onchainAmount: number;
+    holdInvoiceAmount: number;
+    percentageFee: number;
+    invoiceAmountDefined: boolean;
+  } => {
+    let onchainAmount: number;
+    let holdInvoiceAmount: number;
+    let percentageFee: number;
+    let invoiceAmountDefined: boolean;
+
+    if (args.invoiceAmount !== undefined && args.onchainAmount !== undefined) {
+      throw Errors.INVOICE_AND_ONCHAIN_AMOUNT_SPECIFIED();
+    } else if (args.invoiceAmount !== undefined) {
+      invoiceAmountDefined = true;
+
+      this.checkWholeNumber(args.invoiceAmount);
+      holdInvoiceAmount = args.invoiceAmount;
+
+      onchainAmount = args.invoiceAmount * rate;
+
+      percentageFee = Math.ceil(feePercent * onchainAmount);
+
+      onchainAmount -= percentageFee + baseFee;
+      onchainAmount = Math.floor(onchainAmount);
+    } else if (args.onchainAmount !== undefined) {
+      invoiceAmountDefined = false;
+
+      this.checkWholeNumber(args.onchainAmount);
+      onchainAmount = args.onchainAmount;
+
+      holdInvoiceAmount = (args.onchainAmount + baseFee) / rate;
+      holdInvoiceAmount = holdInvoiceAmount / (1 - feePercent);
+      holdInvoiceAmount = Math.ceil(holdInvoiceAmount);
+
+      percentageFee = Math.ceil(holdInvoiceAmount * rate * feePercent);
+    } else {
+      throw Errors.NO_AMOUNT_SPECIFIED();
+    }
+
+    return {
+      onchainAmount,
+      holdInvoiceAmount,
+      percentageFee,
+      invoiceAmountDefined,
+    };
+  };
+
   /**
    * Creates a new Swap from Lightning to the chain
    */
@@ -1842,57 +1897,36 @@ class Service {
       BaseFeeType.ReverseLockup,
     );
 
-    let onchainAmount: number;
-    let holdInvoiceAmount: number;
-
-    let percentageFee: number;
-
-    // True when the invoice amount was set in the request, false when the onchain amount was set
-    let invoiceAmountDefined: boolean;
-
-    if (args.invoiceAmount !== undefined && args.onchainAmount !== undefined) {
-      throw Errors.INVOICE_AND_ONCHAIN_AMOUNT_SPECIFIED();
-    } else if (args.invoiceAmount !== undefined) {
-      invoiceAmountDefined = true;
-
-      this.checkWholeNumber(args.invoiceAmount);
-      holdInvoiceAmount = args.invoiceAmount;
-
-      onchainAmount = args.invoiceAmount * rate;
-
-      percentageFee = Math.ceil(feePercent * onchainAmount);
-
-      onchainAmount -= percentageFee + baseFee;
-      onchainAmount = Math.floor(onchainAmount);
-    } else if (args.onchainAmount !== undefined) {
-      invoiceAmountDefined = false;
-
-      this.checkWholeNumber(args.onchainAmount);
-      onchainAmount = args.onchainAmount;
-
-      holdInvoiceAmount = (args.onchainAmount + baseFee) / rate;
-      holdInvoiceAmount = holdInvoiceAmount / (1 - feePercent);
-      holdInvoiceAmount = Math.ceil(holdInvoiceAmount);
-
-      percentageFee = Math.ceil(holdInvoiceAmount * rate * feePercent);
-    } else {
-      throw Errors.NO_AMOUNT_SPECIFIED();
-    }
+    const {
+      onchainAmount: onchainAmountConst,
+      holdInvoiceAmount: holdInvoiceAmountConst,
+      percentageFee,
+      invoiceAmountDefined,
+    } = this.calculateReverseSwapAmounts(args, rate, feePercent, baseFee);
+    let onchainAmount = onchainAmountConst;
+    let holdInvoiceAmount = holdInvoiceAmountConst;
 
     let extraFee: number | undefined = undefined;
 
     if (args.extraFees !== undefined) {
-      extraFee = FeeProvider.calculateExtraFee(
-        args.extraFees.percentage,
-        holdInvoiceAmount,
+      const {
+        onchainAmount: onchainAmountWithExtraFees,
+        holdInvoiceAmount: holdInvoiceAmountWithExtraFees,
+      } = this.calculateReverseSwapAmounts(
+        args,
         rate,
+        feePercent + args.extraFees.percentage / 100,
+        baseFee,
       );
 
       if (invoiceAmountDefined) {
-        onchainAmount = Math.floor(onchainAmount - extraFee);
+        extraFee = onchainAmount - onchainAmountWithExtraFees;
       } else {
-        holdInvoiceAmount = Math.ceil(holdInvoiceAmount + extraFee);
+        extraFee = holdInvoiceAmountWithExtraFees - holdInvoiceAmount;
       }
+
+      onchainAmount = onchainAmountWithExtraFees;
+      holdInvoiceAmount = holdInvoiceAmountWithExtraFees;
     }
 
     await this.verifyAmount(
@@ -2046,6 +2080,78 @@ class Service {
     return response;
   };
 
+  private calculateChainSwapAmounts = (
+    args: {
+      userLockAmount?: number;
+      serverLockAmount?: number;
+    },
+    rate: number,
+    feePercent: number,
+    baseFee: number,
+  ): {
+    userLockAmount: number;
+    serverLockAmount: number;
+    percentageFee: number;
+    userLockAmountDefined: boolean;
+    isZeroAmount: boolean;
+  } => {
+    let percentageFee: number;
+    let userLockAmount: number;
+    let serverLockAmount: number;
+    let userLockAmountDefined: boolean;
+
+    const isZeroAmount =
+      args.userLockAmount === undefined && args.serverLockAmount === undefined;
+
+    if (
+      args.userLockAmount !== undefined &&
+      args.serverLockAmount !== undefined
+    ) {
+      throw Errors.USER_AND_SERVER_AMOUNT_SPECIFIED();
+    } else if (args.userLockAmount !== undefined) {
+      userLockAmountDefined = true;
+
+      this.checkWholeNumber(args.userLockAmount);
+      userLockAmount = args.userLockAmount;
+
+      const calcRes = this.swapManager.renegotiator.calculateServerLockAmount(
+        rate,
+        userLockAmount,
+        feePercent,
+        baseFee,
+      );
+
+      percentageFee = calcRes.percentageFee;
+      serverLockAmount = calcRes.serverLockAmount;
+    } else if (args.serverLockAmount !== undefined) {
+      userLockAmountDefined = false;
+
+      this.checkWholeNumber(args.serverLockAmount);
+      serverLockAmount = args.serverLockAmount;
+
+      userLockAmount = (serverLockAmount + baseFee) / rate;
+      userLockAmount = userLockAmount / (1 - feePercent);
+      userLockAmount = Math.ceil(userLockAmount);
+
+      percentageFee = Math.ceil(userLockAmount * rate * feePercent);
+    } else if (isZeroAmount) {
+      percentageFee = 0;
+      userLockAmount = 0;
+      serverLockAmount = 0;
+      userLockAmountDefined = false;
+    } else {
+      throw Errors.NO_AMOUNT_SPECIFIED();
+    }
+
+    return {
+      userLockAmount,
+      serverLockAmount,
+      percentageFee,
+      userLockAmountDefined,
+      isZeroAmount,
+    };
+  };
+
   // TODO: test
   public createChainSwap = async (args: {
     pairId: string;
@@ -2157,64 +2263,54 @@ class Service {
       side,
       referral,
     );
-    let percentageFee: number;
 
-    const isZeroAmount =
-      args.userLockAmount === undefined && args.serverLockAmount === undefined;
-    let userLockAmountDefined: boolean = false;
+    const {
+      userLockAmount,
+      serverLockAmount,
+      percentageFee,
+      userLockAmountDefined,
+      isZeroAmount,
+    } = this.calculateChainSwapAmounts(
+      {
+        userLockAmount: args.userLockAmount,
+        serverLockAmount: args.serverLockAmount,
+      },
+      rate,
+      feePercent,
+      baseFee,
+    );
 
-    if (
-      args.userLockAmount !== undefined &&
-      args.serverLockAmount !== undefined
-    ) {
-      throw Errors.USER_AND_SERVER_AMOUNT_SPECIFIED();
-    } else if (args.userLockAmount !== undefined) {
-      userLockAmountDefined = true;
+    const originalUserLockAmount = args.userLockAmount;
+    const originalServerLockAmount = args.serverLockAmount;
 
-      this.checkWholeNumber(args.userLockAmount);
-
-      const calcRes = this.swapManager.renegotiator.calculateServerLockAmount(
-        rate,
-        args.userLockAmount,
-        feePercent,
-        baseFee,
-      );
-
-      percentageFee = calcRes.percentageFee;
-      args.serverLockAmount = calcRes.serverLockAmount;
-    } else if (args.serverLockAmount !== undefined) {
-      userLockAmountDefined = false;
-
-      this.checkWholeNumber(args.serverLockAmount);
-
-      args.userLockAmount = (args.serverLockAmount + baseFee) / rate;
-      args.userLockAmount = args.userLockAmount / (1 - feePercent);
-      args.userLockAmount = Math.ceil(args.userLockAmount);
-
-      percentageFee = Math.ceil(args.userLockAmount * rate * feePercent);
-    } else if (isZeroAmount) {
-      percentageFee = 0;
-      args.userLockAmount = 0;
-      args.serverLockAmount = 0;
-    } else {
-      throw Errors.NO_AMOUNT_SPECIFIED();
-    }
+    args.userLockAmount = userLockAmount;
+    args.serverLockAmount = serverLockAmount;
 
     let extraFee: number | undefined = undefined;
 
     if (!isZeroAmount) {
       if (args.extraFees !== undefined) {
-        extraFee = FeeProvider.calculateExtraFee(
-          args.extraFees.percentage,
-          args.userLockAmount,
+        const {
+          userLockAmount: userLockAmountWithExtraFees,
+          serverLockAmount: serverLockAmountWithExtraFees,
+        } = this.calculateChainSwapAmounts(
+          {
+            userLockAmount: originalUserLockAmount,
+            serverLockAmount: originalServerLockAmount,
+          },
           rate,
+          feePercent + args.extraFees.percentage / 100,
+          baseFee,
         );
 
         if (userLockAmountDefined) {
-          args.serverLockAmount = Math.floor(args.serverLockAmount - extraFee);
+          extraFee = args.serverLockAmount - serverLockAmountWithExtraFees;
         } else {
-          args.userLockAmount = Math.ceil(args.userLockAmount + extraFee);
+          extraFee = userLockAmountWithExtraFees - args.userLockAmount;
         }
+
+        args.userLockAmount = userLockAmountWithExtraFees;
+        args.serverLockAmount = serverLockAmountWithExtraFees;
       }
 
       await this.verifyAmount(

--- a/test/unit/rates/FeeProvider.spec.ts
+++ b/test/unit/rates/FeeProvider.spec.ts
@@ -68,33 +68,6 @@ describe('FeeProvider', () => {
     expect(FeeProvider.addPremium(fee, premium)).toEqual(expected);
   });
 
-  describe('calculateExtraFee', () => {
-    test.each`
-      percentage | amount | rate   | expected
-      ${0}       | ${1}   | ${1}   | ${0}
-      ${1}       | ${1}   | ${1}   | ${1}
-      ${1}       | ${100} | ${1}   | ${1}
-      ${2}       | ${100} | ${1}   | ${2}
-      ${2.5}     | ${100} | ${1}   | ${3}
-      ${2}       | ${100} | ${0.5} | ${1}
-      ${0.01}    | ${100} | ${5}   | ${1}
-      ${99.9}    | ${100} | ${5}   | ${500}
-    `(
-      'should calculate extra fee',
-      ({ percentage, amount, rate, expected }) => {
-        expect(FeeProvider.calculateExtraFee(percentage, amount, rate)).toEqual(
-          expected,
-        );
-      },
-    );
-
-    test('should throw on negative fee percentage', () => {
-      expect(() => {
-        FeeProvider.calculateExtraFee(-1, 100, 1);
-      }).toThrow('invalid extra fees percentage: -1');
-    });
-  });
-
   test('should init', () => {
     feeProvider.init([
       {

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -376,7 +376,6 @@ jest.mock('../../../lib/rates/FeeProvider', () => {
     getPercentageSwapInFee: mockGetPercentageSwapInFee,
   }));
 });
-FeeProvider.calculateExtraFee = jest.fn().mockReturnValue(1000);
 
 const MockedFeeProvider = <jest.Mock<FeeProvider>>(<any>FeeProvider);
 
@@ -2695,21 +2694,18 @@ describe('Service', () => {
     const preimageHash = randomBytes(32);
     const claimPublicKey = getHexBuffer('0xfff');
 
+    const extraFeePercentage = 0.5;
     const extraFees = {
       id: 'extraFeeId',
-      percentage: 0.5,
+      percentage: extraFeePercentage,
     };
 
-    const extraFee = FeeProvider.calculateExtraFee(
-      extraFees.percentage,
-      invoiceAmount,
-      1,
-    );
-
     const onchainAmount =
-      invoiceAmount * (1 - mockGetPercentageFeeResult) -
-      mockGetBaseFeeResult -
-      extraFee;
+      invoiceAmount *
+        (1 - mockGetPercentageFeeResult - extraFeePercentage / 100) -
+      mockGetBaseFeeResult;
+
+    const extraFee = (invoiceAmount * extraFeePercentage) / 100;
 
     const response = await service.createReverseSwap({
       orderSide,
@@ -2766,13 +2762,16 @@ describe('Service', () => {
       percentage: 1,
     };
 
-    const extraFee = 1000;
+    const holdInvoiceAmountWithoutExtraFees = Math.ceil(
+      (onchainAmount + mockGetBaseFeeResult) / (1 - mockGetPercentageFeeResult),
+    );
 
-    const holdInvoiceAmount =
-      Math.ceil(
-        (onchainAmount + mockGetBaseFeeResult) /
-          (1 - mockGetPercentageFeeResult),
-      ) + extraFee;
+    const holdInvoiceAmount = Math.ceil(
+      (onchainAmount + mockGetBaseFeeResult) /
+        (1 - mockGetPercentageFeeResult - extraFees.percentage / 100),
+    );
+
+    const extraFee = holdInvoiceAmount - holdInvoiceAmountWithoutExtraFees;
 
     const response = await service.createReverseSwap({
       orderSide,


### PR DESCRIPTION
This PR proposes changing the way extra fees are calculated so that clients don't need to be aware of them. 

By calculating the total fees by adding the relative fees first (`percentageFee` and `extraFee`), clients can be informed of a single relative fee (the sum) and still get to the same value as the server. As it was, clients would need to know the extra fee in order to calculate `ceil(percentageFee * amount) + ceil(extraFee * amount)`.