### PR TITLE
feat: rescue index cache

### DIFF
--- a/boltzr/src/api/errors.rs
+++ b/boltzr/src/api/errors.rs
@@ -15,6 +15,7 @@ pub struct ApiError {
     pub error: String,
 }
 
+#[derive(Debug)]
 pub struct AxumError(StatusCode, anyhow::Error);
 
 impl AxumError {

--- a/boltzr/src/api/rescue.rs
+++ b/boltzr/src/api/rescue.rs
@@ -37,7 +37,7 @@ pub struct RestoreIndexResponse {
     pub index: i64,
 }
 
-impl TryFrom<RescueParams> for Box<dyn PubkeyIterator> {
+impl TryFrom<RescueParams> for Box<dyn PubkeyIterator + Send> {
     type Error = AxumError;
 
     fn try_from(params: RescueParams) -> Result<Self, Self::Error> {
@@ -109,7 +109,7 @@ where
     S: SwapInfos + Send + Sync + Clone + 'static,
     M: SwapManager + Send + Sync + 'static,
 {
-    let res = state.service.swap_rescue.index(params.try_into()?)?;
+    let res = state.service.swap_rescue.index(params.try_into()?).await?;
     Ok((StatusCode::OK, Json(RestoreIndexResponse { index: res })).into_response())
 }
 

--- a/boltzr/src/service/mod.rs
+++ b/boltzr/src/service/mod.rs
@@ -44,6 +44,7 @@ impl Service {
     ) -> Self {
         Self {
             swap_rescue: SwapRescue::new(
+                cache.clone(),
                 swap_helper,
                 chain_swap_helper,
                 reverse_swap_helper,
@@ -168,6 +169,7 @@ pub mod test {
 
             Self {
                 swap_rescue: SwapRescue::new(
+                    Cache::Memory(MemCache::new()),
                     Arc::new(swap_helper),
                     Arc::new(chain_swap_helper),
                     Arc::new(reverse_swap_helper),


### PR DESCRIPTION
After swap rescue scanning to get last used index, we can cache that index and use it as starting point for the next scan of the same xpub to greatly improve the response times for big wallets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced rescue operations with intelligent caching to minimize redundant lookups and improve overall response times during account recovery procedures.

* **Refactor**
  * Strengthened internal service architecture to improve concurrency handling, stability, and resource efficiency across all background operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->