### PR TITLE
fix(config): update certificate path to follow datadir

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -459,6 +459,13 @@ class Config {
       deepMerge(this.config, this.getDataDirPaths(this.config.datadir));
     }
 
+    if (!tomlConfig?.grpc?.certificates) {
+      this.config.grpc.certificates = path.join(
+        this.config.datadir,
+        'certificates',
+      );
+    }
+
     deepMerge(this.config, tomlConfig);
 
     if (args.currencies) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically assigns a default gRPC certificates path when omitted in the TOML configuration, using the “certificates” folder within the data directory.
  * Reduces setup friction and avoids startup errors related to missing certificate paths, improving reliability for users who rely on default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->