### PR TITLE
chore: relax invoice description regex

### DIFF
--- a/lib/swap/NodeFallback.ts
+++ b/lib/swap/NodeFallback.ts
@@ -19,8 +19,9 @@ type HolisticInvoice = InvoiceWithRoutingHints & {
 class NodeFallback {
   private static readonly addInvoiceTimeout = 10_000;
   private static readonly invoiceMemoRegex = new RegExp(
-    // Visible ASCII characters with a maximal length of 500
-    '^[\x20-\x7E]{0,500}$',
+    // Visible ASCII characters, newlines, and the Bitcoin symbol with a maximal length of 500
+    // eslint-disable-next-line no-control-regex
+    '^[\x20-\x7E\n\r₿]{0,500}$',
   );
 
   constructor(

--- a/test/unit/swap/NodeFallback.spec.ts
+++ b/test/unit/swap/NodeFallback.spec.ts
@@ -386,10 +386,17 @@ describe('NodeFallback', () => {
       ${'\r'}
       ${'\r\n'}
       ${'normal\nstring'}
-    `('should throw on newline', ({ input }) => {
-      expect(() => fallback['checkInvoiceMemo'](input)).toThrow(
-        Errors.INVALID_INVOICE_MEMO().message,
-      );
+    `('should allow newlines: $input', ({ input }) => {
+      fallback['checkInvoiceMemo'](input);
+    });
+
+    test.each`
+      input
+      ${'₿'}
+      ${'1 ₿'}
+      ${'Price: 0.5 ₿'}
+    `('should allow Bitcoin symbol: $input', ({ input }) => {
+      fallback['checkInvoiceMemo'](input);
     });
 
     test.each`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Invoice memo field now supports line breaks, carriage returns, and the Bitcoin symbol (₿) for more flexible memo entry.

## Tests
* Added test coverage for enhanced memo validation including Bitcoin symbol and line break handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->