### PR TITLE
fix: missing server public key for ark chain swaps

### DIFF
--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -1355,6 +1355,7 @@ class SwapManager {
         ]);
 
         timeouts = vHtlc.timeouts;
+        serverKeys = getHexString(currency.arkNode!.pubkey);
 
         res.theirPublicKey = getHexString(theirPublicKey!);
         res.lockupAddress = vHtlc.vHtlc.address;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with Ark-based swap operations by ensuring proper initialization of server configuration during chain data processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->