### PR TITLE
fix: reset pending sweeps gauges to zero

### DIFF
--- a/lib/Prometheus.ts
+++ b/lib/Prometheus.ts
@@ -216,6 +216,12 @@ class Prometheus {
       });
     };
 
+    const setDefaultSymbols = (gauge: Gauge, defaultValue: number) => {
+      service.currencies.forEach((currency) => {
+        gauge.set({ symbol: currency.symbol }, defaultValue);
+      });
+    };
+
     this.swapRegistry!.registerMetric(
       new Gauge({
         name: `${Prometheus.metricPrefix}swap_counts`,
@@ -315,6 +321,8 @@ class Prometheus {
         labelNames: ['symbol'],
         help: 'number of pending sweeps',
         collect: function () {
+          setDefaultSymbols(this, 0);
+
           const pendingSweeps = service.getPendingSweeps();
           for (const [symbol, swaps] of pendingSweeps.entries()) {
             this.set({ symbol }, swaps.length);
@@ -329,6 +337,8 @@ class Prometheus {
         labelNames: ['symbol'],
         help: 'amount in pending sweeps',
         collect: function () {
+          setDefaultSymbols(this, 0);
+
           const pendingSweeps = service.getPendingSweeps();
           for (const [symbol, swaps] of pendingSweeps.entries()) {
             this.set(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that all currency symbols have a default gauge value initialized in metrics before reporting pending sweep counts and amounts. This prevents missing or uninitialized values for any currency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->