### PR TITLE
chore: bump swagger-ui to v5.31.0

### DIFF
--- a/lib/api/Api.ts
+++ b/lib/api/Api.ts
@@ -81,6 +81,16 @@ class Api {
       .route('/swagger-spec.json')
       .get(controller.serveFile('swagger-spec.json'));
 
+    for (const file of [
+      'swagger-ui.css',
+      'swagger-ui-bundle.js',
+      'swagger-ui-standalone-preset.js',
+    ]) {
+      this.app
+        .route(`/swagger/${file}`)
+        .get(controller.serveSwaggerStaticFile(file));
+    }
+
     // GET requests
     this.app.route('/version').get(controller.version);
 

--- a/lib/api/static/index.html
+++ b/lib/api/static/index.html
@@ -1,50 +1,107 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Boltz API</title>
-  <link rel="icon" type="image/ico" href="favicon.ico">
-  <style>
-      html,body {
-          height: 100%;
+  <head>
+    <meta charset="UTF-8" />
+    <title>Boltz API</title>
+    <link rel="icon" type="image/ico" href="favicon.ico" />
+    <style>
+      html,
+      body {
+        height: 100%;
       }
       body {
-          height: 100%;
-          font-size: 14px;
-          margin: 0;
-          background: #14283f;
-          color: #d0d0d0;
-          text-align: center;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          font-family: sans-serif;
+        height: 100%;
+        font-size: 14px;
+        margin: 0;
+        background: #14283f;
+        color: #d0d0d0;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: sans-serif;
       }
-      body > div > *{
-          align-items: center;
-          justify-content: center;
+      body > div > * {
+        align-items: center;
+        justify-content: center;
       }
       .btn {
-          cursor: pointer;
-          display: inline-block;
-          margin: 5px 3px 3px;
-          padding: 8px 12px;
-          text-decoration: none;
-          border-radius: 16px;
-          background-color: #e6c826;
-          color: #14283f;
-          font-weight: 700;
-          text-transform: uppercase;
-          border: none;
+        cursor: pointer;
+        display: inline-block;
+        margin: 5px 3px 3px;
+        padding: 8px 12px;
+        text-decoration: none;
+        border-radius: 16px;
+        background-color: #e6c826;
+        color: #14283f;
+        font-weight: 700;
+        text-transform: uppercase;
+        border: none;
       }
-  </style>
-</head>
-<body>
-<div>
-  <svg width="46.626mm" height="12.965mm" version="1.1" viewBox="0 0 46.626 12.965" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="paint0_linear" x2="0" y2="49" gradientUnits="userSpaceOnUse"><stop stop-color="#FFE96D" offset="0"/><stop stop-color="#E1C218" offset="1"/></linearGradient><linearGradient id="paint0_linear-3" x1="-3" x2="-3" y1="-11" y2="56" gradientUnits="userSpaceOnUse"><stop stop-color="#FFE96D" offset="0"/><stop stop-color="#E1C218" offset="1"/></linearGradient></defs><g transform="translate(-69.488 -50.153)"><g transform="matrix(.26458 0 0 .26458 69.488 50.153)" style="fill:none"><path d="m14.462 28.768-0.0035 0.0072h-12.787c-0.4776 0-0.8756-0.1467-1.194-0.4401s-0.4776-0.6619-0.4776-1.1055c0-0.4723 0.20262-0.9589 0.60786-1.4598l20.342-24.837c0.3763-0.48659 0.7924-0.77997 1.2482-0.88015 0.4559-0.10018 0.8648-0.057246 1.2266 0.1288 0.3618 0.18605 0.6151 0.49016 0.7598 0.91235 0.1448 0.42218 0.1086 0.92666-0.1085 1.5134l-6.643 17.625h1.1057l0.0035-0.0072h12.787c0.4776 0 0.8756 0.1467 1.194 0.4401s0.4776 0.6619 0.4776 1.1055c0 0.4723-0.2026 0.9589-0.6079 1.4598l-20.342 24.837c-0.3763 0.4865-0.7924 0.7799-1.2482 0.8801-0.4559 0.1002-0.86479 0.0573-1.2266-0.1288-0.36182-0.186-0.61509-0.4902-0.75982-0.9123-0.14473-0.4222-0.10855-0.9267 0.10854-1.5135l6.643-17.624z" clip-rule="evenodd" fill="url(#paint0_linear)" fill-rule="evenodd" style="fill:url(#paint0_linear)"/></g><g transform="matrix(.26458 0 0 .26458 81.643 50.938)" style="fill:none"><path d="m0.92 42h19.488c7.672 0 12.488-4.144 12.488-11.312 0-5.152-2.072-7.952-5.264-9.464v-0.224c1.96-1.4 3.808-3.752 3.808-8.008 0-6.44-4.76-10.192-11.76-10.192h-18.76zm8.736-24.08v-7.392h8.736c2.968 0 4.144 1.568 4.144 3.696s-1.176 3.696-4.144 3.696zm0 16.296v-8.68h9.296c3.808 0 4.984 2.352 4.984 4.312 0 2.352-1.232 4.368-4.984 4.368zm40.657 8.288c9.52 0 14.616-6.384 14.616-15.12 0-8.792-5.208-15.176-14.616-15.176s-14.616 6.384-14.616 15.176 5.096 15.12 14.616 15.12zm0-7.56c-3.528 0-5.824-2.24-5.824-7.56 0-5.264 2.24-7.616 5.824-7.616s5.824 2.296 5.824 7.616-2.24 7.56-5.824 7.56zm18.831 7.056h8.624v-41.44h-8.624zm26.552 0.504c2.744 0 5.0404-0.504 5.9364-0.84v-7.168h-0.56c-0.896 0.336-1.8484 0.504-2.8004 0.504-2.576 0-3.752-1.176-3.752-3.92v-11.032h7.0004v-7.336h-7.0004v-7.672h-0.56l-7.672 1.568v6.104h-5.152v7.336h4.76v13.104c0 5.32 3.024 9.352 9.8 9.352zm10.397-0.504h24.192v-7.336h-13.552v-0.224l13.44-14.448v-7.28h-24.024v7.336h13.44v0.224l-13.496 14.504z" fill="url(#paint0_linear)" style="fill:url(#paint0_linear-3)"/></g></g></svg>
-  <h1>API Endpoint</h1>
-  <a class="btn" target="_blank" href="https://api.docs.boltz.exchange/">API Docs</a>
-  <a class="btn" target="_blank" href="https://boltz.exchange">Web App</a>
-</div>
-</body>
+    </style>
+  </head>
+  <body>
+    <div>
+      <svg
+        width="46.626mm"
+        height="12.965mm"
+        version="1.1"
+        viewBox="0 0 46.626 12.965"
+        xml:space="preserve"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <linearGradient
+            id="paint0_linear"
+            x2="0"
+            y2="49"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop stop-color="#FFE96D" offset="0" />
+            <stop stop-color="#E1C218" offset="1" />
+          </linearGradient>
+          <linearGradient
+            id="paint0_linear-3"
+            x1="-3"
+            x2="-3"
+            y1="-11"
+            y2="56"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop stop-color="#FFE96D" offset="0" />
+            <stop stop-color="#E1C218" offset="1" />
+          </linearGradient>
+        </defs>
+        <g transform="translate(-69.488 -50.153)">
+          <g
+            transform="matrix(.26458 0 0 .26458 69.488 50.153)"
+            style="fill: none"
+          >
+            <path
+              d="m14.462 28.768-0.0035 0.0072h-12.787c-0.4776 0-0.8756-0.1467-1.194-0.4401s-0.4776-0.6619-0.4776-1.1055c0-0.4723 0.20262-0.9589 0.60786-1.4598l20.342-24.837c0.3763-0.48659 0.7924-0.77997 1.2482-0.88015 0.4559-0.10018 0.8648-0.057246 1.2266 0.1288 0.3618 0.18605 0.6151 0.49016 0.7598 0.91235 0.1448 0.42218 0.1086 0.92666-0.1085 1.5134l-6.643 17.625h1.1057l0.0035-0.0072h12.787c0.4776 0 0.8756 0.1467 1.194 0.4401s0.4776 0.6619 0.4776 1.1055c0 0.4723-0.2026 0.9589-0.6079 1.4598l-20.342 24.837c-0.3763 0.4865-0.7924 0.7799-1.2482 0.8801-0.4559 0.1002-0.86479 0.0573-1.2266-0.1288-0.36182-0.186-0.61509-0.4902-0.75982-0.9123-0.14473-0.4222-0.10855-0.9267 0.10854-1.5135l6.643-17.624z"
+              clip-rule="evenodd"
+              fill="url(#paint0_linear)"
+              fill-rule="evenodd"
+              style="fill: url(#paint0_linear)"
+            />
+          </g>
+          <g
+            transform="matrix(.26458 0 0 .26458 81.643 50.938)"
+            style="fill: none"
+          >
+            <path
+              d="m0.92 42h19.488c7.672 0 12.488-4.144 12.488-11.312 0-5.152-2.072-7.952-5.264-9.464v-0.224c1.96-1.4 3.808-3.752 3.808-8.008 0-6.44-4.76-10.192-11.76-10.192h-18.76zm8.736-24.08v-7.392h8.736c2.968 0 4.144 1.568 4.144 3.696s-1.176 3.696-4.144 3.696zm0 16.296v-8.68h9.296c3.808 0 4.984 2.352 4.984 4.312 0 2.352-1.232 4.368-4.984 4.368zm40.657 8.288c9.52 0 14.616-6.384 14.616-15.12 0-8.792-5.208-15.176-14.616-15.176s-14.616 6.384-14.616 15.176 5.096 15.12 14.616 15.12zm0-7.56c-3.528 0-5.824-2.24-5.824-7.56 0-5.264 2.24-7.616 5.824-7.616s5.824 2.296 5.824 7.616-2.24 7.56-5.824 7.56zm18.831 7.056h8.624v-41.44h-8.624zm26.552 0.504c2.744 0 5.0404-0.504 5.9364-0.84v-7.168h-0.56c-0.896 0.336-1.8484 0.504-2.8004 0.504-2.576 0-3.752-1.176-3.752-3.92v-11.032h7.0004v-7.336h-7.0004v-7.672h-0.56l-7.672 1.568v6.104h-5.152v7.336h4.76v13.104c0 5.32 3.024 9.352 9.8 9.352zm10.397-0.504h24.192v-7.336h-13.552v-0.224l13.44-14.448v-7.28h-24.024v7.336h13.44v0.224l-13.496 14.504z"
+              fill="url(#paint0_linear)"
+              style="fill: url(#paint0_linear-3)"
+            />
+          </g>
+        </g>
+      </svg>
+      <h1>API Endpoint</h1>
+      <a class="btn" target="_blank" href="https://api.docs.boltz.exchange/"
+        >API Docs</a
+      >
+      <a class="btn" target="_blank" href="https://boltz.exchange">Web App</a>
+    </div>
+  </body>
 </html>

--- a/lib/api/static/swagger.html
+++ b/lib/api/static/swagger.html
@@ -5,23 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Boltz API" />
     <title>Boltz API</title>
+    <link rel="preload" href="/swagger/swagger-ui.css" as="style" />
+    <link rel="preload" href="/swagger/swagger-ui-bundle.js" as="script" />
     <link
-      rel="stylesheet"
-      href="https://unpkg.com/swagger-ui-dist@5.31.0/swagger-ui.css"
+      rel="preload"
+      href="/swagger/swagger-ui-standalone-preset.js"
+      as="script"
     />
+    <link rel="preload" href="/swagger-spec.json" as="fetch" crossorigin />
+    <link rel="stylesheet" href="/swagger/swagger-ui.css" />
   </head>
   <body style="margin: 0">
     <div id="swagger-ui"></div>
-    <script
-      src="https://unpkg.com/swagger-ui-dist@5.31.0/swagger-ui-bundle.js"
-      crossorigin
-    ></script>
-    <script
-      src="https://unpkg.com/swagger-ui-dist@5.31.0/swagger-ui-standalone-preset.js"
-      crossorigin
-    ></script>
-    <script>
-      window.onload = () => {
+    <script src="/swagger/swagger-ui-bundle.js" defer></script>
+    <script src="/swagger/swagger-ui-standalone-preset.js" defer></script>
+    <script defer>
+      window.addEventListener('DOMContentLoaded', () => {
         window.ui = SwaggerUIBundle({
           url: '/swagger-spec.json',
           dom_id: '#swagger-ui',
@@ -29,7 +28,7 @@
           presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
           layout: 'StandaloneLayout',
         });
-      };
+      });
     </script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "redis": "^5.10.0",
         "sequelize": "^6.37.7",
         "slip77": "^0.2.0",
+        "swagger-ui-dist": "^5.31.0",
         "tiny-secp256k1": "^2.2.4",
         "winston": "^3.18.3",
         "winston-loki": "^6.1.3",
@@ -4617,6 +4618,13 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@scure/base": {
       "version": "1.1.1",
@@ -15702,6 +15710,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/synckit": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.12.0",
   "description": "Backend of Boltz",
   "main": "dist/lib/Boltz.js",
+  "scarfSettings": {
+    "enabled": false
+  },
   "scripts": {
     "postinstall": "node parseGitCommit.js",
     "proto": "node protos.js",
@@ -18,7 +21,7 @@
     "start": "node bin/boltzd",
     "dev": "npm run compile && npm run start",
     "lint": "eslint --max-warnings 0 --concurrency auto .",
-    "prettier": "npx prettier '{lib,test}/**/*.ts' bin docs",
+    "prettier": "npx prettier '{lib,test}/**/*.ts' lib/api/static bin docs",
     "prettier:write": "npm run prettier -- --write",
     "prettier:check": "npm run prettier -- --check",
     "regtest:start:ci": "cd regtest && COMPOSE_PROFILES=backend-dev ./start.sh && npm run regtest:db:setup && npm run regtest:solidity:deploy",
@@ -95,6 +98,7 @@
     "redis": "^5.10.0",
     "sequelize": "^6.37.7",
     "slip77": "^0.2.0",
+    "swagger-ui-dist": "^5.31.0",
     "tiny-secp256k1": "^2.2.4",
     "winston": "^3.18.3",
     "winston-loki": "^6.1.3",


### PR DESCRIPTION
[v5.31.0](https://github.com/swagger-api/swagger-ui/releases/tag/v5.31.0) adds dark mode. We gotta have that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API docs UI now served from local assets with preloaded styles/scripts and deferred loading for faster, more reliable startup.

* **Chores**
  * Added bundled Swagger UI dependency and updated project formatting targets.
  * Minor HTML cleanup/formatting changes in the docs UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->