### PR TITLE
chore: minor ZMQ cleanup

### DIFF
--- a/boltzr/src/chain/chain_client.rs
+++ b/boltzr/src/chain/chain_client.rs
@@ -158,7 +158,7 @@ impl BaseClient for ChainClient {
             .client
             .request::<Vec<ZmqNotification>>("getzmqnotifications", None)
             .await?;
-        self.zmq_client.connect(notifications).await?;
+        self.zmq_client.connect(&notifications).await?;
 
         if let Some(mempool_space) = &self.mempool_space {
             mempool_space.connect().await?;

--- a/boltzr/src/chain/types.rs
+++ b/boltzr/src/chain/types.rs
@@ -73,7 +73,7 @@ pub struct SmartFeeEstimate {
     pub feerate: f64,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct ZmqNotification {
     #[serde(rename = "type")]
     pub notification_type: String,

--- a/boltzr/src/chain/zmq_client.rs
+++ b/boltzr/src/chain/zmq_client.rs
@@ -36,23 +36,37 @@ impl ZmqClient {
         }
     }
 
-    pub async fn connect(&self, notifications: Vec<ZmqNotification>) -> anyhow::Result<()> {
-        let raw_tx = match Self::find_notification("pubrawtx", notifications.clone()) {
+    pub async fn connect(&self, notifications: &[ZmqNotification]) -> anyhow::Result<()> {
+        let raw_tx = match Self::find_notification("pubrawtx", notifications) {
             Some(data) => data,
             None => return Err(anyhow::anyhow!("pubrawtx ZMQ missing")),
+        };
+
+        // On regtest we don't need inactivity timeouts
+        let inactivity_timeout = if self.network != Network::Regtest {
+            Some(ZMQ_INACTIVITY_TIMEOUT_SECONDS)
+        } else {
+            None
         };
 
         let tx_sender = self.tx_sender.clone();
         let client_type = self.client_type;
 
-        self.subscribe(raw_tx, "rawtx", move |msg| {
+        self.subscribe(raw_tx, "rawtx", inactivity_timeout, move |msg| {
             // No need to send transactions if no one is listening
             if tx_sender.receiver_count() == 0 {
                 return;
             }
 
-            let tx_bytes = msg.get(1).unwrap().to_vec();
-            let tx: Transaction = match Transaction::parse(&client_type, &tx_bytes) {
+            let tx_bytes = match msg.get(1) {
+                Some(tx_bytes) => tx_bytes,
+                None => {
+                    warn!("{client_type} ZMQ client received a malformed message");
+                    return;
+                }
+            };
+
+            let tx = match Transaction::parse(&client_type, tx_bytes) {
                 Ok(tx) => tx,
                 Err(e) => {
                     warn!("{client_type} ZMQ client could not parse transaction: {e}");
@@ -71,8 +85,9 @@ impl ZmqClient {
 
     async fn subscribe<F>(
         &self,
-        notification: ZmqNotification,
+        notification: &ZmqNotification,
         subscription: &str,
+        inactivity_timeout: Option<u64>,
         handler: F,
     ) -> Result<(), ZmqError>
     where
@@ -83,33 +98,35 @@ impl ZmqClient {
         let mut socket = self.create_socket(&address, subscription).await?;
 
         let subscription = subscription.to_string();
-
         let self_cp = self.clone();
+
         tokio::spawn(async move {
             loop {
-                // On regtest we don't need inactivity timeouts
-                let duration = Duration::from_secs(if self_cp.network != Network::Regtest {
-                    ZMQ_INACTIVITY_TIMEOUT_SECONDS
-                } else {
-                    u64::MAX
-                });
+                let inactivity_timeout = inactivity_timeout.map(Duration::from_secs);
 
                 loop {
-                    match timeout(duration, socket.recv()).await {
-                        Ok(Ok(recv)) => {
-                            handler(recv);
+                    let recv_fut = socket.recv();
+                    let result = if let Some(dur) = inactivity_timeout {
+                        match timeout(dur, recv_fut).await {
+                            Ok(r) => r,
+                            Err(_) => {
+                                warn!(
+                                    "ZMQ {} {subscription} timed out after {:?} of inactivity",
+                                    self_cp.client_type, dur
+                                );
+                                break;
+                            }
                         }
-                        Ok(Err(e)) => {
+                    } else {
+                        recv_fut.await
+                    };
+
+                    match result {
+                        Ok(recv) => handler(recv),
+                        Err(e) => {
                             error!(
                                 "ZMQ {} {subscription} error receiving data: {e}",
                                 self_cp.client_type
-                            );
-                            break;
-                        }
-                        Err(_) => {
-                            warn!(
-                                "ZMQ {} {subscription} timed out after {:?} of inactivity",
-                                self_cp.client_type, duration
                             );
                             break;
                         }
@@ -163,12 +180,177 @@ impl ZmqClient {
         Ok(socket)
     }
 
-    fn find_notification(
+    fn find_notification<'a>(
         to_find: &str,
-        notifications: Vec<ZmqNotification>,
-    ) -> Option<ZmqNotification> {
+        notifications: &'a [ZmqNotification],
+    ) -> Option<&'a ZmqNotification> {
         notifications
-            .into_iter()
+            .iter()
             .find(|elem| elem.notification_type == to_find)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    };
+    use zeromq::{PubSocket, SocketSend, ZmqMessage};
+
+    #[tokio::test]
+    async fn test_subscribe() {
+        let zmq_client = ZmqClient::new(
+            Type::Bitcoin,
+            Network::Mainnet,
+            Config {
+                host: "127.0.0.1".to_string(),
+                port: 28332,
+                cookie: None,
+                user: None,
+                password: None,
+                mempool_space: None,
+            },
+        );
+
+        let address = "tcp://127.0.0.1:28332";
+
+        let mut socket = PubSocket::new();
+        socket.bind(address).await.unwrap();
+
+        let subscription = "rawtx";
+        let message = "test";
+
+        let received_count = Arc::new(AtomicU64::new(0));
+
+        let received_count_cp = received_count.clone();
+        zmq_client
+            .subscribe(
+                &ZmqNotification {
+                    notification_type: "pubrawtx".to_string(),
+                    address: address.to_string(),
+                },
+                subscription,
+                None,
+                move |msg| {
+                    assert_eq!(msg.get(0).unwrap(), subscription);
+                    assert_eq!(msg.get(1).unwrap(), message);
+                    received_count_cp.fetch_add(1, Ordering::SeqCst);
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut msg: ZmqMessage = subscription.into();
+        msg.push_back(message.into());
+        socket.send(msg).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(received_count.load(Ordering::SeqCst), 1);
+
+        socket.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_inactivity_timeout() {
+        let zmq_client = ZmqClient::new(
+            Type::Bitcoin,
+            Network::Mainnet,
+            Config {
+                host: "127.0.0.1".to_string(),
+                port: 28332,
+                cookie: None,
+                user: None,
+                password: None,
+                mempool_space: None,
+            },
+        );
+
+        let address = "tcp://127.0.0.1:28333";
+
+        let mut socket = PubSocket::new();
+        socket.bind(address).await.unwrap();
+
+        let subscription = "rawtx";
+        let message = "test";
+
+        let received_count = Arc::new(AtomicU64::new(0));
+
+        let received_count_cp = received_count.clone();
+        zmq_client
+            .subscribe(
+                &ZmqNotification {
+                    notification_type: "pubrawtx".to_string(),
+                    address: address.to_string(),
+                },
+                subscription,
+                Some(1),
+                move |msg| {
+                    assert_eq!(msg.get(0).unwrap(), subscription);
+                    assert_eq!(msg.get(1).unwrap(), message);
+                    received_count_cp.fetch_add(1, Ordering::SeqCst);
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(2_500)).await;
+
+        let mut msg: ZmqMessage = subscription.into();
+        msg.push_back(message.into());
+        socket.send(msg).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(received_count.load(Ordering::SeqCst), 1);
+
+        socket.close().await;
+    }
+
+    #[test]
+    fn test_replace_zmq_address_wildcard() {
+        let zmq_client = ZmqClient::new(
+            Type::Bitcoin,
+            Network::Mainnet,
+            Config {
+                host: "127.0.0.1".to_string(),
+                port: 28332,
+                cookie: None,
+                user: None,
+                password: None,
+                mempool_space: None,
+            },
+        );
+        assert_eq!(
+            zmq_client.replace_zmq_address_wildcard("0.0.0.0:28332"),
+            "127.0.0.1:28332"
+        );
+    }
+
+    #[test]
+    fn test_find_notification() {
+        let notifications = vec![
+            ZmqNotification {
+                notification_type: "unknown".to_string(),
+                address: "0.0.0.0:28333".to_string(),
+            },
+            ZmqNotification {
+                notification_type: "pubrawtx".to_string(),
+                address: "0.0.0.0:28332".to_string(),
+            },
+        ];
+
+        assert_eq!(
+            ZmqClient::find_notification("pubrawtx", &notifications),
+            Some(&notifications[1])
+        );
+        assert_eq!(
+            ZmqClient::find_notification("pubrawblock", &notifications),
+            None
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable inactivity timeouts for ZMQ subscriptions to improve resilience; automatically disabled on Regtest.

- Bug Fixes
  - Improved robustness handling malformed ZMQ messages and transaction parse/send failures with warnings instead of crashes.
  - Subscription loop now handles timeouts and reconnects to reduce hangs.

- Tests
  - Added tests for subscriptions, inactivity timeout behavior, address wildcard replacement, and notification lookup.

- Refactor
  - Reduced ownership overhead by passing notifications by reference.

- Chore
  - Notification type now supports equality comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->