### PR TITLE
chore: bump Bitcoin Core v29.1

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -40,7 +40,7 @@ GOLANG_VERSION = BuildArgument(
     value="1.24.6-bullseye",
 )
 
-BITCOIN_VERSION = "29.0"
+BITCOIN_VERSION = "29.1"
 LITECOIN_VERSION = "0.21.4"
 ELEMENTS_VERSION = "23.3.0"
 GETH_VERSION = "1.15.5"
@@ -108,7 +108,7 @@ IMAGES: dict[str, Image] = {
         ],
     ),
     "regtest": Image(
-        tag="4.9.3",
+        tag="4.9.4",
         arguments=[
             UBUNTU_VERSION,
             BITCOIN_BUILD_ARG,

--- a/docker/regtest/startRegtest.sh
+++ b/docker/regtest/startRegtest.sh
@@ -28,7 +28,7 @@ docker run \
   -p 9735:9735 \
   -p 9293:9293 \
   -p 9292:9292 \
-  boltz/regtest:4.9.3
+  boltz/regtest:4.9.4
 
 docker exec regtest bash -c "cp /root/.lightning/regtest/*.pem /root/.lightning/regtest/certs"
 docker exec regtest chmod -R 777 /root/.lightning/regtest/certs

--- a/lib/VersionCheck.ts
+++ b/lib/VersionCheck.ts
@@ -78,7 +78,7 @@ class VersionCheck {
   > = {
     [ChainClient.serviceName]: {
       minimal: 230000,
-      maximal: 290000,
+      maximal: 290100,
     },
     [ClnClient.serviceName]: {
       minimal: '25.05',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added compatibility with Bitcoin Core 29.1.

- Bug Fixes
  - Eliminated false incompatibility warnings by increasing the maximum supported node version to 29.1.

- Chores
  - Updated default Bitcoin version reference to 29.1.
  - Bumped regtest Docker image to 4.9.4 for local/test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->