### PR TITLE
feat: rescan last block when received

### DIFF
--- a/test/unit/chain/ZmqClient.spec.ts
+++ b/test/unit/chain/ZmqClient.spec.ts
@@ -213,7 +213,7 @@ describe('ZmqClient', () => {
       }
     });
 
-    // Flow of a transaction that gets added to the mempool and afterwards included in a block
+    // Flow of a transaction that gets added to the mempool
     const mempoolTransaction = generateTransaction(false);
 
     rawTx.sendMessage(mempoolTransaction.toBuffer());
@@ -226,19 +226,7 @@ describe('ZmqClient', () => {
       return !blockAcceptance;
     });
 
-    expect(zmqClient.utxos.has(mempoolTransaction.getId())).toBeTruthy();
-
-    rawTx.sendMessage(mempoolTransaction.toBuffer());
-
-    await waitForFunctionToBeTrue(() => {
-      return blockAcceptance;
-    });
-
-    expect(zmqClient.utxos.has(mempoolTransaction.getId())).toBeFalsy();
-
-    blockAcceptance = false;
-
-    // Flow of a transaction that is added to a block directly
+    // Flow of a transaction that is added to a block
     const blockTransaction = generateTransaction(true);
 
     rawTx.sendMessage(blockTransaction.toBuffer());


### PR DESCRIPTION
To make sure we don't miss any transactions included in blocks (EDIT by @kilrau: because this happened couple of times, especially with sub sat lockup txes, but we can't reproduce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - More accurate transaction confirmation status based on node data.
  - Reduced duplicate or premature transaction notifications.
  - Improved BTC block synchronization with a brief post-block rescan for reliability.
  - Better error reporting when transaction lookup fails, improving observability.

- Tests
  - Split scenarios to independently validate mempool acceptance and block confirmation, improving clarity and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->