### PR TITLE
chore: bump LND to v0.20.1

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -37,7 +37,7 @@ NODE_VERSION = BuildArgument(
 
 GOLANG_VERSION = BuildArgument(
     name="GOLANG_VERSION",
-    value="1.25.5-trixie",
+    value="1.25.7-trixie",
 )
 
 BITCOIN_VERSION = "30.2"
@@ -47,7 +47,7 @@ GETH_VERSION = "1.16.7"
 
 C_LIGHTNING_VERSION = "25.12.1"
 ECLAIR_VERSION = "0.13.1"
-LND_VERSION = "0.20.0-beta"
+LND_VERSION = "0.20.1-beta"
 
 BITCOIN_BUILD_ARG = BuildArgument(
     name="BITCOIN_VERSION",

--- a/lib/VersionCheck.ts
+++ b/lib/VersionCheck.ts
@@ -90,7 +90,7 @@ class VersionCheck {
     },
     [LndClient.serviceName]: {
       minimal: '0.19.0',
-      maximal: '0.20.0',
+      maximal: '0.20.1',
     },
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version to 1.25.7
  * Updated LND (Lightning Network Daemon) version to 0.20.1-beta
  * Updated maximum supported LND version compatibility check to 0.20.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->