### PR TITLE
feat: no coop claims for refunded chain swaps

### DIFF
--- a/test/integration/service/cooperative/ChainSwapSigner.spec.ts
+++ b/test/integration/service/cooperative/ChainSwapSigner.spec.ts
@@ -777,6 +777,19 @@ describe('ChainSwapSigner', () => {
         ),
       ).rejects.toEqual(Errors.INVALID_PARTIAL_SIGNATURE());
     });
+
+    test('should throw when trying to cooperatively claim a refunded swap', async () => {
+      const { chainSwapInfo } = await createOutputs();
+      (chainSwapInfo as any).status = SwapUpdateEvent.TransactionRefunded;
+
+      await expect(
+        signer.signClaim(chainSwapInfo, {
+          index: 0,
+          transaction: Buffer.alloc(0),
+          pubNonce: Buffer.alloc(0),
+        }),
+      ).rejects.toEqual(Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_CLAIM());
+    });
   });
 
   test.each`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent cooperative claims from being initiated when a swap has entered a refunded state, strengthening transaction security and ensuring proper lifecycle management.

* **Tests**
  * Added test coverage to verify that attempting to cooperatively claim a refunded swap is properly rejected with an appropriate error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->