### PR TITLE
refactor: check against max configured contract version

### DIFF
--- a/lib/service/cooperative/DeferredClaimer.ts
+++ b/lib/service/cooperative/DeferredClaimer.ts
@@ -42,7 +42,6 @@ import {
   queryERC20SwapValuesFromLock,
   queryEtherSwapValuesFromLock,
 } from '../../wallet/ethereum/contracts/ContractUtils';
-import Contracts from '../../wallet/ethereum/contracts/Contracts';
 import type ERC20WalletProvider from '../../wallet/providers/ERC20WalletProvider';
 import Errors from '../Errors';
 import type { SwapToClaim } from './CoopSignerBase';
@@ -612,7 +611,7 @@ class DeferredClaimer extends CoopSignerBase<{
           : (swap as ChainSwapInfo).receivingData.lockupAddress,
       ))!;
 
-      if (contracts.version !== Contracts.maxVersion) {
+      if (contracts.version !== manager.highestContractsVersion().version) {
         this.logNotDeferringReason(swap.id, 'not using the latest contracts');
         return false;
       }


### PR DESCRIPTION
We only batch EVM claims for the latest contract version. This commit changes the definition of the latest version from the maximum possible version to the highest configured one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the latest on-chain contract version by referencing a dynamic source, reducing false “outdated contract” checks and enhancing reliability of deferred claiming across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->