### PR TITLE
fix: Docker version build args

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -179,6 +179,7 @@ def build_images(
             tag = branch
 
         build_args = [f"{arg.name}={arg.value}" for arg in build_details.arguments]
+        build_args.append(f"VERSION={tag if tag != 'latest' else branch}")
 
         # Add the prefix "--build-arg " to every entry and
         # join the array to a string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker builds now include a VERSION build argument, derived from the image tag (or branch when the tag is "latest"), improving image version identification in build artifacts.
  * Updated the regression testing submodule to a newer commit to align with the latest test assets and scripts.
* **Notes**
  * No changes to application behavior or public interfaces.
  * Build and command construction remain otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->