### PR TITLE
fix: fail self payments when reverse swap is refunded

### DIFF
--- a/lib/db/models/RefundTransaction.ts
+++ b/lib/db/models/RefundTransaction.ts
@@ -65,6 +65,10 @@ class RefundTransaction extends Model implements RefundTransactionType {
       },
     );
   };
+
+  get isFinal(): boolean {
+    return this.status === RefundStatus.Confirmed;
+  }
 }
 
 export default RefundTransaction;

--- a/test/integration/db/models/RefundTransaction.spec.ts
+++ b/test/integration/db/models/RefundTransaction.spec.ts
@@ -1,0 +1,37 @@
+import Logger from '../../../../lib/Logger';
+import Database from '../../../../lib/db/Database';
+import RefundTransaction, {
+  RefundStatus,
+} from '../../../../lib/db/models/RefundTransaction';
+
+describe('RefundTransaction', () => {
+  const db = new Database(Logger.disabledLogger, Database.memoryDatabase);
+
+  beforeAll(async () => {
+    await db.init();
+  });
+
+  beforeEach(async () => {
+    await RefundTransaction.truncate();
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  test.each`
+    status                    | expected
+    ${RefundStatus.Confirmed} | ${true}
+    ${RefundStatus.Pending}   | ${false}
+    ${RefundStatus.Failed}    | ${false}
+  `('isFinal getter: $status -> $expected', async ({ status, expected }) => {
+    const tx = await RefundTransaction.create({
+      swapId: 'swap',
+      symbol: 'BTC',
+      id: 'tx',
+      vin: 123,
+      status,
+    });
+    expect(tx.isFinal).toBe(expected);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new property to refund transactions that indicates when a refund is finalized.

* **Bug Fixes**
  * Improved error handling for self payments involving refunded transactions.

* **Tests**
  * Introduced integration tests for refund transaction finality.
  * Added unit tests for self payment logic when handling refunded transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->