### PR TITLE
chore: bump LND to v0.19.3

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -37,7 +37,7 @@ NODE_VERSION = BuildArgument(
 
 GOLANG_VERSION = BuildArgument(
     name="GOLANG_VERSION",
-    value="1.24.5-bullseye",
+    value="1.24.6-bullseye",
 )
 
 BITCOIN_VERSION = "29.0"
@@ -47,7 +47,7 @@ GETH_VERSION = "1.15.5"
 
 C_LIGHTNING_VERSION = "25.05"
 ECLAIR_VERSION = "0.12.0"
-LND_VERSION = "0.19.2-beta"
+LND_VERSION = "0.19.3-beta"
 
 BITCOIN_BUILD_ARG = BuildArgument(
     name="BITCOIN_VERSION",
@@ -108,7 +108,7 @@ IMAGES: dict[str, Image] = {
         ],
     ),
     "regtest": Image(
-        tag="4.9.1",
+        tag="4.9.2",
         arguments=[
             UBUNTU_VERSION,
             BITCOIN_BUILD_ARG,

--- a/docker/regtest/startRegtest.sh
+++ b/docker/regtest/startRegtest.sh
@@ -28,7 +28,7 @@ docker run \
   -p 9735:9735 \
   -p 9293:9293 \
   -p 9292:9292 \
-  boltz/regtest:4.9.1
+  boltz/regtest:4.9.2
 
 docker exec regtest bash -c "cp /root/.lightning/regtest/*.pem /root/.lightning/regtest/certs"
 docker exec regtest chmod -R 777 /root/.lightning/regtest/certs

--- a/lib/VersionCheck.ts
+++ b/lib/VersionCheck.ts
@@ -90,7 +90,7 @@ class VersionCheck {
     },
     [LndClient.serviceName]: {
       minimal: '0.19.0',
-      maximal: '0.19.2',
+      maximal: '0.19.3',
     },
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded compatibility to LND 0.19.3, ensuring the app runs with the latest beta.

- Chores
  - Updated Go runtime image to 1.24.6-bullseye for build environment currency.
  - Bumped regtest container image to 4.9.2 and aligned startup script to use the new tag.

- Bug Fixes
  - None.

- Documentation
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->