### PR TITLE
fix: swagger return type for chain swap claims

### DIFF
--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -1586,7 +1586,7 @@ class SwapRouter extends RouterBase {
      * @openapi
      * /swap/chain/{id}/claim:
      *   post:
-     *     description: Send Boltz a partial signature for its claim transaction and get a partial signature for the clients claim in return
+     *     description: Send Boltz a partial signature for its claim transaction and get a partial signature for the clients claim in return. If client claimed already, only providing "signature" is required and an empty object is returned.
      *     tags: [Chain Swap]
      *     parameters:
      *       - in: path
@@ -1607,7 +1607,9 @@ class SwapRouter extends RouterBase {
      *         content:
      *           application/json:
      *             schema:
-     *               $ref: '#/components/schemas/PartialSignature'
+     *               oneOf:
+     *                 - $ref: '#/components/schemas/PartialSignature'
+     *                 - type: object
      *       '404':
      *         description: When no Chain Swap with the ID could be found
      *         content:

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -1041,7 +1041,7 @@
         }
       },
       "post": {
-        "description": "Send Boltz a partial signature for its claim transaction and get a partial signature for the clients claim in return",
+        "description": "Send Boltz a partial signature for its claim transaction and get a partial signature for the clients claim in return. If client claimed already, only providing \"signature\" is required and an empty object is returned.",
         "tags": [
           "Chain Swap"
         ],
@@ -1072,7 +1072,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PartialSignature"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PartialSignature"
+                    },
+                    {
+                      "type": "object"
+                    }
+                  ]
                 }
               }
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated POST `/swap/chain/{id}/claim` endpoint documentation with refined behavior descriptions for already-claimed scenarios.
  * Response schema expanded to support both structured responses and empty object returns.
  * API clients may now submit signature-only requests that return empty responses when appropriate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->