### PR TITLE
chore: fix CI build cache for hold invoice plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,9 @@ jobs:
       - name: Build cache
         uses: actions/cache@v4
         with:
-          path: target
+          path: |
+            target
+            hold/target
           key:
             ${{ runner.os }}-cargo-${{ matrix.rust-version }}-${{
             hashFiles('Cargo.lock') }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow caching to include both the `target` and `hold/target` directories, optimizing build times in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->