### PR TITLE
feat: API endpoint to fetch status of multiple swaps

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ export default [
     ignores: [
       'dist',
       'tools',
+      '.venv',
       'lib/proto',
       'contracts',
       'node_modules',

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -2820,6 +2820,56 @@
         }
       }
     },
+    "/swap/status": {
+      "get": {
+        "tags": [
+          "Swap"
+        ],
+        "description": "Get the status of multiple Swaps",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ids",
+            "required": true,
+            "description": "Array of Swap IDs (max 64)",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "maxItems": 64,
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map of Swap IDs to their latest status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/SwapStatus"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (ids must be an array, contains non-strings, or too many ids)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/swap/{id}": {
       "get": {
         "tags": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added bulk swap status endpoint: GET /swap/status?ids=<id>&ids=<id> (max 64). Returns a map of IDs to statuses; responds 400 for invalid input or unknown IDs.
- Documentation
  - OpenAPI/Swagger updated to document the new bulk status endpoint and parameters.
- Tests
  - Unit tests added for route registration, validation errors, not-found cases, and successful responses.
- Chores
  - ESLint now ignores the .venv directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->