### PR TITLE
fix: Bump ZMQ Inactivity Timeout

### DIFF
--- a/boltzr/src/chain/zmq_client.rs
+++ b/boltzr/src/chain/zmq_client.rs
@@ -13,7 +13,7 @@ use zeromq::{Socket, SocketRecv, SubSocket, ZmqError, ZmqMessage};
 
 pub const ZMQ_TX_CHANNEL_SIZE: usize = 1024 * 16;
 
-const ZMQ_INACTIVITY_TIMEOUT_SECONDS: u64 = 120;
+const ZMQ_INACTIVITY_TIMEOUT_SECONDS: u64 = 300;
 const ZMQ_RECONNECT_DELAY_SECONDS: u64 = 1;
 
 #[derive(Debug, Clone)]

--- a/boltzr/src/chain/zmq_client.rs
+++ b/boltzr/src/chain/zmq_client.rs
@@ -13,7 +13,7 @@ use zeromq::{Socket, SocketRecv, SubSocket, ZmqError, ZmqMessage};
 
 pub const ZMQ_TX_CHANNEL_SIZE: usize = 1024 * 16;
 
-const ZMQ_INACTIVITY_TIMEOUT_SECONDS: u64 = 60;
+const ZMQ_INACTIVITY_TIMEOUT_SECONDS: u64 = 120;
 const ZMQ_RECONNECT_DELAY_SECONDS: u64 = 1;
 
 #[derive(Debug, Clone)]

--- a/lib/chain/ZmqClient.ts
+++ b/lib/chain/ZmqClient.ts
@@ -40,7 +40,7 @@ class ZmqClient<T extends SomeTransaction> extends TypedEventEmitter<{
   // 1 hour
   private static readonly inactivityTimeoutMsBlock = 3_600_000;
   // 1 minute
-  private static readonly inactivityTimeoutMsTransaction = 60_000;
+  private static readonly inactivityTimeoutMsTransaction = 300_000;
 
   // Maximum value for a signed 32-bit integer (Node.js timer limit)
   private static readonly inactivityTimeoutMsRegtest = 2 ** 31 - 1;

--- a/lib/chain/ZmqClient.ts
+++ b/lib/chain/ZmqClient.ts
@@ -39,7 +39,7 @@ class ZmqClient<T extends SomeTransaction> extends TypedEventEmitter<{
 }> {
   // 1 hour
   private static readonly inactivityTimeoutMsBlock = 3_600_000;
-  // 1 minute
+  // 5 minutes
   private static readonly inactivityTimeoutMsTransaction = 300_000;
 
   // Maximum value for a signed 32-bit integer (Node.js timer limit)


### PR DESCRIPTION
Increase the timeout to 5 minutes. One minute was too short for Elements and caused false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the inactivity timeout for ZMQ subscriptions on non-Regtest networks to reduce unintended timeouts during low activity, improving stability of real-time updates. Regtest behavior is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->