### PR TITLE
fix: lower quote output amount in EVM quote test

### DIFF
--- a/boltzr/src/evm/quoter/uniswap_v3/mod.rs
+++ b/boltzr/src/evm/quoter/uniswap_v3/mod.rs
@@ -360,7 +360,7 @@ mod test {
             .quote_output(
                 WRBTC.parse().unwrap(),
                 USDT.parse().unwrap(),
-                U256::from_str_radix("100000000000", 10).unwrap(),
+                U256::from_str_radix("100000000", 10).unwrap(),
             )
             .await
             .unwrap();
@@ -395,7 +395,7 @@ mod test {
 
         let token_in: Address = WRBTC.parse().unwrap();
         let token_out: Address = USDT.parse().unwrap();
-        let amount_out = U256::from_str_radix("100000000000", 10).unwrap();
+        let amount_out = U256::from_str_radix("100000000", 10).unwrap();
 
         let (quote, data) = quoter
             .quote_output(token_in, token_out, amount_out)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated numerical test parameters in quoter unit tests to validate system behavior across different input ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->