### PR TITLE
docs: add `transaction.claim.pending` state to Chain Swaps section

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -161,7 +161,12 @@ A Chain Swap has the following states:
    broadcast
 5. `transaction.server.confirmed`: the lockup transaction of the server has been
    included in a block
-6. `transaction.claimed`: the server claimed the coins that the client locked
+6. `transaction.claim.pending`: Boltz is ready to cooperatively sign for a key
+   path spend. This state is entered once Boltz knows the preimage, which it
+   learns when the client claims non-cooperatively on-chain. If the client does
+   not provide a cooperative signature, Boltz will eventually claim via the
+   script path in a batch transaction.
+7. `transaction.claimed`: the server claimed the coins that the client locked
 
 If the user doesn't send chain bitcoin and the swap expires, Boltz will set the
 state of the swap to `swap.expired`, which means that it was cancelled and chain


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "pending" state for chain swaps to reflect readiness for a cooperative signature.
  * Clarified the cooperative vs. non-cooperative claim flow, how the server proceeds to a claimed state, and fallback to on-chain batch claims if needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->