### PR TITLE
docs: swagger reverse swap expiry unit

### DIFF
--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -1028,7 +1028,7 @@ class SwapRouter extends RouterBase {
      * @openapi
      * /swap/reverse/expiry:
      *   get:
-     *     description: Allowed invoice expiry range per Reverse Swap pair
+     *     description: Allowed invoice expiry range in seconds per Reverse Swap pair
      *     tags: [Reverse Swap]
      *     responses:
      *       '200':

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -703,7 +703,7 @@
     },
     "/swap/reverse/expiry": {
       "get": {
-        "description": "Allowed invoice expiry range per Reverse Swap pair",
+        "description": "Allowed invoice expiry range in seconds per Reverse Swap pair",
         "tags": [
           "Reverse Swap"
         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API documentation for the Reverse Swap expiry endpoint to specify that the allowed invoice expiry range is measured in seconds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->