### PR TITLE
docs: enable search detailed view

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,6 +11,9 @@ export default defineConfig({
     logo: '/assets/logo.svg',
     search: {
       provider: 'local',
+      options: {
+        detailedView: true,
+      },
     },
     nav: [{ text: '🏠 Docs Home', link: docsRoot, target: '_self' }],
     sidebar: [


### PR DESCRIPTION
Changing default search view from:
<img width="1131" height="435" alt="image" src="https://github.com/user-attachments/assets/78a7eb46-3e96-4e81-a3e2-9099e35315a5" />

To:
<img width="1131" height="757" alt="image" src="https://github.com/user-attachments/assets/f4d301d6-289c-45a4-b9b8-337430391941" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced local search with a detailed view mode for search results in the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->