### PR TITLE
Fix missing parsing of referral id in createChain

### DIFF
--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -2152,7 +2152,6 @@ class SwapRouter extends RouterBase {
       webhook,
       pairHash,
       extraFees,
-      referralId,
       preimageHash,
       claimAddress,
       claimPublicKey,
@@ -2166,13 +2165,13 @@ class SwapRouter extends RouterBase {
       { name: 'preimageHash', type: 'string', hex: true },
       { name: 'pairHash', type: 'string', optional: true },
       { name: 'extraFees', type: 'object', optional: true },
-      { name: 'referralId', type: 'string', optional: true },
       { name: 'claimAddress', type: 'string', optional: true },
       { name: 'userLockAmount', type: 'number', optional: true },
       { name: 'serverLockAmount', type: 'number', optional: true },
       { name: 'claimPublicKey', type: 'string', hex: true, optional: true },
       { name: 'refundPublicKey', type: 'string', hex: true, optional: true },
     ]);
+    const referralId = parseReferralId(req);
 
     checkPreimageHashLength(preimageHash);
     const webHookData = this.parseWebHook(webhook);

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -1773,6 +1773,44 @@ describe('SwapRouter', () => {
     });
   });
 
+  test('should create chain swaps with referralId in URL query', async () => {
+    const reqBody = {
+      to: 'L-BTC',
+      from: 'BTC',
+      pairHash: 'pHash',
+      userLockAmount: 123,
+      claimPublicKey: '21',
+      claimAddress: '0x123',
+      serverLockAmount: 321,
+      refundPublicKey: '12',
+      preimageHash: getHexString(randomBytes(32)),
+    };
+    const referralId = 'partner';
+
+    const res = mockResponse();
+
+    await swapRouter['createChain'](
+      mockRequest(reqBody, {
+        referralId,
+      }),
+      res,
+    );
+
+    expect(service.createChainSwap).toHaveBeenCalledTimes(1);
+    expect(service.createChainSwap).toHaveBeenCalledWith({
+      referralId,
+      pairId: 'L-BTC/BTC',
+      orderSide: OrderSide.BUY,
+      pairHash: reqBody.pairHash,
+      claimAddress: reqBody.claimAddress,
+      userLockAmount: reqBody.userLockAmount,
+      serverLockAmount: reqBody.serverLockAmount,
+      preimageHash: getHexBuffer(reqBody.preimageHash),
+      claimPublicKey: getHexBuffer(reqBody.claimPublicKey),
+      refundPublicKey: getHexBuffer(reqBody.refundPublicKey),
+    });
+  });
+
   test('should 404 when getting transactions of chain swap that does not exist', async () => {
     ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
 


### PR DESCRIPTION
Setting the referral id on chain swaps through a query parameter was being ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of referral information during swap creation for greater consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->