### PR TITLE
fix: replace hard-coded fee with feeFloor variable

### DIFF
--- a/lib/chain/ChainClient.ts
+++ b/lib/chain/ChainClient.ts
@@ -39,6 +39,7 @@ interface IChainClient extends TypedEventEmitter<ChainClientEvents> {
   get isRegtest(): boolean;
   get symbol(): string;
   get currencyType(): CurrencyType;
+  get feeFloor(): number;
 
   connect(): Promise<void>;
 
@@ -75,11 +76,12 @@ class ChainClient extends BaseClient implements IChainClient {
 
   private static readonly coreFeeFloor = 0.2;
 
+  public readonly feeFloor: number;
+
   public currencyType: CurrencyType = CurrencyType.BitcoinLike;
   public isRegtest = false;
 
   protected client: RpcClient;
-  protected feeFloor: number;
 
   private readonly mempoolSpace?: MempoolSpace;
   private readonly rebroadcaster: Rebroadcaster;

--- a/lib/chain/ElementsClient.ts
+++ b/lib/chain/ElementsClient.ts
@@ -42,8 +42,16 @@ class ElementsClient extends ChainClient implements IElementsClient {
       );
     }
 
-    super(logger, sidecar, network, config, ElementsClient.symbol);
-    this.feeFloor = config.feeFloor ?? ElementsClient.elementsFeeFloor;
+    super(
+      logger,
+      sidecar,
+      network,
+      {
+        ...config,
+        feeFloor: config.feeFloor ?? ElementsClient.elementsFeeFloor,
+      },
+      ElementsClient.symbol,
+    );
     this.currencyType = CurrencyType.Liquid;
   }
 

--- a/lib/chain/ElementsWrapper.ts
+++ b/lib/chain/ElementsWrapper.ts
@@ -43,6 +43,10 @@ class ElementsWrapper
 
   public serviceName = () => 'ElementsWrapper';
 
+  public get feeFloor(): number {
+    return this.walletClient().feeFloor;
+  }
+
   public connect = async () => {
     await Promise.all(this.clients.map((c) => c.connect()));
 

--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -806,9 +806,12 @@ class UtxoNursery extends TypedEventEmitter<{
 
     // If the transaction fee is less than 80% of the estimation, Boltz will wait for a confirmation
     //
-    // Special case: if the fee estimation is the lowest possible of 2 sat/vbyte,
+    // Special case: if the fee estimation is at the lowest possible (fee floor),
     // every fee paid by the transaction will be accepted
-    if (transactionFeePerVbyte / feeEstimation < 0.8 && feeEstimation !== 2) {
+    if (
+      transactionFeePerVbyte / feeEstimation < 0.8 &&
+      feeEstimation !== chainClient.feeFloor
+    ) {
       return Errors.LOCKUP_TRANSACTION_FEE_TOO_LOW().message;
     }
 

--- a/test/unit/chain/ChainClient.spec.ts
+++ b/test/unit/chain/ChainClient.spec.ts
@@ -1,0 +1,54 @@
+import Logger from '../../../lib/Logger';
+import ChainClient from '../../../lib/chain/ChainClient';
+import type Sidecar from '../../../lib/sidecar/Sidecar';
+
+jest.mock('../../../lib/chain/RpcClient', () => {
+  return jest.fn().mockImplementation(() => ({}));
+});
+
+jest.mock('../../../lib/chain/Rebroadcaster', () => {
+  return jest.fn().mockImplementation(() => ({}));
+});
+
+describe('ChainClient', () => {
+  const mockSidecar = {
+    on: jest.fn(),
+  } as unknown as Sidecar;
+
+  const baseConfig = {
+    host: '127.0.0.1',
+    port: 8332,
+    user: 'bitcoin',
+    password: 'password',
+  };
+
+  describe('feeFloor config parsing', () => {
+    test('should use default feeFloor when not provided in config', () => {
+      const client = new ChainClient(
+        Logger.disabledLogger,
+        mockSidecar,
+        'mainnet',
+        baseConfig,
+        'BTC',
+      );
+
+      expect(client.feeFloor).toEqual(0.2);
+    });
+
+    test('should use custom feeFloor when provided in config', () => {
+      const customFeeFloor = 1.0;
+      const client = new ChainClient(
+        Logger.disabledLogger,
+        mockSidecar,
+        'mainnet',
+        {
+          ...baseConfig,
+          feeFloor: customFeeFloor,
+        },
+        'BTC',
+      );
+
+      expect(client.feeFloor).toEqual(customFeeFloor);
+    });
+  });
+});

--- a/test/unit/chain/ElementsWrapper.spec.ts
+++ b/test/unit/chain/ElementsWrapper.spec.ts
@@ -1,0 +1,64 @@
+import Logger from '../../../lib/Logger';
+import ElementsWrapper from '../../../lib/chain/ElementsWrapper';
+import type Sidecar from '../../../lib/sidecar/Sidecar';
+
+describe('ElementsWrapper', () => {
+  const mockSidecar = {
+    on: jest.fn(),
+  } as unknown as Sidecar;
+
+  const baseConfig = {
+    host: '127.0.0.1',
+    port: 123,
+    user: 'good',
+    password: 'morning',
+  };
+
+  describe('feeFloor', () => {
+    test('should return feeFloor from wallet client (default)', () => {
+      const wrapper = new ElementsWrapper(
+        Logger.disabledLogger,
+        mockSidecar,
+        'liquidRegtest',
+        baseConfig,
+      );
+
+      // Default Elements fee floor is 0.1
+      expect(wrapper.feeFloor).toEqual(0.1);
+    });
+
+    test('should return custom feeFloor from wallet client', () => {
+      const customFeeFloor = 0.05;
+      const wrapper = new ElementsWrapper(
+        Logger.disabledLogger,
+        mockSidecar,
+        'liquidRegtest',
+        {
+          ...baseConfig,
+          feeFloor: customFeeFloor,
+        },
+      );
+
+      expect(wrapper.feeFloor).toEqual(customFeeFloor);
+    });
+
+    test('should return feeFloor from lowball client when configured', () => {
+      const customFeeFloor = 0.03;
+      const wrapper = new ElementsWrapper(
+        Logger.disabledLogger,
+        mockSidecar,
+        'liquidRegtest',
+        {
+          ...baseConfig,
+          lowball: {
+            ...baseConfig,
+            feeFloor: customFeeFloor,
+          },
+        },
+      );
+
+      // Lowball client is the wallet client when configured
+      expect(wrapper.feeFloor).toEqual(customFeeFloor);
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API to read the configured fee floor (feeFloor) is now exposed; wrappers surface it as a property.

* **Refactor**
  * 0-conf acceptance and fee checks now use the dynamic fee floor instead of a hard-coded constant.

* **Tests**
  * Unit tests and mocks updated to include and validate feeFloor behavior; new tests cover default and custom feeFloor handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->