### PR TITLE
fix: EIP refund signer cannot convert BigInt

### DIFF
--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -72,6 +72,12 @@ class EipSigner {
           ? (swap as Swap).onchainAmount
           : (swap as ChainSwapInfo).receivingData.amount;
 
+      if (onchainAmount === null || onchainAmount === undefined) {
+        throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+          'no coins were locked up',
+        );
+      }
+
       const contractAddress =
         swap.type === SwapType.Submarine
           ? (swap as Swap).lockupAddress

--- a/test/integration/service/cooperative/EipSigner.spec.ts
+++ b/test/integration/service/cooperative/EipSigner.spec.ts
@@ -124,6 +124,23 @@ describe('EipSigner', () => {
     );
   });
 
+  test('should throw when no coins were locked up', async () => {
+    SwapRepository.getSwap = jest.fn().mockResolvedValue({
+      orderSide: 1,
+      pair: 'RBTC/BTC',
+      type: SwapType.Submarine,
+      version: SwapVersion.Taproot,
+      preimageHash: getHexString(randomBytes(32)),
+      status: SwapUpdateEvent.InvoiceFailedToPay,
+      lockupAddress: '0xfbd623a70f5D6d50d2935071b5c4cd0E5a9772Ad',
+      timeoutBlockHeight: 123,
+      onchainAmount: null,
+    });
+    await expect(signer.signSwapRefund('no coins locked')).rejects.toEqual(
+      Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND('no coins were locked up'),
+    );
+  });
+
   test('should throw when no signer is available', async () => {
     SwapRepository.getSwap = jest.fn().mockResolvedValue({
       orderSide: 1,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced refund request processing by implementing validation checks to ensure coins were properly locked up before generating refund signatures. Invalid refund operations without proper coin lock-ups are now properly rejected with appropriate error messages.

* **Tests**
  * Added comprehensive test scenarios to validate refund signature behavior for edge cases involving missing or insufficient lock-up amounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->