### PR TITLE
fix: Bump Liquid Taproot claim tx size

### DIFF
--- a/lib/rates/FeeProvider.ts
+++ b/lib/rates/FeeProvider.ts
@@ -97,7 +97,7 @@ class FeeProvider {
       [SwapVersion.Taproot]: {
         normalClaim: 181,
         reverseLockup: 269,
-        reverseClaim: 193,
+        reverseClaim: 221,
       },
       [SwapVersion.Legacy]: {
         normalClaim: 216,


### PR DESCRIPTION
Current byte size of 193 for Liquid tx assumes cooperative claim, with the fee budget of 20 sats. In rare edge cases when the client loses connection to the server during coop signing, such claims are executed unilaterally with preimage. The discounted vsize of the tx in such cases is 221 bytes. The fee of 20 sats prevents it from mining (must be at least 0.1 * discountVsize), unless the tx is broadcasted by the web app directly to Boltz's own elements node. But if the client fails to do that, his claim gets stuck, while the server receives its leg of the swap.

The web app cannot increase the fee of the claim without reducing the amount of sats that was promised in the beginning as the outcome of the swap. The solution is to bump the tx size assumption to 221 bytes, and therefore liquid claim fee to 23 sats, to account for this worst case scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transaction size calculation for certain Liquid Taproot swap operations to improve accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->