### PR TITLE
feat: prevent allowing refunds when swap has pending HTLCs

### DIFF
--- a/lib/lightning/LightningClient.ts
+++ b/lib/lightning/LightningClient.ts
@@ -31,6 +31,10 @@ type NodeInfo = {
   };
 };
 
+type Htlcs = {
+  preimageHash: Buffer;
+};
+
 type ChannelInfo = {
   remotePubkey: string;
   private: boolean;
@@ -40,6 +44,7 @@ type ChannelInfo = {
   capacity: number;
   localBalance: number;
   remoteBalance: number;
+  htlcs: Htlcs[];
 };
 
 type HopHint = {

--- a/lib/lightning/LndClient.ts
+++ b/lib/lightning/LndClient.ts
@@ -814,6 +814,9 @@ class LndClient extends BaseClient<EventTypes> implements LightningClient {
         remotePubkey: chan.remotePubkey,
         localBalance: chan.localBalance,
         remoteBalance: chan.remoteBalance,
+        htlcs: chan.pendingHtlcsList.map((htlc) => ({
+          preimageHash: Buffer.from(htlc.hashLock),
+        })),
       };
     });
   };

--- a/lib/lightning/cln/ClnClient.ts
+++ b/lib/lightning/cln/ClnClient.ts
@@ -314,6 +314,9 @@ class ClnClient
           localBalance: msatToSat(chan.getSpendableMsat()!.getMsat()),
           remoteBalance: msatToSat(chan.getReceivableMsat()!.getMsat()),
           remotePubkey: getHexString(Buffer.from(chan.getPeerId_asU8())),
+          htlcs: chan.getHtlcsList().map((htlc) => ({
+            preimageHash: Buffer.from(htlc.getPaymentHash_asU8()),
+          })),
         };
       });
   };

--- a/lib/swap/NodeSwitch.ts
+++ b/lib/swap/NodeSwitch.ts
@@ -115,16 +115,20 @@ class NodeSwitch {
     );
   };
 
-  public static hasClient = (currency: Currency, type?: NodeType): boolean => {
-    return [currency.lndClient, currency.clnClient].some(
-      (client?: LightningClient) => {
-        if (type !== undefined) {
-          return client?.type === type;
-        }
-
-        return client !== undefined;
-      },
+  public static getClients = (currency: Currency): LightningClient[] => {
+    return [currency.lndClient, currency.clnClient].filter(
+      (client) => client !== undefined,
     );
+  };
+
+  public static hasClient = (currency: Currency, type?: NodeType): boolean => {
+    return NodeSwitch.getClients(currency).some((client) => {
+      if (type !== undefined) {
+        return client?.type === type;
+      }
+
+      return client !== undefined;
+    });
   };
 
   public updateClnThresholds = (

--- a/test/unit/service/cooperative/MusigSigner.spec.ts
+++ b/test/unit/service/cooperative/MusigSigner.spec.ts
@@ -1,0 +1,80 @@
+import { randomBytes } from 'crypto';
+import Logger from '../../../../lib/Logger';
+import type LndClient from '../../../../lib/lightning/LndClient';
+import type ClnClient from '../../../../lib/lightning/cln/ClnClient';
+import MusigSigner from '../../../../lib/service/cooperative/MusigSigner';
+import type SwapNursery from '../../../../lib/swap/SwapNursery';
+import type WalletManager from '../../../../lib/wallet/WalletManager';
+import type { Currency } from '../../../../lib/wallet/WalletManager';
+
+describe('MusigSigner', () => {
+  const btcCurrency = {
+    lndClient: {} as unknown as LndClient,
+    clnClient: {} as unknown as ClnClient,
+  };
+
+  const currencies = new Map<string, Currency>([
+    ['BTC', btcCurrency as Currency],
+  ]);
+
+  const signer = new MusigSigner(
+    Logger.disabledLogger,
+    currencies,
+    {} as unknown as WalletManager,
+    {} as unknown as SwapNursery,
+  );
+
+  describe('hasPendingHtlcs', () => {
+    const hasPendingHtlcs = signer['hasPendingHtlcs'];
+
+    test('should return false when there are no pending HTLCs', async () => {
+      btcCurrency.lndClient.listChannels = jest.fn().mockResolvedValue([]);
+      btcCurrency.clnClient.listChannels = jest.fn().mockResolvedValue([]);
+
+      await expect(hasPendingHtlcs('BTC', randomBytes(32))).resolves.toEqual(
+        false,
+      );
+    });
+
+    test('should return true when there are pending HTLCs', async () => {
+      const preimageHash = randomBytes(32);
+
+      btcCurrency.lndClient.listChannels = jest
+        .fn()
+        .mockResolvedValue([{ htlcs: [{ preimageHash }] }]);
+      btcCurrency.clnClient.listChannels = jest
+        .fn()
+        .mockResolvedValue([{ htlcs: [{ preimageHash }] }]);
+
+      await expect(hasPendingHtlcs('BTC', preimageHash)).resolves.toEqual(true);
+    });
+
+    test('should return true when LND has pending HTLCs', async () => {
+      const preimageHash = randomBytes(32);
+
+      btcCurrency.lndClient.listChannels = jest
+        .fn()
+        .mockResolvedValue([{ htlcs: [{ preimageHash }] }]);
+      btcCurrency.clnClient.listChannels = jest.fn().mockResolvedValue([]);
+
+      await expect(hasPendingHtlcs('BTC', preimageHash)).resolves.toEqual(true);
+    });
+
+    test('should return true when CLN has pending HTLCs', async () => {
+      const preimageHash = randomBytes(32);
+
+      btcCurrency.lndClient.listChannels = jest.fn().mockResolvedValue([]);
+      btcCurrency.clnClient.listChannels = jest
+        .fn()
+        .mockResolvedValue([{ htlcs: [{ preimageHash }] }]);
+
+      await expect(hasPendingHtlcs('BTC', preimageHash)).resolves.toEqual(true);
+    });
+
+    test('should return false when currency is undefined', async () => {
+      await expect(
+        hasPendingHtlcs('unknown', randomBytes(32)),
+      ).resolves.toEqual(false);
+    });
+  });
+});

--- a/test/unit/swap/NodeSwitch.spec.ts
+++ b/test/unit/swap/NodeSwitch.spec.ts
@@ -353,6 +353,16 @@ describe('NodeSwitch', () => {
   );
 
   test.each`
+    currency                    | expected
+    ${{}}                       | ${[]}
+    ${{ lndClient }}            | ${[lndClient]}
+    ${{ clnClient }}            | ${[clnClient]}
+    ${{ lndClient, clnClient }} | ${[lndClient, clnClient]}
+  `('should get clients', ({ currency, expected }) => {
+    expect(NodeSwitch.getClients(currency)).toEqual(expected);
+  });
+
+  test.each`
     has      | currency         | type
     ${true}  | ${currency}      | ${undefined}
     ${true}  | ${{ lndClient }} | ${undefined}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel information now includes details about active and pending HTLCs (Hashed Time-Locked Contracts), providing enhanced visibility into channel states.
  * Refunds are now blocked if there are pending HTLCs associated with a swap, adding an extra layer of safety.

* **Refactor**
  * Improved internal logic for managing and retrieving Lightning clients, streamlining client handling.

* **Tests**
  * Added and updated integration and unit tests to cover new HTLC-related logic and refund precondition checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->