### PR TITLE
fix: handle self payment failed lockups

### DIFF
--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -1494,11 +1494,17 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     lightningClient?: LightningClient,
   ) => {
     if (lightningClient !== undefined) {
-      await LightningNursery.cancelReverseInvoices(
-        lightningClient,
-        swap as ReverseSwap,
-        false,
-      );
+      try {
+        await LightningNursery.cancelReverseInvoices(
+          lightningClient,
+          swap as ReverseSwap,
+          false,
+        );
+      } catch (e) {
+        this.logger.warn(
+          `Could not cancel invoices of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${formatError(e)}`,
+        );
+      }
     }
 
     const onchainAmount =

--- a/test/unit/lightning/SelfPaymentClient.spec.ts
+++ b/test/unit/lightning/SelfPaymentClient.spec.ts
@@ -556,8 +556,14 @@ describe('SelfPaymentClient', () => {
 
     test('should throw error when reverse swap is refunded', async () => {
       const reverseSwap = {
+        id: 'rev',
         status: SwapUpdateEvent.TransactionRefunded,
       } as unknown as ReverseSwap;
+
+      const swap = {
+        id: 'sub',
+        type: SwapType.Submarine,
+      } as unknown as Swap;
 
       RefundTransactionRepository.getTransactionForSwap = jest
         .fn()
@@ -565,9 +571,25 @@ describe('SelfPaymentClient', () => {
           isFinal: true,
         });
 
-      await expect(
-        client['getPreimage']({} as unknown as Swap, reverseSwap),
-      ).rejects.toThrow('incorrect payment details');
+      await expect(client['getPreimage'](swap, reverseSwap)).rejects.toThrow(
+        'incorrect payment details',
+      );
+    });
+
+    test('should throw error when reverse swap transaction failed', async () => {
+      const reverseSwap = {
+        id: 'rev',
+        status: SwapUpdateEvent.TransactionFailed,
+      } as unknown as ReverseSwap;
+
+      const swap = {
+        id: 'sub',
+        type: SwapType.Submarine,
+      } as unknown as Swap;
+
+      await expect(client['getPreimage'](swap, reverseSwap)).rejects.toThrow(
+        'incorrect payment details',
+      );
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified self-payment failure handling to provide consistent error messaging and clearer feedback across different failure scenarios.
  * Gracefully handle reverse-invoice cancellation failures so swap processing continues without disruption, with improved diagnostic logging for troubleshooting.
  * Small test coverage updates to validate these failure paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->