### PR TITLE
fix: add database triggers for preimage hash uniqueness checks

### DIFF
--- a/boltzr/migrations/2025-07-15-210514_preimage_hash_trigger/down.sql
+++ b/boltzr/migrations/2025-07-15-210514_preimage_hash_trigger/down.sql
@@ -1,0 +1,15 @@
+DROP TRIGGER IF EXISTS trigger_check_preimage_on_chain_swaps ON "chainSwaps";
+
+DROP TRIGGER IF EXISTS trigger_check_preimage_on_reverse_swaps ON "reverseSwaps";
+
+DROP TRIGGER IF EXISTS trigger_check_preimage_on_swaps ON swaps;
+
+DROP FUNCTION IF EXISTS check_reverse_chain_swap_preimage_uniqueness();
+
+DROP FUNCTION IF EXISTS check_submarine_swap_preimage_uniqueness();
+
+DROP TABLE IF EXISTS "chainSwaps";
+
+DROP TABLE IF EXISTS "reverseSwaps";
+
+DROP TABLE IF EXISTS swaps;

--- a/boltzr/migrations/2025-07-15-210514_preimage_hash_trigger/up.sql
+++ b/boltzr/migrations/2025-07-15-210514_preimage_hash_trigger/up.sql
@@ -1,0 +1,61 @@
+-- Minimum viable tables for preimage hash uniqueness check. Currently, the real swap tables are created and managed by typescript code
+CREATE TABLE IF NOT EXISTS swaps (
+    id VARCHAR(255) PRIMARY KEY,
+    "preimageHash" VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "reverseSwaps" (
+    id VARCHAR(255) PRIMARY KEY,
+    "preimageHash" VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "chainSwaps" (
+    id VARCHAR(255) PRIMARY KEY,
+    "preimageHash" VARCHAR(64) NOT NULL
+);
+
+-- Preimage hash uniqueness trigger functions and triggers
+CREATE OR REPLACE FUNCTION check_submarine_swap_preimage_uniqueness()
+RETURNS TRIGGER AS $$
+DECLARE
+    _preimage_hash TEXT := NEW."preimageHash";
+BEGIN
+    IF
+        EXISTS(SELECT 1 FROM swaps WHERE "preimageHash" = _preimage_hash) OR
+        EXISTS(SELECT 1 FROM "chainSwaps" WHERE "preimageHash" = _preimage_hash)
+    THEN
+        RAISE EXCEPTION 'SWAP_WITH_PREIMAGE_EXISTS';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION check_reverse_chain_swap_preimage_uniqueness()
+RETURNS TRIGGER AS $$
+DECLARE
+    _preimage_hash TEXT := NEW."preimageHash";
+BEGIN
+    IF
+        EXISTS(SELECT 1 FROM swaps WHERE "preimageHash" = _preimage_hash) OR
+        EXISTS(SELECT 1 FROM "reverseSwaps" WHERE "preimageHash" = _preimage_hash) OR
+        EXISTS(SELECT 1 FROM "chainSwaps" WHERE "preimageHash" = _preimage_hash)
+    THEN
+        RAISE EXCEPTION 'SWAP_WITH_PREIMAGE_EXISTS';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_check_preimage_on_swaps
+BEFORE INSERT ON swaps
+FOR EACH ROW EXECUTE FUNCTION check_submarine_swap_preimage_uniqueness();
+
+CREATE TRIGGER trigger_check_preimage_on_reverse_swaps
+BEFORE INSERT ON "reverseSwaps"
+FOR EACH ROW EXECUTE FUNCTION check_reverse_chain_swap_preimage_uniqueness();
+
+CREATE TRIGGER trigger_check_preimage_on_chain_swaps
+BEFORE INSERT ON "chainSwaps"
+FOR EACH ROW EXECUTE FUNCTION check_reverse_chain_swap_preimage_uniqueness();

--- a/boltzr/src/db/helpers/mod.rs
+++ b/boltzr/src/db/helpers/mod.rs
@@ -5,6 +5,7 @@ use diesel::sql_types::{Bool, Nullable};
 pub mod chain_swap;
 pub mod keys;
 pub mod offer;
+pub mod preimage_hash_triggers;
 pub mod referral;
 pub mod refund_transaction;
 pub mod reverse_swap;

--- a/boltzr/src/db/helpers/preimage_hash_triggers.rs
+++ b/boltzr/src/db/helpers/preimage_hash_triggers.rs
@@ -1,0 +1,142 @@
+#[cfg(test)]
+mod tests {
+    use crate::db::helpers::web_hook::test::get_pool;
+    use alloy::hex;
+    use diesel::RunQueryDsl;
+    use diesel::result::Error as DieselError;
+    use diesel::sql_query;
+    use rand::RngCore;
+
+    fn generate_random_preimage_hash() -> String {
+        let mut entropy_bytes = [0u8; 32];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut entropy_bytes);
+        hex::encode(entropy_bytes)
+    }
+
+    fn insert_swap<Conn>(conn: &mut Conn, preimage_hash: &str) -> Result<usize, DieselError>
+    where
+        Conn: diesel::Connection<Backend = diesel::pg::Pg>,
+    {
+        let sql = format!(
+            r#"INSERT INTO swaps (
+                id, "preimageHash"
+            ) VALUES (
+                'test_swap_{preimage_hash}', '{preimage_hash}'
+            )"#
+        );
+        sql_query(&sql).execute(conn)
+    }
+
+    fn insert_reverse_swap<Conn>(conn: &mut Conn, preimage_hash: &str) -> Result<usize, DieselError>
+    where
+        Conn: diesel::Connection<Backend = diesel::pg::Pg>,
+    {
+        let sql = format!(
+            r#"INSERT INTO "reverseSwaps" (
+                id, "preimageHash"
+            ) VALUES (
+                'test_reverse_{preimage_hash}', '{preimage_hash}'
+            )"#
+        );
+        sql_query(&sql).execute(conn)
+    }
+
+    fn insert_chain_swap<Conn>(conn: &mut Conn, preimage_hash: &str) -> Result<usize, DieselError>
+    where
+        Conn: diesel::Connection<Backend = diesel::pg::Pg>,
+    {
+        let sql = format!(
+            r#"INSERT INTO "chainSwaps" (
+                id, "preimageHash"
+            ) VALUES (
+                'test_chain_{preimage_hash}', '{preimage_hash}'
+            )"#
+        );
+        sql_query(&sql).execute(conn)
+    }
+
+    fn assert_duplicate_preimage_error(result: Result<usize, DieselError>) {
+        assert!(
+            result.is_err(),
+            "Expected error due to duplicate preimageHash, but operation succeeded"
+        );
+
+        let error = result.unwrap_err();
+        if let DieselError::DatabaseError(_, info) = error {
+            let error_msg = info.message();
+            assert!(
+                error_msg.contains("SWAP_WITH_PREIMAGE_EXISTS"),
+                "Error should contain SWAP_WITH_PREIMAGE_EXISTS, got: {error_msg}"
+            );
+        } else {
+            panic!("Expected DatabaseError, but got: {error:?}");
+        }
+    }
+
+    #[test]
+    fn test_submarine_swap_prevents_duplicates_in_other_tables() {
+        let pool = get_pool();
+        let mut conn = pool.get().unwrap();
+        let test_preimage_hash = generate_random_preimage_hash();
+
+        insert_swap(&mut conn, &test_preimage_hash).expect("Should insert first swap successfully");
+
+        let result = insert_reverse_swap(&mut conn, &test_preimage_hash);
+        assert_duplicate_preimage_error(result);
+
+        let result = insert_chain_swap(&mut conn, &test_preimage_hash);
+        assert_duplicate_preimage_error(result);
+    }
+
+    #[test]
+    fn test_reverse_then_swap_succeeds() {
+        let pool = get_pool();
+        let mut conn = pool.get().unwrap();
+        let preimage_hash = generate_random_preimage_hash();
+
+        insert_reverse_swap(&mut conn, &preimage_hash).expect("Should insert reverse swap first");
+
+        insert_swap(&mut conn, &preimage_hash)
+            .expect("Should succeed - submarine swaps don't check against reverse swaps");
+    }
+
+    #[test]
+    fn test_chain_swap_prevents_submarine_swap_duplicate() {
+        let pool = get_pool();
+        let mut conn = pool.get().unwrap();
+        let test_preimage_hash = generate_random_preimage_hash();
+
+        insert_chain_swap(&mut conn, &test_preimage_hash)
+            .expect("Should insert chain swap successfully");
+
+        let result = insert_swap(&mut conn, &test_preimage_hash);
+        assert_duplicate_preimage_error(result);
+    }
+
+    #[test]
+    fn test_chain_swap_prevents_reverse_swap_duplicate() {
+        let pool = get_pool();
+        let mut conn = pool.get().unwrap();
+        let test_preimage_hash = generate_random_preimage_hash();
+
+        insert_chain_swap(&mut conn, &test_preimage_hash)
+            .expect("Should insert chain swap successfully");
+
+        let result = insert_reverse_swap(&mut conn, &test_preimage_hash);
+        assert_duplicate_preimage_error(result);
+    }
+
+    #[test]
+    fn test_reverse_swap_prevents_chain_swap_duplicate() {
+        let pool = get_pool();
+        let mut conn = pool.get().unwrap();
+        let test_preimage_hash = generate_random_preimage_hash();
+
+        insert_reverse_swap(&mut conn, &test_preimage_hash)
+            .expect("Should insert reverse swap successfully");
+
+        let result = insert_chain_swap(&mut conn, &test_preimage_hash);
+        assert_duplicate_preimage_error(result);
+    }
+}

