### PR TITLE
Harden ZMQ reconnect

### DIFF
--- a/boltzr/src/chain/chain_client.rs
+++ b/boltzr/src/chain/chain_client.rs
@@ -8,6 +8,7 @@ use crate::chain::types::{
 use crate::chain::utils::{Outpoint, Transaction};
 use crate::chain::zmq_client::{ZMQ_TX_CHANNEL_SIZE, ZmqClient};
 use crate::chain::{BaseClient, Client, Config};
+use crate::wallet::Network;
 use async_trait::async_trait;
 use std::collections::HashSet;
 use tokio::sync::broadcast::{Receiver, Sender, channel, error::RecvError};
@@ -44,6 +45,7 @@ impl ChainClient {
         cancellation_token: CancellationToken,
         cache: Cache,
         client_type: Type,
+        network: Network,
         symbol: String,
         config: Config,
     ) -> anyhow::Result<Self> {
@@ -55,7 +57,7 @@ impl ChainClient {
                 .mempool_space
                 .clone()
                 .map(|url| MempoolSpace::new(cancellation_token.clone(), symbol.clone(), url)),
-            zmq_client: ZmqClient::new(client_type, config),
+            zmq_client: ZmqClient::new(client_type, network, config),
             tx_sender: channel(ZMQ_TX_CHANNEL_SIZE).0,
         };
 
@@ -371,6 +373,7 @@ pub mod test {
             CancellationToken::new(),
             cache::Cache::Memory(cache::MemCache::new()),
             Type::Bitcoin,
+            Network::Regtest,
             "BTC".to_string(),
             Config {
                 host: "127.0.0.1".to_string(),

--- a/boltzr/src/chain/elements_client.rs
+++ b/boltzr/src/chain/elements_client.rs
@@ -37,6 +37,7 @@ impl ElementsClient {
             cancellation_token.clone(),
             cache.clone(),
             TYPE,
+            network,
             SYMBOL.to_string(),
             config.base,
         )?;
@@ -45,6 +46,7 @@ impl ElementsClient {
                 cancellation_token.clone(),
                 cache,
                 TYPE,
+                network,
                 SYMBOL.to_string(),
                 lowball_config,
             )?),
@@ -139,7 +141,7 @@ impl Client for ElementsClient {
     fn zero_conf_safe(&self, transaction: &Transaction) -> oneshot::Receiver<bool> {
         if self.network == Network::Regtest {
             let (tx, rx) = oneshot::channel();
-            tx.send(true).unwrap();
+            let _ = tx.send(true);
             return rx;
         }
 

--- a/boltzr/src/chain/zmq_client.rs
+++ b/boltzr/src/chain/zmq_client.rs
@@ -1,27 +1,36 @@
-use crate::chain::{
-    Config,
-    types::{Type, ZmqNotification},
-    utils::Transaction,
+use crate::{
+    chain::{
+        Config,
+        types::{Type, ZmqNotification},
+        utils::Transaction,
+    },
+    wallet::Network,
 };
 use tokio::sync::broadcast::{self, Sender};
-use tracing::{debug, error, warn};
-use zeromq::{Socket, SocketRecv, ZmqError, ZmqMessage};
+use tokio::time::{Duration, timeout};
+use tracing::{debug, error, info, warn};
+use zeromq::{Socket, SocketRecv, SubSocket, ZmqError, ZmqMessage};
 
 pub const ZMQ_TX_CHANNEL_SIZE: usize = 1024 * 16;
+
+const ZMQ_INACTIVITY_TIMEOUT_SECONDS: u64 = 60;
+const ZMQ_RECONNECT_DELAY_SECONDS: u64 = 1;
 
 #[derive(Debug, Clone)]
 pub struct ZmqClient {
     client_type: Type,
+    network: Network,
     config: Config,
     pub tx_sender: Sender<Transaction>,
 }
 
 impl ZmqClient {
-    pub fn new(client_type: Type, config: Config) -> ZmqClient {
+    pub fn new(client_type: Type, network: Network, config: Config) -> ZmqClient {
         let (tx_sender, _) = broadcast::channel::<Transaction>(ZMQ_TX_CHANNEL_SIZE);
 
         ZmqClient {
             client_type,
+            network,
             config,
             tx_sender,
         }
@@ -70,26 +79,62 @@ impl ZmqClient {
         F: Fn(ZmqMessage) + Send + 'static,
     {
         let address = self.replace_zmq_address_wildcard(&notification.address);
-        debug!(
-            "Connecting to {} {} ZMQ at {}",
-            subscription, self.client_type, address
-        );
 
-        let mut socket = zeromq::SubSocket::new();
-        socket.connect(&address).await?;
+        let mut socket = self.create_socket(&address, subscription).await?;
 
-        socket.subscribe(subscription).await?;
+        let subscription = subscription.to_string();
 
+        let self_cp = self.clone();
         tokio::spawn(async move {
             loop {
-                match socket.recv().await {
-                    Ok(recv) => {
-                        handler(recv);
+                // On regtest we don't need inactivity timeouts
+                let duration = Duration::from_secs(if self_cp.network != Network::Regtest {
+                    ZMQ_INACTIVITY_TIMEOUT_SECONDS
+                } else {
+                    u64::MAX
+                });
+
+                loop {
+                    match timeout(duration, socket.recv()).await {
+                        Ok(Ok(recv)) => {
+                            handler(recv);
+                        }
+                        Ok(Err(e)) => {
+                            error!(
+                                "ZMQ {} {subscription} error receiving data: {e}",
+                                self_cp.client_type
+                            );
+                            break;
+                        }
+                        Err(_) => {
+                            warn!(
+                                "ZMQ {} {subscription} timed out after {:?} of inactivity",
+                                self_cp.client_type, duration
+                            );
+                            break;
+                        }
                     }
-                    Err(e) => {
-                        error!("Error receiving data: {}", e);
-                        break;
-                    }
+                }
+
+                loop {
+                    let reconnect_delay = Duration::from_secs(ZMQ_RECONNECT_DELAY_SECONDS);
+                    info!(
+                        "ZMQ {} {subscription} disconnected; reconnecting in {:?}",
+                        self_cp.client_type, reconnect_delay
+                    );
+                    tokio::time::sleep(reconnect_delay).await;
+
+                    socket = match self_cp.create_socket(&address, &subscription).await {
+                        Ok(socket) => socket,
+                        Err(e) => {
+                            error!(
+                                "ZMQ {} {subscription} error reconnecting: {e}",
+                                self_cp.client_type
+                            );
+                            continue;
+                        }
+                    };
+                    break;
                 }
             }
         });
@@ -99,6 +144,23 @@ impl ZmqClient {
 
     fn replace_zmq_address_wildcard(&self, address: &str) -> String {
         address.replace("0.0.0.0", &self.config.host)
+    }
+
+    async fn create_socket(
+        &self,
+        address: &str,
+        subscription: &str,
+    ) -> Result<SubSocket, ZmqError> {
+        debug!(
+            "Connecting to {subscription} {} ZMQ: {address}",
+            self.client_type
+        );
+
+        let mut socket = SubSocket::new();
+        socket.connect(address).await?;
+        socket.subscribe(subscription).await?;
+
+        Ok(socket)
     }
 
     fn find_notification(

--- a/boltzr/src/currencies.rs
+++ b/boltzr/src/currencies.rs
@@ -78,6 +78,7 @@ pub async fn connect_nodes<K: KeysHelper>(
                         cancellation_token.clone(),
                         cache.clone(),
                         crate::chain::types::Type::Bitcoin,
+                        network,
                         currency.symbol.clone(),
                         config,
                     ))

--- a/lib/Boltz.ts
+++ b/lib/Boltz.ts
@@ -146,6 +146,12 @@ class Boltz {
       })
       .filter((manager): manager is EthereumManager => manager !== undefined);
 
+    this.sidecar = new Sidecar(
+      this.logger,
+      this.config.sidecar,
+      this.config.datadir,
+    );
+
     this.currencies = this.parseCurrencies();
 
     const walletCurrencies = Array.from(this.currencies.values());
@@ -156,12 +162,6 @@ class Boltz {
       this.config.mnemonicpathEvm,
       walletCurrencies,
       this.ethereumManagers,
-    );
-
-    this.sidecar = new Sidecar(
-      this.logger,
-      this.config.sidecar,
-      this.config.datadir,
     );
 
     const notificationClient = new NotificationClient(
@@ -441,6 +441,8 @@ class Boltz {
       try {
         const chainClient = new ChainClient(
           this.logger,
+          this.sidecar,
+          currency.network,
           currency.chain,
           currency.symbol,
         );
@@ -520,7 +522,12 @@ class Boltz {
         type: CurrencyType.Liquid,
         symbol: symbol,
         network: LiquidNetworks[network],
-        chainClient: new ElementsWrapper(this.logger, chain),
+        chainClient: new ElementsWrapper(
+          this.logger,
+          this.sidecar,
+          network,
+          chain,
+        ),
         limits: {
           ...this.config.liquid,
         },

--- a/lib/chain/ChainClient.ts
+++ b/lib/chain/ChainClient.ts
@@ -18,8 +18,10 @@ import type {
   WalletTransaction,
 } from '../consts/Types';
 import ChainTipRepository from '../db/repositories/ChainTipRepository';
+import type Sidecar from '../sidecar/Sidecar';
 import MempoolSpace from './MempoolSpace';
 import Rebroadcaster from './Rebroadcaster';
+import Rescanner from './Rescanner';
 import RpcClient from './RpcClient';
 import type { SomeTransaction, ZmqNotification } from './ZmqClient';
 import ZmqClient, { filters } from './ZmqClient';
@@ -91,9 +93,10 @@ class ChainClient<T extends SomeTransaction = Transaction>
   public static readonly decimals = 100_000_000;
 
   public currencyType: CurrencyType = CurrencyType.BitcoinLike;
+  public isRegtest = false;
+  public zmqClient: ZmqClient<T>;
 
   protected client: RpcClient;
-  protected zmqClient: ZmqClient<T>;
   protected feeFloor = 2;
 
   private readonly mempoolSpace?: MempoolSpace;
@@ -101,14 +104,29 @@ class ChainClient<T extends SomeTransaction = Transaction>
 
   constructor(
     logger: Logger,
+    sidecar: Sidecar,
+    network: string,
     private readonly config: ChainConfig,
     symbol: string,
   ) {
     super(logger, symbol);
 
     this.client = new RpcClient(logger, symbol, this.config);
-    this.zmqClient = new ZmqClient(symbol, logger, this, config.host);
+    this.isRegtest = network.toLowerCase().includes('regtest');
+    this.zmqClient = new ZmqClient(
+      symbol,
+      logger,
+      this.isRegtest,
+      this,
+      config.host,
+    );
     this.rebroadcaster = new Rebroadcaster(this.logger, this);
+
+    const rescanner = new Rescanner(this.logger, this, sidecar);
+
+    this.zmqClient.on('reconnected', () => {
+      rescanner.rescan();
+    });
 
     if (this.config.mempoolSpace && this.config.mempoolSpace !== '') {
       this.mempoolSpace = new MempoolSpace(

--- a/lib/chain/ElementsClient.ts
+++ b/lib/chain/ElementsClient.ts
@@ -5,6 +5,7 @@ import type Logger from '../Logger';
 import { CurrencyType } from '../consts/Enums';
 import type { AddressInfo, LiquidBalances } from '../consts/LiquidTypes';
 import { liquidSymbol } from '../consts/LiquidTypes';
+import type Sidecar from '../sidecar/Sidecar';
 import type { AddressType, IChainClient } from './ChainClient';
 import ChainClient from './ChainClient';
 
@@ -32,10 +33,12 @@ class ElementsClient
 
   constructor(
     logger: Logger,
+    sidecar: Sidecar,
+    network: string,
     config: ChainConfig,
     public readonly isLowball = false,
   ) {
-    super(logger, config, ElementsClient.symbol);
+    super(logger, sidecar, network, config, ElementsClient.symbol);
     this.feeFloor = ElementsClient.feeFloor;
     this.currencyType = CurrencyType.Liquid;
   }

--- a/lib/chain/ElementsWrapper.ts
+++ b/lib/chain/ElementsWrapper.ts
@@ -6,6 +6,7 @@ import { allSettledFirst } from '../PromiseUtils';
 import { formatError } from '../Utils';
 import { CurrencyType } from '../consts/Enums';
 import type { MempoolAcceptResult, UnspentUtxo } from '../consts/Types';
+import type Sidecar from '../sidecar/Sidecar';
 import type { AddressType, ChainClientEvents } from './ChainClient';
 import type { IElementsClient, LiquidAddressType } from './ElementsClient';
 import ElementsClient from './ElementsClient';
@@ -22,14 +23,23 @@ class ElementsWrapper
 
   private readonly clients: ElementsClient[] = [];
 
-  constructor(logger: Logger, config: LiquidChainConfig) {
+  constructor(
+    logger: Logger,
+    sidecar: Sidecar,
+    network: string,
+    config: LiquidChainConfig,
+  ) {
     super(logger, ElementsClient.symbol);
 
-    this.clients.push(new ElementsClient(this.logger, config, false));
+    this.clients.push(
+      new ElementsClient(this.logger, sidecar, network, config, false),
+    );
 
     if (config.lowball !== undefined) {
       this.logger.info(`Using lowball for ${this.clients[0].serviceName()}`);
-      this.clients.push(new ElementsClient(this.logger, config.lowball, true));
+      this.clients.push(
+        new ElementsClient(this.logger, sidecar, network, config.lowball, true),
+      );
     }
 
     if (
@@ -40,6 +50,7 @@ class ElementsWrapper
     } else {
       this.zeroConfCheck = new TestMempoolAccept(
         this.logger,
+        this.clients[0].isRegtest,
         this.publicClient(),
         config.zeroConfWaitTime,
       );

--- a/lib/chain/Rescanner.ts
+++ b/lib/chain/Rescanner.ts
@@ -23,13 +23,12 @@ class Rescanner {
     }
 
     await this.lock.acquire(Rescanner.serviceName, async () => {
+      const height = this.chainClient.scannedHeight;
       this.logger.info(
-        `Rescanning ${this.chainClient.symbol} chain from height ${this.chainClient.zmqClient.blockHeight}`,
+        `Rescanning ${this.chainClient.symbol} chain from height ${height}`,
       );
 
-      await this.chainClient.rescanChain(
-        this.chainClient.zmqClient.blockHeight,
-      );
+      await this.chainClient.rescanChain(height);
       await this.sidecar.rescanMempool([this.chainClient.symbol]);
     });
   };

--- a/lib/chain/Rescanner.ts
+++ b/lib/chain/Rescanner.ts
@@ -1,0 +1,38 @@
+import AsyncLock from 'async-lock';
+import type Logger from '../Logger';
+import type Sidecar from '../sidecar/Sidecar';
+import type ChainClient from './ChainClient';
+
+class Rescanner {
+  private static readonly serviceName = 'rescan';
+
+  private readonly lock = new AsyncLock();
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly chainClient: ChainClient,
+    private readonly sidecar: Sidecar,
+  ) {}
+
+  public rescan = async () => {
+    if (this.lock.isBusy(Rescanner.serviceName)) {
+      this.logger.debug(
+        `Rescanning ${this.chainClient.symbol} is already in progress`,
+      );
+      return;
+    }
+
+    await this.lock.acquire(Rescanner.serviceName, async () => {
+      this.logger.info(
+        `Rescanning ${this.chainClient.symbol} chain from height ${this.chainClient.zmqClient.blockHeight}`,
+      );
+
+      await this.chainClient.rescanChain(
+        this.chainClient.zmqClient.blockHeight,
+      );
+      await this.sidecar.rescanMempool([this.chainClient.symbol]);
+    });
+  };
+}
+
+export default Rescanner;

--- a/lib/chain/ZmqClient.ts
+++ b/lib/chain/ZmqClient.ts
@@ -31,7 +31,7 @@ export type SomeTransaction = Transaction | LiquidTransaction;
 
 class ZmqClient<T extends SomeTransaction> extends TypedEventEmitter<{
   block: number;
-  reconnected: unknown;
+  reconnected: string;
   transaction: {
     transaction: T;
     confirmed: boolean;
@@ -42,7 +42,7 @@ class ZmqClient<T extends SomeTransaction> extends TypedEventEmitter<{
   // 1 minute
   private static readonly inactivityTimeoutMsTransaction = 60_000;
 
-  // Maximum value for an unsigned 32-bit integer which is the limit of Node.js
+  // Maximum value for a signed 32-bit integer (Node.js timer limit)
   private static readonly inactivityTimeoutMsRegtest = 2 ** 31 - 1;
 
   // IDs of transactions that contain a UTXOs of Boltz
@@ -415,7 +415,7 @@ class ZmqClient<T extends SomeTransaction> extends TypedEventEmitter<{
       inactivityTimeoutMs,
     );
     socket.on('reconnected', () => {
-      this.emit('reconnected', undefined);
+      this.emit('reconnected', filter);
     });
     this.sockets.push(socket);
     socket.connect();

--- a/lib/chain/ZmqSocket.ts
+++ b/lib/chain/ZmqSocket.ts
@@ -1,0 +1,107 @@
+import { Subscriber } from 'zeromq';
+import type Logger from '../Logger';
+import { sleep } from '../PromiseUtils';
+import { formatError } from '../Utils';
+import TypedEventEmitter from '../consts/TypedEventEmitter';
+
+class ZmqSocket extends TypedEventEmitter<{
+  data: Buffer;
+  reconnected: unknown;
+}> {
+  private static readonly reconnectTimeoutMs = 1_000;
+
+  private socket: Subscriber;
+  private disconnected = false;
+  private shouldReconnect = true;
+  private inactivityTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly symbol: string,
+    private readonly filter: string,
+    private readonly address: string,
+    private readonly inactivityTimeoutMs: number,
+  ) {
+    super();
+
+    this.socket = new Subscriber();
+  }
+
+  public connect = () => {
+    this.logger.debug(
+      `Connecting to ${this.symbol} ZMQ filter ${this.filter}: ${this.address}`,
+    );
+
+    this.socket = new Subscriber();
+    this.socket.connect(this.address);
+    this.socket.subscribe(this.filter);
+
+    this.resetInactivityTimer();
+    void this.listen();
+  };
+
+  public disconnect = () => {
+    this.logger.silly(
+      `Disconnecting ${this.symbol} ZMQ filter ${this.filter}: ${this.address}`,
+    );
+
+    this.shouldReconnect = false;
+    this.clearInactivityTimer();
+    this.socket.close();
+  };
+
+  private listen = async () => {
+    try {
+      for await (const [, data] of this.socket) {
+        this.resetInactivityTimer();
+        if (this.disconnected) {
+          this.logger.info(
+            `${this.symbol} ZMQ filter ${this.filter} reconnected on ${this.address}`,
+          );
+
+          this.disconnected = false;
+          this.emit('reconnected', undefined);
+        }
+
+        this.emit('data', data);
+      }
+    } finally {
+      this.clearInactivityTimer();
+    }
+  };
+
+  private clearInactivityTimer = () => {
+    if (this.inactivityTimer !== undefined) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = undefined;
+    }
+  };
+
+  private resetInactivityTimer = () => {
+    this.clearInactivityTimer();
+
+    this.inactivityTimer = setTimeout(async () => {
+      this.logger.warn(
+        `${this.symbol} ZMQ filter ${this.filter} inactive for ${this.inactivityTimeoutMs}ms on ${this.address}; reconnecting`,
+      );
+      this.disconnected = true;
+
+      try {
+        this.socket.close();
+      } catch (error) {
+        this.logger.debug(
+          `Error closing ${this.symbol} ZMQ socket (${this.filter} @ ${this.address}) after inactivity: ${formatError(error)}`,
+        );
+      }
+
+      await sleep(ZmqSocket.reconnectTimeoutMs);
+      if (!this.shouldReconnect) {
+        return;
+      }
+
+      this.connect();
+    }, this.inactivityTimeoutMs);
+  };
+}
+
+export default ZmqSocket;

--- a/lib/chain/ZmqSocket.ts
+++ b/lib/chain/ZmqSocket.ts
@@ -32,6 +32,8 @@ class ZmqSocket extends TypedEventEmitter<{
       `Connecting to ${this.symbol} ZMQ filter ${this.filter}: ${this.address}`,
     );
 
+    this.shouldReconnect = true;
+
     this.socket = new Subscriber();
     this.socket.connect(this.address);
     this.socket.subscribe(this.filter);

--- a/lib/chain/elements/TestMempoolAccept.ts
+++ b/lib/chain/elements/TestMempoolAccept.ts
@@ -6,7 +6,6 @@ import type ElementsClient from '../ElementsClient';
 import type { ZeroConfCheck } from './ZeroConfCheck';
 
 class TestMempoolAccept implements ZeroConfCheck {
-  private static readonly regtestChain = 'liquidregtest';
   private static readonly zeroConfCheckTimeDefault = 1_000;
   private static readonly zeroConfCheckAllowedErrors = [
     'min relay fee not met',
@@ -15,10 +14,9 @@ class TestMempoolAccept implements ZeroConfCheck {
 
   private readonly zeroConfCheckTime: number;
 
-  private isRegtest = false;
-
   constructor(
     private readonly logger: Logger,
+    private readonly isRegtest: boolean,
     private readonly publicClient: ElementsClient,
     zeroConfWaitTime?: number,
   ) {
@@ -34,9 +32,7 @@ class TestMempoolAccept implements ZeroConfCheck {
   }
 
   public init = async (): Promise<void> => {
-    const { chain } = await this.publicClient.getBlockchainInfo();
-    if (chain === TestMempoolAccept.regtestChain) {
-      this.isRegtest = true;
+    if (this.isRegtest) {
       this.logger.warn(
         'Elements chain is regtest; skipping 0-conf mempool acceptance check',
       );

--- a/test/integration/Nodes.ts
+++ b/test/integration/Nodes.ts
@@ -6,11 +6,14 @@ import ElementsClient from '../../lib/chain/ElementsClient';
 import Redis from '../../lib/db/Redis';
 import LndClient from '../../lib/lightning/LndClient';
 import ClnClient from '../../lib/lightning/cln/ClnClient';
+import type Sidecar from '../../lib/sidecar/Sidecar';
 
 const host = process.platform === 'win32' ? '192.168.99.100' : '127.0.0.1';
 
 export const bitcoinClient = new ChainClient(
   Logger.disabledLogger,
+  {} as unknown as Sidecar,
+  'bitcoinRegtest',
   {
     host,
     port: 18443,
@@ -28,6 +31,8 @@ export const elementsConfig = {
 };
 export const elementsClient = new ElementsClient(
   Logger.disabledLogger,
+  {} as unknown as Sidecar,
+  'liquidRegtest',
   elementsConfig,
 );
 

--- a/test/integration/chain/ElementsWrapper.spec.ts
+++ b/test/integration/chain/ElementsWrapper.spec.ts
@@ -3,15 +3,21 @@ import Logger from '../../../lib/Logger';
 import { sleep } from '../../../lib/PromiseUtils';
 import ElementsWrapper from '../../../lib/chain/ElementsWrapper';
 import { ClientStatus, CurrencyType } from '../../../lib/consts/Enums';
+import type Sidecar from '../../../lib/sidecar/Sidecar';
 import { elementsConfig } from '../Nodes';
 
 jest.mock('../../../lib/db/repositories/ChainTipRepository');
 
 describe('ElementsWrapper', () => {
-  const wrapper = new ElementsWrapper(Logger.disabledLogger, {
-    ...elementsConfig,
-    lowball: elementsConfig,
-  });
+  const wrapper = new ElementsWrapper(
+    Logger.disabledLogger,
+    {} as unknown as Sidecar,
+    'liquidRegtest',
+    {
+      ...elementsConfig,
+      lowball: elementsConfig,
+    },
+  );
 
   beforeAll(async () => {
     await wrapper.connect();
@@ -57,6 +63,8 @@ describe('ElementsWrapper', () => {
     test('should construct with just public node', () => {
       const oneWrapper = new ElementsWrapper(
         Logger.disabledLogger,
+        {} as unknown as Sidecar,
+        'liquidRegtest',
         elementsConfig,
       );
 
@@ -165,6 +173,8 @@ describe('ElementsWrapper', () => {
     test('should emit confirmed and unconfirmed transaction from public node if no lowball client is configued', async () => {
       const oneWrapper = new ElementsWrapper(
         Logger.disabledLogger,
+        {} as unknown as Sidecar,
+        'liquidRegtest',
         elementsConfig,
       );
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -322,6 +332,8 @@ describe('ElementsWrapper', () => {
     async ({ name }) => {
       const oneWrapper = new ElementsWrapper(
         Logger.disabledLogger,
+        {} as unknown as Sidecar,
+        'liquidRegtest',
         elementsConfig,
       );
       await oneWrapper.connect();

--- a/test/integration/chain/ElementsWrapper.spec.ts
+++ b/test/integration/chain/ElementsWrapper.spec.ts
@@ -170,7 +170,7 @@ describe('ElementsWrapper', () => {
       await sleep(wrapper['zeroConfCheckTime'] * 2);
     });
 
-    test('should emit confirmed and unconfirmed transaction from public node if no lowball client is configued', async () => {
+    test('should emit confirmed and unconfirmed transaction from public node if no lowball client is configured', async () => {
       const oneWrapper = new ElementsWrapper(
         Logger.disabledLogger,
         {} as unknown as Sidecar,

--- a/test/integration/chain/elements/TestMempoolAccept.spec.ts
+++ b/test/integration/chain/elements/TestMempoolAccept.spec.ts
@@ -21,7 +21,7 @@ describe('TestMempoolAccept', () => {
 
   test('should use default check time', async () => {
     expect(
-      new TestMempoolAccept(Logger.disabledLogger, elementsClient)[
+      new TestMempoolAccept(Logger.disabledLogger, true, elementsClient)[
         'zeroConfCheckTime'
       ],
     ).toEqual(TestMempoolAccept['zeroConfCheckTimeDefault']);
@@ -31,6 +31,7 @@ describe('TestMempoolAccept', () => {
     const checkTime = 1000;
     testMempoolAccept = new TestMempoolAccept(
       Logger.disabledLogger,
+      true,
       elementsClient,
       checkTime,
     );
@@ -57,6 +58,7 @@ describe('TestMempoolAccept', () => {
 
       const instance = new TestMempoolAccept(
         Logger.disabledLogger,
+        isRegtest,
         elementsClient,
       );
       await instance.init();
@@ -81,9 +83,9 @@ describe('TestMempoolAccept', () => {
 
       const instance = new TestMempoolAccept(
         Logger.disabledLogger,
+        true,
         elementsClient,
       );
-      instance['isRegtest'] = true;
 
       const result = await instance.checkTransaction(mockTransaction);
 
@@ -106,9 +108,9 @@ describe('TestMempoolAccept', () => {
 
       const instance = new TestMempoolAccept(
         Logger.disabledLogger,
+        false,
         elementsClient,
       );
-      instance['isRegtest'] = false;
 
       const result = await instance.checkTransaction(mockTransaction);
 
@@ -138,9 +140,9 @@ describe('TestMempoolAccept', () => {
 
         const instance = new TestMempoolAccept(
           Logger.disabledLogger,
+          false,
           elementsClient,
         );
-        instance['isRegtest'] = false;
 
         const result = await instance.checkTransaction(mockTransaction);
 
@@ -166,9 +168,9 @@ describe('TestMempoolAccept', () => {
 
       const instance = new TestMempoolAccept(
         Logger.disabledLogger,
+        false,
         elementsClient,
       );
-      instance['isRegtest'] = false;
 
       const result = await instance.checkTransaction(mockTransaction);
 

--- a/test/unit/chain/ChainClient.spec.ts
+++ b/test/unit/chain/ChainClient.spec.ts
@@ -2,6 +2,7 @@ import Logger from '../../../lib/Logger';
 import { getHexBuffer } from '../../../lib/Utils';
 import ChainClient from '../../../lib/chain/ChainClient';
 import ChainTipRepository from '../../../lib/db/repositories/ChainTipRepository';
+import type Sidecar from '../../../lib/sidecar/Sidecar';
 
 const relevantInputs = new Set<string>();
 const relevantOutputs = new Set<string>();
@@ -62,6 +63,8 @@ describe('ChainClient', () => {
 
   const chainClient = new ChainClient(
     Logger.disabledLogger,
+    {} as unknown as Sidecar,
+    'bitcoinRegtest',
     {
       host: '',
       port: 0,

--- a/test/unit/chain/ElementsClient.spec.ts
+++ b/test/unit/chain/ElementsClient.spec.ts
@@ -1,6 +1,7 @@
 import { Transaction } from 'liquidjs-lib';
 import Logger from '../../../lib/Logger';
 import ElementsClient from '../../../lib/chain/ElementsClient';
+import type Sidecar from '../../../lib/sidecar/Sidecar';
 
 describe('ElementsClient', () => {
   test.each`
@@ -12,6 +13,8 @@ describe('ElementsClient', () => {
     async ({ lowball, expected }) => {
       const client = new ElementsClient(
         Logger.disabledLogger,
+        {} as unknown as Sidecar,
+        'liquidRegtest',
         {
           host: '127.0.0.1',
           port: 123,

--- a/test/unit/chain/Rescanner.spec.ts
+++ b/test/unit/chain/Rescanner.spec.ts
@@ -1,0 +1,74 @@
+import Rescanner from '../../../lib/chain/Rescanner';
+
+describe('Rescanner', () => {
+  const symbol = 'BTC';
+  const blockHeight = 123;
+
+  let logger: any;
+  let chainClient: any;
+  let sidecar: any;
+
+  beforeEach(() => {
+    logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+    } as any;
+
+    chainClient = {
+      symbol,
+      zmqClient: { blockHeight },
+      rescanChain: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    sidecar = {
+      rescanMempool: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    jest.clearAllMocks();
+  });
+
+  test('should rescan chain from current height and rescan mempool', async () => {
+    const rescanner = new Rescanner(logger, chainClient, sidecar);
+
+    await rescanner.rescan();
+
+    expect(logger.info).toHaveBeenCalledWith(
+      `Rescanning ${symbol} chain from height ${blockHeight}`,
+    );
+
+    expect(chainClient.rescanChain).toHaveBeenCalledTimes(1);
+    expect(chainClient.rescanChain).toHaveBeenCalledWith(blockHeight);
+
+    expect(sidecar.rescanMempool).toHaveBeenCalledTimes(1);
+    expect(sidecar.rescanMempool).toHaveBeenCalledWith([symbol]);
+  });
+
+  test('should not start a new rescan if one is already in progress', async () => {
+    let resolveRescan: () => void;
+    const rescanPromise = new Promise<void>((resolve) => {
+      resolveRescan = resolve;
+    });
+
+    chainClient.rescanChain = jest.fn().mockImplementation(() => rescanPromise);
+
+    const rescanner = new Rescanner(logger, chainClient, sidecar);
+
+    const firstCall = rescanner.rescan();
+
+    await Promise.resolve();
+
+    await rescanner.rescan();
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      `Rescanning ${symbol} is already in progress`,
+    );
+
+    expect(chainClient.rescanChain).toHaveBeenCalledTimes(1);
+    expect(sidecar.rescanMempool).toHaveBeenCalledTimes(0);
+
+    resolveRescan!();
+    await firstCall;
+
+    expect(sidecar.rescanMempool).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/chain/Rescanner.spec.ts
+++ b/test/unit/chain/Rescanner.spec.ts
@@ -16,7 +16,7 @@ describe('Rescanner', () => {
 
     chainClient = {
       symbol,
-      zmqClient: { blockHeight },
+      scannedHeight: blockHeight,
       rescanChain: jest.fn().mockResolvedValue(undefined),
     } as any;
 

--- a/test/unit/chain/ZmqClient.spec.ts
+++ b/test/unit/chain/ZmqClient.spec.ts
@@ -1,9 +1,9 @@
 import { Transaction, crypto } from 'bitcoinjs-lib';
 import { OutputType } from 'boltz-core';
 import { randomBytes } from 'crypto';
-import type { Socket } from 'zeromq/v5-compat';
-import { socket as openSocket } from 'zeromq/v5-compat';
+import { Publisher } from 'zeromq';
 import Logger from '../../../lib/Logger';
+import { sleep } from '../../../lib/PromiseUtils';
 import { getHexString, reverseBuffer } from '../../../lib/Utils';
 import type ChainClient from '../../../lib/chain/ChainClient';
 import Errors from '../../../lib/chain/Errors';
@@ -21,20 +21,19 @@ import FakedChainClient from './FakeChainClient';
 class ZmqPublisher {
   public address: string;
 
-  private socket: Socket;
+  private socket: Publisher;
   private readonly filter: string;
 
   constructor(port: number, filter: string) {
     this.address = `tcp://127.0.0.1:${port}`;
     this.filter = filter.replace('pub', '');
 
-    this.socket = openSocket('pub');
+    this.socket = new Publisher();
   }
 
-  public bind = () =>
-    new Promise((resolve) => {
-      this.socket.bind(this.address, resolve);
-    });
+  public bind = async () => {
+    await this.socket.bind(this.address);
+  };
 
   public close = () => {
     this.socket.close();
@@ -100,6 +99,7 @@ describe('ZmqClient', () => {
     zmqClient.close();
 
     rawTx.close();
+    rawBlock.close();
     hashBlock.close();
   });
 
@@ -292,20 +292,10 @@ describe('ZmqClient', () => {
     expect(blockHeight).toEqual(reorgHeight + blocksToGenerate);
   });
 
-  test('should fallback to hashblock notifications', async () => {
-    rawBlock.close();
-
-    // Wait until there are three sockets in the ZmqClient which
-    // means that the client connected to the hashblock fallback
-    await waitForFunctionToBeTrue(() => {
-      return zmqClient['sockets'].length === 3;
-    });
-
-    // Wait a little longer to make sure the socket is connected
-    await wait(10);
-  });
-
   test('should handle hashblock notifications', async () => {
+    zmqClient['initHashBlock']();
+    await sleep(100);
+
     let blockHeight = 0;
 
     zmqClient.on('block', (height) => {
@@ -346,51 +336,6 @@ describe('ZmqClient', () => {
     });
 
     expect(blockHeight).toEqual(reorgHeight + blocksToGenerate);
-  });
-
-  test('should reject connecting to addresses that are not ZMQ publishers', async () => {
-    expect(ZmqClient['connectTimeout']).toEqual(1000);
-    const createSocket = zmqClient['createSocket'];
-
-    const filter = 'filter';
-
-    expect(zmqClient['sockets'].length).toEqual(3);
-
-    const invalidAddress = `tcp://127.0.0.1:${await getPort()}`;
-    await expect(createSocket(invalidAddress, filter)).rejects.toEqual(
-      Errors.ZMQ_CONNECTION_TIMEOUT(
-        zmqClient['symbol'],
-        filter,
-        invalidAddress,
-      ),
-    );
-
-    expect(zmqClient['sockets'].length).toEqual(3);
-    zmqClient.close();
-  });
-
-  test('should sanitize ZMQ addresses', async () => {
-    const zmqClient = new ZmqClient(
-      'BTC',
-      Logger.disabledLogger,
-      chainClient as unknown as ChainClient,
-      '127.0.0.1',
-    );
-
-    const address = `tcp://0.0.0.0:${await getPort()}`;
-    const filterName = 'name';
-
-    await expect(
-      zmqClient['createSocket'](address, filterName),
-    ).rejects.toEqual(
-      Errors.ZMQ_CONNECTION_TIMEOUT(
-        'BTC',
-        filterName,
-        address.replace('0.0.0.0', '127.0.0.1'),
-      ),
-    );
-
-    zmqClient.close();
   });
 
   test.each`

--- a/test/unit/chain/ZmqClient.spec.ts
+++ b/test/unit/chain/ZmqClient.spec.ts
@@ -80,6 +80,7 @@ describe('ZmqClient', () => {
   const zmqClient = new ZmqClient(
     'BTC',
     Logger.disabledLogger,
+    false,
     chainClient as unknown as ChainClient,
     '127.0.0.1',
   );
@@ -107,6 +108,7 @@ describe('ZmqClient', () => {
     const rejectZmqClient = new ZmqClient(
       'BTC',
       Logger.disabledLogger,
+      false,
       chainClient as unknown as ChainClient,
       '127.0.0.1',
     );
@@ -349,6 +351,7 @@ describe('ZmqClient', () => {
       const zmqClient = new ZmqClient(
         'BTC',
         Logger.disabledLogger,
+        false,
         chainClient as unknown as ChainClient,
         '127.0.0.1',
       );

--- a/test/unit/chain/ZmqSocket.spec.ts
+++ b/test/unit/chain/ZmqSocket.spec.ts
@@ -1,0 +1,102 @@
+import { Publisher } from 'zeromq';
+import Logger from '../../../lib/Logger';
+import { sleep } from '../../../lib/PromiseUtils';
+import ZmqSocket from '../../../lib/chain/ZmqSocket';
+import { getPort } from '../../Utils';
+
+describe('ZmqSocket', () => {
+  const filter = 'rawtx';
+
+  const createSocket = async () => {
+    const pub = new Publisher();
+    const port = await getPort();
+    const address = `tcp://127.0.0.1:${port}`;
+
+    await pub.bind(address);
+
+    return {
+      pub,
+      address,
+    };
+  };
+
+  test('should emit data', async () => {
+    const { address, pub } = await createSocket();
+
+    const socket = new ZmqSocket(
+      Logger.disabledLogger,
+      'BTC',
+      filter,
+      address,
+      5_000,
+    );
+
+    socket.connect();
+
+    const receivedPromise = new Promise<Buffer>((resolve) => {
+      socket.on('data', (data) => {
+        resolve(data);
+        socket.removeAllListeners();
+      });
+    });
+
+    await sleep(50);
+
+    const message = Buffer.from('test');
+    await pub.send([filter, message]);
+
+    expect(await receivedPromise).toEqual(message);
+
+    socket.disconnect();
+    pub.close();
+  });
+
+  test('should reconnect after inactivity', async () => {
+    const { address, pub } = await createSocket();
+
+    const inactivityTimeout = 1_000;
+    const socket = new ZmqSocket(
+      Logger.disabledLogger,
+      'BTC',
+      filter,
+      address,
+      inactivityTimeout,
+    );
+
+    socket.connect();
+
+    await sleep(inactivityTimeout + 100);
+
+    expect(socket['disconnected']).toBe(true);
+
+    await sleep(ZmqSocket['reconnectTimeoutMs'] - 10);
+
+    const dataPromise = new Promise<Buffer>((resolve) => {
+      socket.on('data', (data) => {
+        resolve(data);
+      });
+    });
+    const reconnectedPromise = new Promise<unknown>((resolve) => {
+      socket.on('reconnected', () => {
+        resolve(true);
+      });
+    });
+
+    const message = Buffer.from('test');
+
+    // Send some messages to make sure it reconnects
+    for (let i = 0; i < 10; i++) {
+      await pub.send([filter, message]);
+      await sleep(100);
+    }
+
+    expect(socket['disconnected']).toBe(false);
+
+    expect(await dataPromise).toEqual(message);
+    expect(await reconnectedPromise).toBe(true);
+
+    socket.removeAllListeners();
+    socket.disconnect();
+    pub.close();
+  });
+});


### PR DESCRIPTION
Closes #1036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network-aware chain clients with explicit regtest support; Sidecar integrated across chain components; rescans triggered on ZMQ reconnects.
* **Refactor**
  * Unified ZMQ handling via a new ZmqSocket/ZmqClient design with inactivity timeouts, automatic reconnects and clearer events.
* **Bug Fixes**
  * Zero-conf handling adjusted for regtest and safer send/error handling.
* **Tests**
  * Added/updated unit and integration tests for ZMQ sockets, reconnection, rescanning, and updated constructors to include Sidecar/network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->