### PR TITLE
chore: update readme nostr link to primal

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ API documentation can be found [here](https://docs.boltz.exchange/v/api).
 * Get Help: [Support Center](https://support.boltz.exchange/hc/center/) | [Discord](https://discord.gg/QBvZGcW) | [Telegram](https://t.me/boltzhq)
 * Read the Docs: [Docs Home](https://docs.boltz.exchange/)
 * Read our Blog: [Substack](https://blog.boltz.exchange/)
-* Follow us: [X/Twitter](https://twitter.com/Boltzhq) | [Nostr](https://snort.social/p/npub1psm37hke2pmxzdzraqe3cjmqs28dv77da74pdx8mtn5a0vegtlas9q8970)
+* Follow us: [X/Twitter](https://twitter.com/Boltzhq) | [Nostr](https://primal.net/p/nprofile1qqsqcdcltmv4qanpx3p7svcufdsg9rkk00x7l2sknra4e6whkv59l7clgcdzj)
 * Open a Lightning channel with us: [CLN](https://amboss.space/node/02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018) | [LND](https://amboss.space/node/026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2)&#x20;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README Resources section to replace an outdated Nostr profile URL with the current link, ensuring users are directed to the correct profile via Primal. This is a content-only change with no impact on application behavior or public APIs. Improves clarity and reliability of external references for users browsing project resources online.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->