### PR TITLE
docs: change warning boxes from "danger" to "warning"

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -6,7 +6,7 @@ next: false
 
 This page lists all available endpoints of the deprecated Boltz API v1.
 
-::: danger
+::: warning
 
 API v1 is maintained for existing integrations only and does not include the
 latest features or swap pairs. For any new integrations, we strongly recommend

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -49,9 +49,9 @@ Supported currencies: Bitcoin, Lightning, Liquid
 **Please [get in touch with us](https://docs.boltz.exchange/#resources) for help
 during the integration - don't be shy!**
 
-::: danger
+::: warning
 
-Only consider integrating Boltz API from scratch if above libraries don't serve
-your need and you absolutely know what you are doing.
+Only consider integrating Boltz API from scratch if the above libraries don't
+serve your needs and you absolutely know what you are doing.
 
 :::


### PR DESCRIPTION
From
<img width="889" height="167" alt="Screenshot from 2025-08-21 12-13-16" src="https://github.com/user-attachments/assets/54fe1371-e02b-4d5e-91c1-f874487abe96" />
To
<img width="898" height="173" alt="image" src="https://github.com/user-attachments/assets/95a235a8-acbb-465c-9c9c-c8b371b61088" />

Danger is just not correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Changed deprecation/advisory notices from “danger” to “warning” in API v1 and Breez SDK docs for clearer, less alarming messaging.
  * Minor grammar and wording edits in the Breez SDK guidance to improve readability.
  * No behavioral, functional, or public API changes; content tone and clarity improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->