### PR TITLE
fix: resolve temporary lifetime issues for Rust 1.88

### DIFF
--- a/boltzr/src/swap/manager.rs
+++ b/boltzr/src/swap/manager.rs
@@ -308,10 +308,12 @@ impl SwapManager for Manager {
                     .collect::<Result<Vec<boltz_core::bitcoin::InputDetail>>>()?;
                 let inputs = inputs.iter().collect::<Vec<_>>();
 
+                let address_converted: bitcoin::Address = address.try_into()?;
+                let destination = boltz_core::Destination::Single(&address_converted);
                 let params =
                     boltz_core::wrapper::Params::Bitcoin(boltz_core::wrapper::BitcoinParams {
                         inputs: &inputs,
-                        destination: &boltz_core::Destination::Single(&address.try_into()?),
+                        destination: &destination,
                         fee: fee.into(),
                     });
 
@@ -324,11 +326,13 @@ impl SwapManager for Manager {
                     .collect::<Result<Vec<boltz_core::elements::InputDetail>>>()?;
                 let inputs = inputs.iter().collect::<Vec<_>>();
 
+                let address_converted: elements::Address = address.try_into()?;
+                let destination = boltz_core::Destination::Single(&address_converted);
                 let params =
                     boltz_core::wrapper::Params::Elements(boltz_core::wrapper::ElementsParams {
                         genesis_hash: client.network().liquid_genesis_hash()?,
                         inputs: &inputs,
-                        destination: &boltz_core::Destination::Single(&address.try_into()?),
+                        destination: &destination,
                         fee: fee.into(),
                     });
 


### PR DESCRIPTION
Rust 1.88 introduced stricter borrow checking rules for temporary values. The previous code created temporaries inline that were dropped before the borrows were used, causing `E0716` errors.

This fix binds temporaries to let statements to extend their lifetime:
- BitcoinInputDetail / ElementsInputDetail structs
- Input arrays
- Converted addresses
- Destination wrappers

Fixes compilation with rustc 1.88.0+