### PR TITLE
fix: only settle confirmed lockups when invoice is set

### DIFF
--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -745,7 +745,7 @@ class SwapManager {
       // the lockup transaction is confirmed the swap should be settled directly
       if (
         updatedSwap.lockupTransactionId &&
-        updatedSwap.status !== SwapUpdateEvent.TransactionZeroConfRejected &&
+        updatedSwap.status === SwapUpdateEvent.TransactionConfirmed &&
         swap.expectedAmount === swap.onchainAmount &&
         updatedSwap.expectedAmount === updatedSwap.onchainAmount
       ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced swap settlement mechanism to mandate confirmed transaction status prior to settlement. Settlements now strictly require transaction confirmation before proceeding, replacing the previous approach that allowed settlements under broader conditions. This ensures swaps only settle after complete transaction confirmation, improving system reliability and eliminating incomplete settlement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->