### PR TITLE
fix: swap rescue key drift

### DIFF
--- a/boltzr/src/service/rescue.rs
+++ b/boltzr/src/service/rescue.rs
@@ -21,6 +21,10 @@ use tracing::{debug, instrument, trace};
 const DERIVATION_PATH: &str = "m/44/0/0/0";
 const GAP_LIMIT: u64 = 50;
 
+trait Identifiable {
+    fn id(&self) -> &str;
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct TreeLeaf {
     pub version: u64,
@@ -233,6 +237,12 @@ pub struct RescuableSwap {
     pub preimage_hash: String,
 }
 
+impl Identifiable for RescuableSwap {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+}
+
 impl TryFrom<(&Swap, u64, String, Option<String>)> for RescuableSwap {
     type Error = anyhow::Error;
 
@@ -322,6 +332,12 @@ pub struct RestorableSwap {
     pub claim_details: Option<ClaimDetails>,
     #[serde(rename = "refundDetails", skip_serializing_if = "Option::is_none")]
     pub refund_details: Option<SwapDetailsBase>,
+}
+
+impl Identifiable for RestorableSwap {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
 }
 
 impl TryFrom<(&Swap, u64, String, Option<String>)> for RestorableSwap {
@@ -444,6 +460,7 @@ impl SwapRescue {
         process: F,
     ) -> Result<Vec<R>>
     where
+        R: Identifiable,
         F: Fn(
             &Self,
             &HashMap<String, u64>,
@@ -459,7 +476,8 @@ impl SwapRescue {
             DERIVATION_PATH
         };
 
-        let mut result = Vec::new();
+        let mut result = HashMap::new();
+        let mut keys_map = HashMap::new();
 
         for from in (0..).step_by(GAP_LIMIT as usize) {
             let to = from + GAP_LIMIT;
@@ -471,8 +489,7 @@ impl SwapRescue {
                 xpub.identifier().to_string()
             );
 
-            let keys_map = Self::derive_keys(&secp, xpub, derivation_path, from, to)?;
-            let keys = keys_map.keys().map(|k| Some(k.clone())).collect::<Vec<_>>();
+            let keys = Self::derive_keys(&secp, &mut keys_map, xpub, derivation_path, from, to)?;
 
             let mut swaps = Vec::new();
             let mut chain_swaps = Vec::new();
@@ -519,19 +536,16 @@ impl SwapRescue {
                     result.len(),
                 );
 
-                return Ok(result);
+                return Ok(result.into_values().collect());
             }
 
-            result.append(&mut process(
-                self,
-                &keys_map,
-                swaps,
-                chain_swaps,
-                reverse_swaps,
-            )?);
+            for swap in process(self, &keys_map, swaps, chain_swaps, reverse_swaps)? {
+                // The map deduplicates for us
+                result.insert(swap.id().to_string(), swap);
+            }
         }
 
-        Ok(result)
+        Ok(result.into_values().collect())
     }
 
     fn process_rescuable_swaps(
@@ -554,12 +568,6 @@ impl SwapRescue {
         rescuable.append(
             &mut chain_swaps
                 .into_iter()
-                .filter(|s| {
-                    if let Some(their_public_key) = &s.receiving().theirPublicKey {
-                        return keys_map.contains_key(their_public_key);
-                    }
-                    false
-                })
                 .map(|s| self.create_rescuable_chain_swap(&secp, keys_map, s))
                 .collect::<Result<Vec<RescuableSwap>>>()?,
         );
@@ -587,12 +595,6 @@ impl SwapRescue {
         restorable.append(
             &mut chain_swaps
                 .into_iter()
-                .filter(|s| {
-                    if let Some(their_public_key) = &s.receiving().theirPublicKey {
-                        return keys_map.contains_key(their_public_key);
-                    }
-                    false
-                })
                 .map(|s| self.create_restorable_chain_swap(&secp, keys_map, s))
                 .collect::<Result<Vec<RestorableSwap>>>()?,
         );
@@ -617,7 +619,7 @@ impl SwapRescue {
 
         (
             &s,
-            Self::lookup_from_keys(keys_map, s.refundPublicKey.clone(), &s.id)?,
+            Self::lookup_from_keys(keys_map, &s.refundPublicKey, &s.id)?,
             Self::derive_our_public_key(secp, &wallet, &s.id(), s.keyIndex)?,
             Self::derive_blinding_key(&wallet, &s.id, &s.chain_symbol()?, &s.lockupAddress)?,
         )
@@ -634,7 +636,7 @@ impl SwapRescue {
 
         (
             &s,
-            Self::lookup_from_keys(keys_map, s.receiving().theirPublicKey.clone(), &s.id())?,
+            Self::lookup_from_keys(keys_map, &s.receiving().theirPublicKey, &s.id())?,
             Self::derive_our_public_key(secp, &wallet, &s.id(), s.receiving().keyIndex)?,
             Self::derive_blinding_key(
                 &wallet,
@@ -656,14 +658,9 @@ impl SwapRescue {
 
         (
             &s,
-            Self::lookup_from_keys(keys_map, s.refundPublicKey.clone(), &s.id)?,
+            Self::lookup_from_keys(keys_map, &s.refundPublicKey, &s.id)?,
             Self::derive_our_public_key(secp, &wallet, &s.id(), s.keyIndex)?,
-            Self::derive_blinding_key(
-                &wallet,
-                &s.id,
-                &s.chain_symbol()?,
-                &s.lockupAddress.clone(),
-            )?,
+            Self::derive_blinding_key(&wallet, &s.id, &s.chain_symbol()?, &s.lockupAddress)?,
         )
             .try_into()
     }
@@ -684,7 +681,7 @@ impl SwapRescue {
             claim_details: Some(
                 (
                     &s,
-                    Self::lookup_from_keys(keys_map, s.sending().theirPublicKey.clone(), &s.id())?,
+                    Self::lookup_from_keys(keys_map, &s.sending().theirPublicKey, &s.id())?,
                     Self::derive_our_public_key(
                         secp,
                         &sending_wallet,
@@ -703,11 +700,7 @@ impl SwapRescue {
             refund_details: Some(
                 (
                     s.receiving(),
-                    Self::lookup_from_keys(
-                        keys_map,
-                        s.receiving().theirPublicKey.clone(),
-                        &s.id(),
-                    )?,
+                    Self::lookup_from_keys(keys_map, &s.receiving().theirPublicKey, &s.id())?,
                     Self::derive_our_public_key(
                         secp,
                         &receiving_wallet,
@@ -736,14 +729,9 @@ impl SwapRescue {
 
         (
             &s,
-            Self::lookup_from_keys(keys_map, s.claimPublicKey.clone(), &s.id())?,
+            Self::lookup_from_keys(keys_map, &s.claimPublicKey, &s.id())?,
             Self::derive_our_public_key(secp, &wallet, &s.id(), s.keyIndex)?,
-            Self::derive_blinding_key(
-                &wallet,
-                &s.id,
-                &s.chain_symbol()?,
-                &s.lockupAddress.clone(),
-            )?,
+            Self::derive_blinding_key(&wallet, &s.id, &s.chain_symbol()?, &s.lockupAddress)?,
         )
             .try_into()
     }
@@ -789,22 +777,32 @@ impl SwapRescue {
         )))
     }
 
-    fn lookup_from_keys(keys: &HashMap<String, u64>, key: Option<String>, id: &str) -> Result<u64> {
+    fn lookup_from_keys(
+        keys: &HashMap<String, u64>,
+        key: &Option<String>,
+        id: &str,
+    ) -> Result<u64> {
         Ok(*keys
-            .get(&key.ok_or_else(|| anyhow!("no public key for {}", id))?)
+            .get(
+                key.as_ref()
+                    .ok_or_else(|| anyhow!("no public key for {}", id))?,
+            )
             .ok_or_else(|| anyhow!("no key mapping for {}", id))?)
     }
 
     fn derive_keys<C: secp256k1::Verification>(
         secp: &Secp256k1<C>,
+        keys: &mut HashMap<String, u64>,
         xpub: &Xpub,
         derivation_path: &str,
         start: u64,
         end: u64,
-    ) -> Result<HashMap<String, u64>> {
-        let mut map = HashMap::new();
+    ) -> Result<Vec<String>> {
+        let mut result = Vec::new();
 
-        for i in start..end {
+        // Add extra keys to the map to avoid keys not being found because of the gap limit
+        // for swaps with multiple keys
+        for i in start..(end + (end - start)) {
             let key = xpub
                 .derive_pub(
                     secp,
@@ -812,10 +810,16 @@ impl SwapRescue {
                 )
                 .map(|derived| derived.public_key)?;
 
-            map.insert(hex::encode(key.serialize()), i);
+            let key = hex::encode(key.serialize());
+
+            keys.insert(key.clone(), i);
+
+            if i < end {
+                result.push(key);
+            }
         }
 
-        Ok(map)
+        Ok(result)
     }
 }
 
@@ -1352,7 +1356,7 @@ mod test {
         assert_eq!(
             SwapRescue::lookup_from_keys(
                 &HashMap::from([(key.to_string(), 21)]),
-                Some(key.to_string()),
+                &Some(key.to_string()),
                 ""
             )
             .unwrap(),
@@ -1364,7 +1368,7 @@ mod test {
     fn test_lookup_from_keys_no_key() {
         let id = "adsf";
         assert_eq!(
-            SwapRescue::lookup_from_keys(&HashMap::new(), None, id)
+            SwapRescue::lookup_from_keys(&HashMap::new(), &None, id)
                 .err()
                 .unwrap()
                 .to_string(),
@@ -1376,7 +1380,7 @@ mod test {
     fn test_lookup_from_keys_no_mapping() {
         let id = "adsf";
         assert_eq!(
-            SwapRescue::lookup_from_keys(&HashMap::new(), Some("".to_string()), id)
+            SwapRescue::lookup_from_keys(&HashMap::new(), &Some("".to_string()), id)
                 .err()
                 .unwrap()
                 .to_string(),
@@ -1387,8 +1391,11 @@ mod test {
     #[test]
     fn test_derive_keys() {
         let xpub = Xpub::from_str("xpub661MyMwAqRbcGXPykvqCkK3sspTv2iwWTYpY9gBewku5Noj96ov1EqnKMDzGN9yPsncpRoUymJ7zpJ7HQiEtEC9Af2n3DmVu36TSV4oaiym").unwrap();
-        let keys = SwapRescue::derive_keys(
+
+        let mut keys = HashMap::new();
+        let keys_vec = SwapRescue::derive_keys(
             &Secp256k1::verification_only(),
+            &mut keys,
             &xpub,
             DERIVATION_PATH,
             0,
@@ -1396,12 +1403,23 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(keys.len(), 10);
+        assert_eq!(keys.len(), 20);
+        assert_eq!(keys_vec.len(), 10);
+
+        assert_eq!(
+            keys_vec[0],
+            "025964821780625d20ba1af21a45b203a96dcc5986c75c2d43bdc873d224810b0c"
+        );
         assert_eq!(
             *keys
                 .get("025964821780625d20ba1af21a45b203a96dcc5986c75c2d43bdc873d224810b0c")
                 .unwrap(),
             0
+        );
+
+        assert_eq!(
+            keys_vec[1],
+            "03f00262509d6c450463b293dedf06ccb472d160325debdb97fae58b05f0863cf0"
         );
         assert_eq!(
             *keys
@@ -1409,16 +1427,50 @@ mod test {
                 .unwrap(),
             1
         );
+
+        let keys_vec = SwapRescue::derive_keys(
+            &Secp256k1::verification_only(),
+            &mut keys,
+            &xpub,
+            DERIVATION_PATH,
+            11,
+            12,
+        )
+        .unwrap();
+
+        assert_eq!(keys.len(), 20);
+        assert_eq!(keys_vec.len(), 1);
+
+        assert_eq!(
+            keys_vec[0],
+            "02a21f37434b4f5b9e53c8401b75a078e5f6fb797c6d29feb8d9fbf980e6320b3b"
+        );
+        assert_eq!(
+            *keys
+                .get("02a21f37434b4f5b9e53c8401b75a078e5f6fb797c6d29feb8d9fbf980e6320b3b")
+                .unwrap(),
+            11
+        );
     }
 
     #[test]
     fn test_derive_keys_custom_path() {
         let xpub = Xpub::from_str("xpub661MyMwAqRbcGXPykvqCkK3sspTv2iwWTYpY9gBewku5Noj96ov1EqnKMDzGN9yPsncpRoUymJ7zpJ7HQiEtEC9Af2n3DmVu36TSV4oaiym").unwrap();
-        let keys =
-            SwapRescue::derive_keys(&Secp256k1::verification_only(), &xpub, "m/45/1/0/0", 0, 10)
-                .unwrap();
 
-        assert_eq!(keys.len(), 10);
+        let mut keys = HashMap::new();
+        let keys_vec = SwapRescue::derive_keys(
+            &Secp256k1::verification_only(),
+            &mut keys,
+            &xpub,
+            "m/45/1/0/0",
+            0,
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(keys.len(), 20);
+        assert_eq!(keys_vec.len(), 10);
+
         assert_eq!(
             *keys
                 .get("0331369109fbd305f2fdd1a0babc5a6bc629bed7aa987b4472526c2be520ed3457")

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -1698,6 +1698,22 @@ class SwapRouter extends RouterBase {
      *         derivationPath:
      *           type: string
      *           description: Derivation path to use for the rescue. Defaults to m/44/0/0/0
+     */
+
+    /**
+     * @openapi
+     * components:
+     *   schemas:
+     *     Transaction:
+     *       type: object
+     *       required: ["id", "hex"]
+     *       properties:
+     *         id:
+     *           type: string
+     *           description: ID of the transaction
+     *         hex:
+     *           type: string
+     *           description: The transaction encoded as HEX
      *
      *     RescuableSwap:
      *       type: object
@@ -1737,16 +1753,7 @@ class SwapRouter extends RouterBase {
      *           type: string
      *           description: Lockup address of the Swap
      *         transaction:
-     *           type: object
-     *           description: Lockup transaction of the Swap
-     *           required: ["id", "hex"]
-     *           properties:
-     *             id:
-     *               type: string
-     *               description: ID of the transaction
-     *             hex:
-     *               type: string
-     *               description: The transaction encoded as HEX
+     *           $ref: '#/components/schemas/Transaction'
      *         createdAt:
      *           type: number
      *           description: UNIX timestamp of the creation of the Swap
@@ -1754,10 +1761,100 @@ class SwapRouter extends RouterBase {
 
     /**
      * @openapi
+     * components:
+     *   schemas:
+     *     RestoreClaimDetails:
+     *       type: object
+     *       required: ["tree", "keyIndex", "lockupAddress", "serverPublicKey", "timeoutBlockHeight", "preimageHash"]
+     *       properties:
+     *         tree:
+     *           $ref: '#/components/schemas/SwapTree'
+     *         amount:
+     *           type: number
+     *           description: Amount of the swap
+     *         keyIndex:
+     *           type: number
+     *           description: Derivation index for the claim key used in the swap
+     *         transaction:
+     *           $ref: '#/components/schemas/Transaction'
+     *         lockupAddress:
+     *           type: string
+     *           description: Address in which coins are locked
+     *         serverPublicKey:
+     *           type: string
+     *           description: Public key of the server
+     *         timeoutBlockHeight:
+     *           type: number
+     *           description: Block height at which the HTLC will time out
+     *         blindingKey:
+     *           type: string
+     *           description: Blinding key of the lockup address. Only set when the chain is Liquid
+     *         preimageHash:
+     *           type: string
+     *           description: Hash of the preimage required to claim the swap
+     *
+     *     RestoreRefundDetails:
+     *       type: object
+     *       required: ["tree", "keyIndex", "lockupAddress", "serverPublicKey", "timeoutBlockHeight"]
+     *       properties:
+     *         tree:
+     *           $ref: '#/components/schemas/SwapTree'
+     *         amount:
+     *           type: number
+     *           description: Amount of the swap
+     *         keyIndex:
+     *           type: number
+     *           description: Derivation index for the refund key used in the swap
+     *         transaction:
+     *           $ref: '#/components/schemas/Transaction'
+     *         lockupAddress:
+     *           type: string
+     *           description: Address in which coins are locked
+     *         serverPublicKey:
+     *           type: string
+     *           description: Public key of the server
+     *         timeoutBlockHeight:
+     *           type: number
+     *           description: Block height at which the HTLC will time out
+     *         blindingKey:
+     *           type: string
+     *           description: Blinding key of the lockup address. Only set when the chain is Liquid
+     *
+     *     RestorableSwap:
+     *       type: object
+     *       required: ["id", "type", "status", "createdAt", "from", "to"]
+     *       properties:
+     *         id:
+     *           type: string
+     *           description: ID of the Swap
+     *         type:
+     *           type: string
+     *           enum: ["submarine", "reverse", "chain"]
+     *           description: Type of the Swap
+     *         status:
+     *           type: string
+     *           description: Status of the Swap
+     *         createdAt:
+     *           type: number
+     *           description: UNIX timestamp of the creation of the Swap
+     *         from:
+     *           type: string
+     *           description: Asset the client is supposed to send
+     *         to:
+     *           type: string
+     *           description: Asset the client is supposed to receive
+     *         claimDetails:
+     *           $ref: '#/components/schemas/RestoreClaimDetails'
+     *         refundDetails:
+     *           $ref: '#/components/schemas/RestoreRefundDetails'
+     */
+
+    /**
+     * @openapi
      * /swap/rescue:
      *   post:
      *     tags: [Swap]
-     *     description: Rescue swaps that were created with an XPUB
+     *     description: Rescue swaps that were created with an XPUB. Use when trying to refund a swap for which all information was lost
      *     requestBody:
      *       required: true
      *       content:
@@ -1773,6 +1870,29 @@ class SwapRouter extends RouterBase {
      *               type: array
      *               items:
      *                 $ref: '#/components/schemas/RescuableSwap'
+     */
+
+    /**
+     * @openapi
+     * /swap/restore:
+     *   post:
+     *     tags: [Swap]
+     *     description: Restore swaps that were created with an XPUB. Use when trying to refund or claim a swap for which all information was lost
+     *     requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             $ref: '#/components/schemas/RescueRequest'
+     *     responses:
+     *       '200':
+     *         description: List of swaps that can be restored
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: array
+     *               items:
+     *                 $ref: '#/components/schemas/RestorableSwap'
      */
 
     return router;

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -2868,7 +2868,7 @@
         "tags": [
           "Swap"
         ],
-        "description": "Rescue swaps that were created with an XPUB",
+        "description": "Rescue swaps that were created with an XPUB. Use when trying to refund a swap for which all information was lost",
         "requestBody": {
           "required": true,
           "content": {
@@ -2888,6 +2888,39 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/RescuableSwap"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/swap/restore": {
+      "post": {
+        "tags": [
+          "Swap"
+        ],
+        "description": "Restore swaps that were created with an XPUB. Use when trying to refund or claim a swap for which all information was lost",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RescueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of swaps that can be restored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RestorableSwap"
                   }
                 }
               }
@@ -4093,6 +4126,23 @@
           }
         }
       },
+      "Transaction": {
+        "type": "object",
+        "required": [
+          "id",
+          "hex"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the transaction"
+          },
+          "hex": {
+            "type": "string",
+            "description": "The transaction encoded as HEX"
+          }
+        }
+      },
       "RescuableSwap": {
         "type": "object",
         "required": [
@@ -4157,26 +4207,148 @@
             "description": "Lockup address of the Swap"
           },
           "transaction": {
-            "type": "object",
-            "description": "Lockup transaction of the Swap",
-            "required": [
-              "id",
-              "hex"
-            ],
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "ID of the transaction"
-              },
-              "hex": {
-                "type": "string",
-                "description": "The transaction encoded as HEX"
-              }
-            }
+            "$ref": "#/components/schemas/Transaction"
           },
           "createdAt": {
             "type": "number",
             "description": "UNIX timestamp of the creation of the Swap"
+          }
+        }
+      },
+      "RestoreClaimDetails": {
+        "type": "object",
+        "required": [
+          "tree",
+          "keyIndex",
+          "lockupAddress",
+          "serverPublicKey",
+          "timeoutBlockHeight",
+          "preimageHash"
+        ],
+        "properties": {
+          "tree": {
+            "$ref": "#/components/schemas/SwapTree"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Amount of the swap"
+          },
+          "keyIndex": {
+            "type": "number",
+            "description": "Derivation index for the claim key used in the swap"
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/Transaction"
+          },
+          "lockupAddress": {
+            "type": "string",
+            "description": "Address in which coins are locked"
+          },
+          "serverPublicKey": {
+            "type": "string",
+            "description": "Public key of the server"
+          },
+          "timeoutBlockHeight": {
+            "type": "number",
+            "description": "Block height at which the HTLC will time out"
+          },
+          "blindingKey": {
+            "type": "string",
+            "description": "Blinding key of the lockup address. Only set when the chain is Liquid"
+          },
+          "preimageHash": {
+            "type": "string",
+            "description": "Hash of the preimage required to claim the swap"
+          }
+        }
+      },
+      "RestoreRefundDetails": {
+        "type": "object",
+        "required": [
+          "tree",
+          "keyIndex",
+          "lockupAddress",
+          "serverPublicKey",
+          "timeoutBlockHeight"
+        ],
+        "properties": {
+          "tree": {
+            "$ref": "#/components/schemas/SwapTree"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Amount of the swap"
+          },
+          "keyIndex": {
+            "type": "number",
+            "description": "Derivation index for the refund key used in the swap"
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/Transaction"
+          },
+          "lockupAddress": {
+            "type": "string",
+            "description": "Address in which coins are locked"
+          },
+          "serverPublicKey": {
+            "type": "string",
+            "description": "Public key of the server"
+          },
+          "timeoutBlockHeight": {
+            "type": "number",
+            "description": "Block height at which the HTLC will time out"
+          },
+          "blindingKey": {
+            "type": "string",
+            "description": "Blinding key of the lockup address. Only set when the chain is Liquid"
+          }
+        }
+      },
+      "RestorableSwap": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "status",
+          "createdAt",
+          "from",
+          "to"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the Swap"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "submarine",
+              "reverse",
+              "chain"
+            ],
+            "description": "Type of the Swap"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the Swap"
+          },
+          "createdAt": {
+            "type": "number",
+            "description": "UNIX timestamp of the creation of the Swap"
+          },
+          "from": {
+            "type": "string",
+            "description": "Asset the client is supposed to send"
+          },
+          "to": {
+            "type": "string",
+            "description": "Asset the client is supposed to receive"
+          },
+          "claimDetails": {
+            "$ref": "#/components/schemas/RestoreClaimDetails"
+          },
+          "refundDetails": {
+            "$ref": "#/components/schemas/RestoreRefundDetails"
           }
         }
       }


### PR DESCRIPTION
Chain swaps which have two keys (claim and rescue) could error when one of their keys was in a lookup batch but the other was not (eg, batch size 50; claim key is index 49 but the refund one index 50)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to restore swaps created with an XPUB, enabling swap history recovery.
  * Introduced detailed schemas for restorations, including claim and refund details.
* **Improvements**
  * Enhanced swap handling with uniform ID access and deduplication.
  * Extended key derivation range for improved key coverage.
  * Updated API documentation with clearer descriptions and schema references.
* **Bug Fixes**
  * Simplified and corrected swap filtering and key lookup logic.
* **Tests**
  * Updated tests to align with new key derivation behavior and method signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->