### PR TITLE
offerinfo command

### DIFF
--- a/boltzr/src/db/models/offer.rs
+++ b/boltzr/src/db/models/offer.rs
@@ -1,9 +1,30 @@
+use crate::utils::serde::hex;
 use diesel::{AsChangeset, Insertable, Queryable, Selectable};
+use serde::Serialize;
 
-#[derive(Queryable, Selectable, Insertable, AsChangeset, PartialEq, Clone, Default, Debug)]
+#[derive(
+    Queryable, Selectable, Insertable, AsChangeset, PartialEq, Clone, Default, Debug, Serialize,
+)]
 #[diesel(table_name = crate::db::schema::offers)]
 pub struct Offer {
+    #[serde(serialize_with = "hex::serialize")]
     pub signer: Vec<u8>,
     pub offer: String,
     pub url: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_offer_serialization_hex_signer() {
+        let offer = Offer {
+            signer: vec![0x01, 0x02, 0x0A, 0xFF],
+            offer: "dummy offer".to_string(),
+            url: Some("http://example.com".to_string()),
+        };
+        let json = serde_json::to_string(&offer).expect("serialization should work");
+        assert!(json.contains("\"signer\":\"01020aff\""));
+    }
 }

--- a/boltzr/src/main.rs
+++ b/boltzr/src/main.rs
@@ -206,7 +206,7 @@ async fn main() {
         match notifications::mattermost::Client::<notifications::commands::Commands>::new(
             cancellation_token.clone(),
             config,
-            notifications::commands::Commands::new(backup_client.clone()),
+            notifications::commands::Commands::new(db_pool.clone(), backup_client.clone()),
         )
         .await
         {

--- a/boltzr/src/utils/mod.rs
+++ b/boltzr/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod bip21;
 pub mod pair;
+pub mod serde;
 mod timeout_map;
 pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/boltzr/src/utils/serde.rs
+++ b/boltzr/src/utils/serde.rs
@@ -1,0 +1,39 @@
+pub mod hex {
+    use alloy::hex;
+    use serde::Serializer;
+
+    pub fn serialize<S>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&hex::encode(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hex;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Wrapper<'a> {
+        #[serde(serialize_with = "hex::serialize")]
+        data: &'a [u8],
+    }
+
+    #[test]
+    fn test_serialize_non_empty() {
+        let wrapper = Wrapper {
+            data: &[0xAB, 0xCD],
+        };
+        let json = serde_json::to_string(&wrapper).unwrap();
+        assert_eq!(json, "{\"data\":\"abcd\"}");
+    }
+
+    #[test]
+    fn test_serialize_empty() {
+        let wrapper = Wrapper { data: &[] };
+        let json = serde_json::to_string(&wrapper).unwrap();
+        assert_eq!(json, "{\"data\":\"\"}");
+    }
+}

--- a/lib/cli/commands/ClnThreshold.ts
+++ b/lib/cli/commands/ClnThreshold.ts
@@ -2,7 +2,7 @@ import type { Arguments } from 'yargs';
 import { stringToSwapType, swapTypeToGrpcSwapType } from '../../consts/Enums';
 import { InvoiceClnThresholdRequest } from '../../proto/boltzrpc_pb';
 import type { ApiType, BuilderTypes } from '../BuilderComponents';
-import { callback, loadBoltzClient } from '../Command';
+import { callback, loadBoltzClient, parseAmount } from '../Command';
 
 export const command = 'clnthreshold <type> <threshold>';
 
@@ -15,8 +15,8 @@ export const builder = {
     choices: ['submarine', 'reverse'],
   },
   threshold: {
-    type: 'number',
-    describe: 'the threshold in satoshis',
+    type: 'string',
+    describe: 'the threshold',
   },
 };
 
@@ -25,7 +25,7 @@ export const handler = async (
 ) => {
   const threshold = new InvoiceClnThresholdRequest.Threshold();
   threshold.setType(swapTypeToGrpcSwapType(stringToSwapType(argv.type)));
-  threshold.setThreshold(argv.threshold);
+  threshold.setThreshold(parseAmount(argv.threshold));
 
   const req = new InvoiceClnThresholdRequest();
   req.addThresholds(threshold);

--- a/lib/cli/commands/SendCoins.ts
+++ b/lib/cli/commands/SendCoins.ts
@@ -2,7 +2,7 @@ import type { Arguments } from 'yargs';
 import { SendCoinsRequest } from '../../proto/boltzrpc_pb';
 import type { ApiType, BuilderTypes } from '../BuilderComponents';
 import BuilderComponents from '../BuilderComponents';
-import { callback, loadBoltzClient } from '../Command';
+import { callback, loadBoltzClient, parseAmount } from '../Command';
 
 export const command =
   'sendcoins <symbol> <address> <amount> <label> [fee] [send_all]';
@@ -17,7 +17,7 @@ export const builder = {
   },
   amount: {
     describe: 'amount that should be sent',
-    type: 'number',
+    type: 'string',
   },
   label: {
     describe: 'label for the transaction',
@@ -40,7 +40,7 @@ export const handler = (
 
   request.setSymbol(argv.symbol);
   request.setAddress(argv.address);
-  request.setAmount(argv.amount);
+  request.setAmount(parseAmount(argv.amount));
   request.setLabel(argv.label);
   request.setFee(argv.fee);
   request.setSendAll(argv.send_all);

--- a/test/unit/cli/Command.spec.ts
+++ b/test/unit/cli/Command.spec.ts
@@ -1,0 +1,40 @@
+import { parseAmount } from '../../../lib/cli/Command';
+
+describe('Command', () => {
+  describe('parseAmount', () => {
+    test.each`
+      amount            | expected
+      ${'0'}            | ${0}
+      ${'1'}            | ${1}
+      ${'100'}          | ${100}
+      ${'0.00000001'}   | ${1}
+      ${'0.1'}          | ${10_000_000}
+      ${'1.23456789'}   | ${123_456_789}
+      ${'123.45678901'} | ${12_345_678_901}
+      ${'-1'}           | ${-1}
+      ${'-0.1'}         | ${-10_000_000}
+      ${'-100'}         | ${-100}
+    `(
+      'should convert "$amount" to $expected satoshis',
+      ({ amount, expected }) => {
+        expect(parseAmount(amount)).toBe(expected);
+      },
+    );
+
+    test.each(['abc', '', 'NaN'])(
+      'should throw on invalid amount "%s"',
+      (invalidAmount) => {
+        expect(() => parseAmount(invalidAmount as string)).toThrow(
+          'invalid amount',
+        );
+      },
+    );
+
+    test.each([' 123 ', '\n100\t'])(
+      'should handle whitespace in amount "%s"',
+      (amount) => {
+        expect(() => parseAmount(amount as string)).not.toThrow();
+      },
+    );
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new CLI command to fetch and display information about BOLT12 offers in pretty-printed JSON format.
  - Introduced flexible amount parsing in CLI commands, allowing input of amounts as strings (including decimals) which are accurately converted to satoshis.

- **Bug Fixes**
  - Improved serialization of offer data, ensuring byte fields (e.g., signer) are displayed as lowercase hex strings in JSON outputs.

- **Tests**
  - Added unit tests for the new amount parsing logic and for verifying correct serialization of offer data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->