### PR TITLE
docs: add hint to pro docs about queued ln payments

### DIFF
--- a/docs/pro.md
+++ b/docs/pro.md
@@ -9,7 +9,9 @@ Boltz Pro temporarily offers incentives, like 0% or even negative fees, to
 encourage users to conduct swaps that work in favor of our liquidity needs. It
 has much stricter limits, e.g. the available fee budget for routing on
 Lightning, or the time limit to fund swaps and is **not designed for regular
-payments**.
+payments**. Lightning payments may be queued and dispatched with a delay of
+several minutes, or not sent at all if liquidity conditions change and the swap
+is cancelled.
 
 ## Web Usage
 


### PR DESCRIPTION
Related: https://github.com/BoltzExchange/boltz-web-app/pull/1113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Lightning payment behavior to note that payments may be queued and dispatched with delays of several minutes, or may not be sent if liquidity conditions change and the swap is cancelled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->