### PR TITLE
feat: blocked domains for webhooks

### DIFF
--- a/boltzr/src/config.rs
+++ b/boltzr/src/config.rs
@@ -299,6 +299,7 @@ providerEndpoint = "http://127.0.0.1:8545"
                     retry_interval: Some(60),
                     request_timeout: None,
                     max_retries: None,
+                    block_list: None,
                 }),
                 api: crate::api::Config {
                     host: "127.0.0.1".to_string(),

--- a/boltzr/src/currencies.rs
+++ b/boltzr/src/currencies.rs
@@ -48,6 +48,7 @@ pub async fn connect_nodes<K: KeysHelper>(
     liquid: Option<LiquidConfig>,
     db: Pool,
     cache: Cache,
+    webhook_block_list: Option<Vec<String>>,
 ) -> anyhow::Result<(wallet::Network, Currencies, OfferSubscriptions)> {
     let mnemonic = match mnemonic_path {
         Some(path) => fs::read_to_string(path)?,
@@ -103,6 +104,7 @@ pub async fn connect_nodes<K: KeysHelper>(
                                         &currency.symbol,
                                         network,
                                         &config,
+                                        webhook_block_list.clone(),
                                         offer_helper.clone(),
                                         reverse_swap_helper.clone(),
                                         offer_subscriptions.clone(),

--- a/boltzr/src/grpc/service.rs
+++ b/boltzr/src/grpc/service.rs
@@ -360,7 +360,7 @@ where
         debug!("Adding new WebHook for swap {}", params.id);
         trace!("Adding WebHook: {:#?}", params);
 
-        if let Err(err) = crate::webhook::caller::validate_url(
+        if let Err(err) = self.web_hook_status_caller.validate_url(
             &params.url,
             self.manager.get_network() == crate::wallet::Network::Regtest,
         ) {

--- a/boltzr/src/lightning/cln/invoice_fetcher.rs
+++ b/boltzr/src/lightning/cln/invoice_fetcher.rs
@@ -44,6 +44,10 @@ impl InvoiceFetcher {
         }
     }
 
+    pub fn validate_url(&self, url: &str, allow_http: bool) -> anyhow::Result<()> {
+        self.invoice_caller.validate_url(url, allow_http)
+    }
+
     pub async fn fetch_invoice(
         &self,
         offer: Offer,

--- a/boltzr/src/lightning/cln/mod.rs
+++ b/boltzr/src/lightning/cln/mod.rs
@@ -51,12 +51,14 @@ pub struct Cln {
 }
 
 impl Cln {
+    #[allow(clippy::too_many_arguments)]
     #[instrument(
         name = "Cln::new",
         skip(
             cancellation_token,
             network,
             config,
+            webhook_block_list,
             offer_helper,
             reverse_swap_helper,
             offer_subscriptions
@@ -67,6 +69,7 @@ impl Cln {
         symbol: &str,
         network: wallet::Network,
         config: &Config,
+        webhook_block_list: Option<Vec<String>>,
         offer_helper: Arc<dyn OfferHelper + Send + Sync + 'static>,
         reverse_swap_helper: Arc<dyn ReverseSwapHelper + Send + Sync + 'static>,
         offer_subscriptions: OfferSubscriptions,
@@ -97,6 +100,7 @@ impl Cln {
                 symbol,
                 network,
                 &config.hold,
+                webhook_block_list,
                 cln.clone(),
                 offer_helper.clone(),
                 offer_subscriptions,
@@ -369,6 +373,7 @@ pub mod test {
                         .to_string(),
                 },
             },
+            None,
             Arc::new(offer_helper),
             Arc::new(reverse_swap_helper),
             OfferSubscriptions::new(crate::wallet::Network::Regtest),

--- a/boltzr/src/main.rs
+++ b/boltzr/src/main.rs
@@ -154,6 +154,12 @@ async fn main() {
         config.liquid,
         db_pool.clone(),
         cache.clone(),
+        config
+            .sidecar
+            .webhook
+            .as_ref()
+            .map(|w| w.block_list.clone())
+            .unwrap_or_default(),
     )
     .await
     {
@@ -224,11 +230,7 @@ async fn main() {
 
     let web_hook_status_caller = webhook::status_caller::StatusCaller::new(
         cancellation_token.clone(),
-        config.sidecar.webhook.unwrap_or(webhook::caller::Config {
-            request_timeout: None,
-            max_retries: None,
-            retry_interval: None,
-        }),
+        config.sidecar.webhook.unwrap_or_default(),
         network == wallet::Network::Regtest,
         db::helpers::web_hook::WebHookHelperDatabase::new(db_pool.clone()),
     );

--- a/boltzr/src/webhook/invoice_caller.rs
+++ b/boltzr/src/webhook/invoice_caller.rs
@@ -165,6 +165,10 @@ impl InvoiceCaller {
 
         Ok(res)
     }
+
+    pub fn validate_url(&self, url: &str, allow_http: bool) -> anyhow::Result<()> {
+        self.caller.validate_url(url, allow_http)
+    }
 }
 
 #[cfg(test)]

--- a/boltzr/src/webhook/status_caller.rs
+++ b/boltzr/src/webhook/status_caller.rs
@@ -45,6 +45,10 @@ impl StatusCaller {
         });
         self.caller.call_webhook(hook, data).await
     }
+
+    pub fn validate_url(&self, url: &str, allow_http: bool) -> anyhow::Result<()> {
+        self.caller.validate_url(url, allow_http)
+    }
 }
 
 #[cfg(test)]
@@ -55,11 +59,7 @@ pub mod test {
     pub fn new_caller(cancellation_token: CancellationToken) -> StatusCaller {
         StatusCaller::new(
             cancellation_token,
-            Config {
-                request_timeout: None,
-                max_retries: None,
-                retry_interval: None,
-            },
+            Config::default(),
             true,
             WebHookHelperDatabase::new(get_pool()),
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for blocking specific webhook URLs using a configurable block list. URLs containing blocked substrings will now be rejected.
  * Introduced new error messages for blocked URLs in webhook configuration.

* **Improvements**
  * Enhanced URL validation across webhook and invoice handling to respect the new block list.
  * Updated configuration options to allow specifying a block list for webhooks.
  * Improved test coverage for URL blocking and validation logic.

* **Refactor**
  * Streamlined method signatures and internal handling of webhook URL validation for better maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->