### PR TITLE
refactor: remove contract refund subscriptions

### DIFF
--- a/lib/wallet/ethereum/ConsolidatedEventHandler.ts
+++ b/lib/wallet/ethereum/ConsolidatedEventHandler.ts
@@ -14,11 +14,9 @@ class ConsolidatedEventHandler extends TypedEventEmitter<Events> {
 
     handler.on('eth.lockup', (lockup) => this.emit('eth.lockup', lockup));
     handler.on('eth.claim', (claim) => this.emit('eth.claim', claim));
-    handler.on('eth.refund', (refund) => this.emit('eth.refund', refund));
 
     handler.on('erc20.lockup', (lockup) => this.emit('erc20.lockup', lockup));
     handler.on('erc20.claim', (claim) => this.emit('erc20.claim', claim));
-    handler.on('erc20.refund', (refund) => this.emit('erc20.refund', refund));
   };
 
   public rescan = async (startHeight: number): Promise<void> => {

--- a/test/unit/wallet/ethereum/ConsolidatedEventHandler.spec.ts
+++ b/test/unit/wallet/ethereum/ConsolidatedEventHandler.spec.ts
@@ -28,10 +28,8 @@ describe('ConsolidatedEventHandler', () => {
     event
     ${'eth.lockup'}
     ${'eth.claim'}
-    ${'eth.refund'}
     ${'erc20.lockup'}
     ${'erc20.claim'}
-    ${'erc20.refund'}
   `('should forward event $event', ({ event }) => {
     expect.assertions(6);
 
@@ -39,7 +37,7 @@ describe('ConsolidatedEventHandler', () => {
     handler.register(eventsV3);
     handler.register(eventsV4);
 
-    expect(eventsV3.on).toHaveBeenCalledTimes(6);
+    expect(eventsV3.on).toHaveBeenCalledTimes(4);
     expect(eventsV3.on).toHaveBeenCalledWith(event, expect.any(Function));
 
     expect(emittersV3[event]).toBeDefined();


### PR DESCRIPTION
Those are not being used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed refund event tracking for Ethereum and ERC20 transactions. The wallet no longer monitors, records, or reports refund events from these transaction types. Event handling now exclusively tracks lockup and claim events associated with atomic swap operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->