--- a/boltzr/src/db/helpers/web_hook.rs
+++ b/boltzr/src/db/helpers/web_hook.rs
@@ -161,7 +161,7 @@ pub mod test {
         POOL.get_or_init(|| {
             Mutex::new(
                 connect(Config {
-                    host: "127.0.0.2".to_string(),
+                    host: "127.0.0.1".to_string(),
                     port: 5432,
                     database: "boltz_test".to_string(),
                     username: "boltz".to_string(),

--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -63,6 +63,10 @@ class Database {
         password: postgresConfig.password,
         dialect: 'postgres',
         logging: this.logger.silly,
+        retry: {
+          max: 3,
+          match: ['40001'],
+        },
       });
     } else {
       if (!isTest) {

--- a/lib/db/repositories/ReverseSwapRepository.ts
+++ b/lib/db/repositories/ReverseSwapRepository.ts
@@ -1,6 +1,7 @@
 import type { Order, WhereOptions } from 'sequelize';
-import { Op } from 'sequelize';
+import { Op, Transaction } from 'sequelize';
 import { SwapUpdateEvent } from '../../consts/Enums';
+import Database from '../Database';
 import type { ReverseSwapType } from '../models/ReverseSwap';
 import ReverseSwap from '../models/ReverseSwap';
 
@@ -48,7 +49,14 @@ class ReverseSwapRepository {
   public static addReverseSwap = (
     reverseSwap: ReverseSwapType,
   ): Promise<ReverseSwap> => {
-    return ReverseSwap.create(reverseSwap);
+    return Database.sequelize.transaction(
+      {
+        isolationLevel: Transaction.ISOLATION_LEVELS.SERIALIZABLE,
+      },
+      async (transaction) => {
+        return await ReverseSwap.create(reverseSwap, { transaction });
+      },
+    );
   };
 
   public static setInvoiceSettled = (

--- a/test/unit/notifications/CommandHandler.spec.ts
+++ b/test/unit/notifications/CommandHandler.spec.ts
@@ -213,15 +213,13 @@ describe('CommandHandler', () => {
       quote: 'BTC',
     });
 
-    await Promise.all([
-      SwapRepository.addSwap(swapExample),
-      SwapRepository.addSwap(pendingSwapExample),
+    await SwapRepository.addSwap(swapExample);
+    await SwapRepository.addSwap(pendingSwapExample);
 
-      ReverseSwapRepository.addReverseSwap(reverseSwapExample),
-      ReverseSwapRepository.addReverseSwap(pendingReverseSwapExample),
+    await ReverseSwapRepository.addReverseSwap(reverseSwapExample);
+    await ReverseSwapRepository.addReverseSwap(pendingReverseSwapExample);
 
-      SwapRepository.addSwap(channelSwapExample),
-    ]);
+    await SwapRepository.addSwap(channelSwapExample);
 
     await ChannelCreationRepository.addChannelCreation(channelCreationExample);
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced uniqueness of preimage hashes across swap-related records to prevent duplicate entries.

* **Bug Fixes**
  * Improved database transaction handling for swap operations, reducing the risk of conflicts and ensuring data consistency.

* **Tests**
  * Added comprehensive tests to verify preimage hash uniqueness constraints across all swap tables.

* **Chores**
  * Updated database retry logic for better handling of serialization errors.
  * Adjusted test database configuration for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->