### PR TITLE
chore: explicit S3 names in setup errors

### DIFF
--- a/boltzr/src/backup/mod.rs
+++ b/boltzr/src/backup/mod.rs
@@ -52,11 +52,15 @@ impl Backup {
     ) -> anyhow::Result<Self> {
         let mut s3_providers: Vec<Box<dyn BackupProvider + Send + Sync>> = Vec::new();
 
-        for (index, provider_config) in config.simple_storage.into_iter().enumerate() {
+        for provider_config in config.simple_storage.into_iter() {
             match providers::s3::S3::new(&provider_config).await {
                 Ok(provider) => s3_providers.push(Box::new(provider)),
                 Err(e) => {
-                    error!("Failed to initialize S3 provider {}: {}", index, e);
+                    error!(
+                        "Failed to initialize S3 provider {}: {}",
+                        providers::s3::S3::name(&provider_config),
+                        e
+                    );
                 }
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during S3 provider initialization to display provider details instead of numeric indices for better clarity when troubleshooting configuration issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->