### PR TITLE
docs: update regtest conf

### DIFF
--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -10,8 +10,7 @@ Backend development.
   installed. We recommend using
   [nvm](https://github.com/nvm-sh/nvm#install--update-script) to manage npm
   installs: `nvm install --lts`
-- [Docker](https://docs.docker.com/engine/install/) or
-  [Orbstack](https://orbstack.dev/) for Apple Silicon Macs
+- [Docker](https://docs.docker.com/engine/install/)
 
 The regtest environment of the Boltz Backend is based on
 [boltz-regtest](https://github.com/BoltzExchange/boltz-regtest). To start the
@@ -22,32 +21,6 @@ To use the nodes in the container with the Boltz Backend, use a configuration
 file in `~/.boltz/boltz.conf` similar to this one:
 
 <<< @/boltz.conf{toml} [Boltz configuration]
-
-We recommend adding aliases to control executables of Boltz and nodes to your
-`.bashrc`:
-
-```bash
-# Boltz Docker regtest
-boltzDir="<path to the cloned repository>"
-boltzDataDir="$boltzDir/docker/regtest/data"
-
-alias bitcoin-cli-sim='bitcoin-cli --regtest --rpcport=18443 -rpcuser=boltz -rpcpassword=anoVB0m1KvX0SmpPxvaLVADg0UQVLQTEx3jCD3qtuRI'
-alias elements-cli-sim='elements-cli --regtest --rpcport=18884 -rpcuser=boltz -rpcpassword=anoVB0m1KvX0SmpPxvaLVADg0UQVLQTEx3jCD3qtuRI'
-
-lndCert="$boltzDataDir/lnd/certificates/tls.cert"
-lndMacaroon="$boltzDataDir/lnd/macaroons/admin.macaroon"
-
-alias lnclibtc='lncli --rpcserver=127.0.0.1:10009 --tlscertpath=$lndCert --macaroonpath=$lndMacaroon'
-alias lnclibtc2='lncli --rpcserver=127.0.0.1:10011 --tlscertpath=$lndCert --macaroonpath=$lndMacaroon'
-
-alias lncliltc='lncli --rpcserver=127.0.0.1:11009 --tlscertpath=$lndCert --macaroonpath=$lndMacaroon'
-alias lncliltc2='lncli --rpcserver=127.0.0.1:11010 --tlscertpath=$lndCert --macaroonpath=$lndMacaroon'
-
-alias lightning-cli-sim='docker exec -it regtest lightning-cli'
-
-# Add the Boltz executables to the path
-export PATH="$boltzDir/bin:$PATH"
-```
 
 ## boltzr-cli
 

--- a/docs/boltz.conf
+++ b/docs/boltz.conf
@@ -79,7 +79,7 @@ maxSwapAmount = 4_294_967
 minSwapAmount = 50_000
 
   [pairs.timeoutDelta]
-  chain= 1440
+  chain = 1440
   reverse = 1440
   swapMinimal = 1440
   swapMaximal = 2880
@@ -92,7 +92,7 @@ rate = 1
 fee = 0.25
 swapInFee = 0.1
 
-maxSwapAmount = 1127.0.0.100
+maxSwapAmount = 4_294_967
 minSwapAmount = 2_500
 
 swapTypes = ["chain"]
@@ -104,7 +104,7 @@ swapTypes = ["chain"]
   minSwapAmount = 25_000
 
   [pairs.timeoutDelta]
-  chain= 1440
+  chain = 1440
   reverse = 1440
   swapMinimal = 1440
   swapMaximal = 2880
@@ -153,7 +153,6 @@ maxZeroConfAmount = 0
     privateKeyPath = "./regtest/data/cln2/regtest/hold/client-key.pem"
     certChainPath = "./regtest/data/cln2/regtest/hold/client.pem"
 
-
 [liquid]
 symbol = "L-BTC"
 network = "liquidRegtest"
@@ -182,7 +181,7 @@ providerEndpoint = "http://127.0.0.1:8545"
  [[rsk.tokens]]
  symbol = "RBTC"
 
- maxSwapAmount = 4_294_96700
+ maxSwapAmount = 4_294_967
  minSwapAmount = 10000
 
- minWalletBalance = 10127.0.0.100
+ minWalletBalance = 10_000_000


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated backend setup: regtest source renamed to boltz-regtest and start/stop commands standardized to regtest:start/regtest:stop; Orbstack guidance for Apple Silicon removed (Docker only).
  * Replaced large inline configuration with a concise boltz.conf header and alias/config guidance; condensed boltzr-cli usage notes.
  * Added a comprehensive local/regtest boltz.conf example covering endpoints, sidecar ports, swap/pair settings, currencies/networks, and test credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->