### PR TITLE
chore: ignore errror when setting span parent

### DIFF
--- a/boltzr/src/grpc/server.rs
+++ b/boltzr/src/grpc/server.rs
@@ -150,9 +150,8 @@ where
                     });
 
                     let span = tracing::info_span!("grpc_request");
-                    if let Err(e) = span.set_parent(parent_cx) {
-                        tracing::warn!("Failed to set parent span context: {:?}", e);
-                    }
+                    // Ignore the error, else this will log when OpenTelemetry is disabled in the Node.js daemon
+                    let _ = span.set_parent(parent_cx);
 
                     span
                 },


### PR DESCRIPTION
Closes #1128

Else it will log warnings when OpenTelemetry is disabled in the Node.js daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced internal error handling for tracing functionality to operate more gracefully when certain conditions are not met.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->