### PR TITLE
fix: use second routing hint in MRH

### DIFF
--- a/lib/swap/ReverseRoutingHints.ts
+++ b/lib/swap/ReverseRoutingHints.ts
@@ -140,6 +140,17 @@ class ReverseRoutingHints {
           feeProportionalMillionths: 21,
         },
       ],
+      // Useless hint to trick LND into thinking the MRH is not an LSP
+      [
+        {
+          nodeId:
+            '02e6109db08c459453bac736158f3962a28f05df0c4b8660479679c1f48c1ed8d8',
+          chanId: transactionToLndScid(902436, 21, 0),
+          feeBaseMsat: 1,
+          cltvExpiryDelta: 82,
+          feeProportionalMillionths: 22,
+        },
+      ],
     ];
   };
 

--- a/test/unit/swap/ReverseRoutingHints.spec.ts
+++ b/test/unit/swap/ReverseRoutingHints.spec.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'crypto';
 import { ECPair } from '../../../lib/ECPairHelper';
 import { getHexBuffer, getHexString, getSwapMemo } from '../../../lib/Utils';
 import { SwapType, SwapVersion } from '../../../lib/consts/Enums';
+import { transactionToLndScid } from '../../../lib/lightning/ChannelUtils';
 import type { DecodedInvoice } from '../../../lib/lightning/LightningClient';
 import PaymentRequestUtils from '../../../lib/service/PaymentRequestUtils';
 import Errors from '../../../lib/swap/Errors';
@@ -15,6 +16,17 @@ describe('ReverseRoutingHints', () => {
   } as Currency;
 
   const reverseMinerFees = 123;
+
+  const fakeRoutingHint = [
+    {
+      nodeId:
+        '02e6109db08c459453bac736158f3962a28f05df0c4b8660479679c1f48c1ed8d8',
+      chanId: transactionToLndScid(902436, 21, 0),
+      feeBaseMsat: 1,
+      cltvExpiryDelta: 82,
+      feeProportionalMillionths: 22,
+    },
+  ];
 
   const paymentRequestUtils = new PaymentRequestUtils();
   const hints = new ReverseRoutingHints(
@@ -135,6 +147,7 @@ describe('ReverseRoutingHints', () => {
                 feeProportionalMillionths: 21,
               },
             ],
+            fakeRoutingHint,
           ],
         });
       },
@@ -207,6 +220,7 @@ describe('ReverseRoutingHints', () => {
                 feeProportionalMillionths: 21,
               },
             ],
+            fakeRoutingHint,
           ],
         });
       });


### PR DESCRIPTION
The probing logic of LND assumes that the first node of the routing hint is a LSP (and probes that node) if all route hints have the same first node. We trick that heuristic by adding a second routing hint with a different public key when we add a magic routing hint to the invoice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced routing hints to include an additional entry for improved compatibility with Lightning Network payments.
- **Tests**
  - Updated test cases to verify the presence of the new routing hint in relevant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->