### PR TITLE
chore: bring back Rust build CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+      - name: 'Free disk space'
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+
       - name: Check out code
         uses: actions/checkout@v4
         with:
@@ -39,6 +46,21 @@ jobs:
 
       - name: Install Node.js dependencies
         run: npm ci
+
+      - name: Rust build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key:
+            ${{ runner.os }}-npm-rust-build-${{ matrix.rust-version }}-${{
+            hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-rust-build-${{ matrix.rust-version }}-
 
       - name: Start regtest
         run: npm run regtest:start:ci && sudo chmod -R 777 regtest
@@ -68,6 +90,13 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+      - name: 'Free disk space'
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+
       - name: Check out code
         uses: actions/checkout@v4
         with:
@@ -98,6 +127,21 @@ jobs:
 
       - name: Install Node.js dependencies
         run: npm ci
+
+      - name: Rust build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key:
+            ${{ runner.os }}-cargo-build-${{ matrix.rust-version }}-${{
+            hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ matrix.rust-version }}-
 
       - name: Start regtest
         run: npm run regtest:start:ci && sudo chmod -R 777 regtest


### PR DESCRIPTION
Effectively reverts https://github.com/BoltzExchange/boltz-backend/commit/a96a97676573c3630bd5325e8e41ade445f8667c

Found that nice trick in https://github.com/rust-bitcoin/rust-miniscript/pull/880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline infrastructure with optimizations to improve build stability and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->