### PR TITLE
docs: extra fees endpoint

### DIFF
--- a/lib/api/v2/routers/ReferralRouter.ts
+++ b/lib/api/v2/routers/ReferralRouter.ts
@@ -205,6 +205,59 @@ class ReferralRouter extends RouterBase {
      */
     router.get('/stats', this.handleError(this.getStats));
 
+    /**
+     * @openapi
+     * /referral/stats/extra:
+     *   get:
+     *     description: Extra fees collected for swaps created with a referral ID
+     *     tags: [Referral]
+     *     parameters:
+     *       - in: header
+     *         name: TS
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: Current UNIX timestamp when the request is sent
+     *       - in: header
+     *         name: API-KEY
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: Your API key
+     *       - in: header
+     *         name: API-HMAC
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: HMAC-SHA256 with your API-Secret as key of the TS + HTTP method (all uppercase) + the HTTP path
+     *     responses:
+     *       '200':
+     *         description: Extra fees collected by swap ID grouped by year and month
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               description: Year
+     *               additionalProperties:
+     *                 type: object
+     *                 description: Month
+     *                 additionalProperties:
+     *                   type: object
+     *                   description: Extra fees collected in that month
+     *                   additionalProperties:
+     *                     type: integer
+     *                     format: uint64
+     *                     description: Total extra fees collected grouped by identifier
+     *             examples:
+     *               json:
+     *                 value: '{"2024":{"1":{"swap123":1000,"swap456":2500},"2":{"swap789":1500}}}'
+     *       '401':
+     *         description: Unauthorized in case of an unknown API-KEY or bad HMAC
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+     */
     router.get('/stats/extra', this.handleError(this.getExtraFees));
 
     return router;

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -1443,6 +1443,84 @@
         }
       }
     },
+    "/referral/stats/extra": {
+      "get": {
+        "description": "Extra fees collected for swaps created with a referral ID",
+        "tags": [
+          "Referral"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "TS",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Current UNIX timestamp when the request is sent"
+          },
+          {
+            "in": "header",
+            "name": "API-KEY",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your API key"
+          },
+          {
+            "in": "header",
+            "name": "API-HMAC",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "HMAC-SHA256 with your API-Secret as key of the TS + HTTP method (all uppercase) + the HTTP path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Extra fees collected by swap ID grouped by year and month",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Year",
+                  "additionalProperties": {
+                    "type": "object",
+                    "description": "Month",
+                    "additionalProperties": {
+                      "type": "object",
+                      "description": "Extra fees collected in that month",
+                      "additionalProperties": {
+                        "type": "integer",
+                        "format": "uint64",
+                        "description": "Total extra fees collected grouped by identifier"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "json": {
+                    "value": "{\"2024\":{\"1\":{\"swap123\":1000,\"swap456\":2500},\"2\":{\"swap789\":1500}}}"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized in case of an unknown API-KEY or bad HMAC",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/swap/submarine": {
       "get": {
         "description": "Possible pairs for Submarine Swaps",


### PR DESCRIPTION
Closes #999


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new endpoint to view extra fees collected for referral-based swaps, grouped by year, month, and swap ID.
  * Endpoint requires authentication via specific headers and provides detailed statistics in a structured JSON format.

* **Documentation**
  * Updated API documentation to include the new referral statistics endpoint, detailing request requirements and response structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->