### PR TITLE
docs: link go code examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ test/integration/sidecar/sidecar
 # Docs
 docs/.vitepress/dist
 docs/.vitepress/cache
+docs/fetched

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -412,9 +412,7 @@ const submarineSwap = async () => {
 })();
 ```
 
-```[Go Bitcoin]
-https://github.com/BoltzExchange/boltz-client/blob/master/examples/submarine/submarine.go
-```
+<<< @/fetched/submarine.go [Go Bitcoin]
 
 :::
 
@@ -922,9 +920,7 @@ const reverseSwap = async () => {
 })();
 ```
 
-```[Go Bitcoin]
-https://github.com/BoltzExchange/boltz-client/blob/master/examples/reverse/reverse.go
-```
+<<< @/fetched/reverse.go [Go Bitcoin]
 
 :::
 

--- a/docs/setup.js
+++ b/docs/setup.js
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+const { exit } = require('child_process');
+
+const dir = path.join(__dirname, 'fetched');
+if (!fs.existsSync(dir)) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+const downloadAndSave = async (url, filename) => {
+  try {
+    const response = await axios.get(url);
+    const content = response.data;
+
+    const filePath = path.join(dir, filename);
+    fs.writeFileSync(filePath, content);
+
+    console.log(`Downloaded: ${filename}`);
+  } catch (error) {
+    console.error(`Error downloading ${filename}:`, error);
+    exit(1);
+  }
+};
+
+(async () => {
+  const files = [
+    {
+      url: 'https://raw.githubusercontent.com/BoltzExchange/boltz-client/refs/heads/master/examples/submarine/submarine.go',
+      filename: 'submarine.go',
+    },
+    {
+      url: 'https://raw.githubusercontent.com/BoltzExchange/boltz-client/refs/heads/master/examples/reverse/reverse.go',
+      filename: 'reverse.go',
+    },
+  ];
+
+  await Promise.all(
+    files.map((file) => downloadAndSave(file.url, file.filename)),
+  );
+})();

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "test:int": "jest test/integration --runInBand --testTimeout 10000",
     "changelog": "git-cliff -o CHANGELOG.md",
     "prepublishOnly": "npm run compile && rm -f dist/package.json",
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
+    "docs:setup": "node docs/setup.js",
+    "docs:dev": "npm run docs:setup && vitepress dev docs",
+    "docs:build": "npm run docs:setup && vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },
   "bin": {


### PR DESCRIPTION
- link to go code example in code group tab instead of separate section, avoids overlooking the go examples and makes clear for which swap types there are go code samples as we don't have one for chain swaps
- reorder: examples before websocket

Supersedes #1045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Moved and consolidated WebSocket API docs into a dedicated later section (endpoints, subscriptions/updates, BOLT12 invoice requests, routing hints, ping/pong examples).
  - Replaced inline swap examples with externally referenced fetched code blocks for cleaner docs and reduced inline samples.

- Chores
  - Added a docs setup step that downloads example code before building/serving docs and wired it into dev/build scripts.
  - Ignored downloaded doc assets from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->