### PR TITLE
chore: bump Node.js in Dockerfile to v24

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -32,7 +32,7 @@ UBUNTU_VERSION = BuildArgument(
 
 NODE_VERSION = BuildArgument(
     name="NODE_VERSION",
-    value="22-bookworm-slim",
+    value="24-bookworm-slim",
 )
 
 GOLANG_VERSION = BuildArgument(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base runtime environment from Node.js 22 to Node.js 24.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->