### PR TITLE
fix: encoding of calldata for token inputs

### DIFF
--- a/boltzr/src/evm/quoter/mod.rs
+++ b/boltzr/src/evm/quoter/mod.rs
@@ -126,6 +126,10 @@ impl QuoteAggregator {
         token_out: Address,
         amount_in: U256,
     ) -> Result<Vec<(U256, Data)>> {
+        if amount_in.is_zero() {
+            return Ok(vec![]);
+        }
+
         debug!("Quoting {}", self.symbol);
 
         Ok(Self::filter_quotes(
@@ -146,6 +150,10 @@ impl QuoteAggregator {
         token_out: Address,
         amount_out: U256,
     ) -> Result<Vec<(U256, Data)>> {
+        if amount_out.is_zero() {
+            return Ok(vec![]);
+        }
+
         debug!("Quoting {}", self.symbol);
 
         Ok(Self::filter_quotes(

--- a/boltzr/src/evm/quoter/uniswap_v3/abis/IERC20.sol
+++ b/boltzr/src/evm/quoter/uniswap_v3/abis/IERC20.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.4.0) (token/ERC20/IERC20.sol)
+
+pragma solidity >=0.4.16;
+
+/**
+ * @dev Interface of the ERC-20 standard as defined in the ERC.
+ */
+interface IERC20 {
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    /**
+     * @dev Returns the value of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the value of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves a `value` amount of tokens from the caller's account to `to`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address to, uint256 value) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the
+     * caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 value) external returns (bool);
+
+    /**
+     * @dev Moves a `value` amount of tokens from `from` to `to` using the
+     * allowance mechanism. `value` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}


### PR DESCRIPTION
- Qouting 0 amounts are wasted calls and showed errors because quoting 0 fails
- Transferring to the Uniswap UniversalRouter is easier to handle than approving the address of the first pool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ERC-20 token handling in swap routing operations.

* **Bug Fixes**
  * Improved handling of edge cases for quote operations with zero amounts.
  * Enhanced token transfer pre-processing in swap execution flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->