### PR TITLE
docs: add overview which amounts limits are enforced on by swap type

### DIFF
--- a/docs/swap-limits-and-fees.md
+++ b/docs/swap-limits-and-fees.md
@@ -92,6 +92,14 @@ rejected.
 Each pair has limits that define acceptable swap amounts. Check the pair
 endpoints for current limits.
 
+Limits are enforced on the following amounts:
+
+| Swap Type     | Enforced On      |
+| ------------- | ---------------- |
+| **Submarine** | Invoice amount   |
+| **Reverse**   | Invoice amount   |
+| **Chain**     | User lock amount |
+
 ### Minimum Amount
 
 The minimum ensures the swap covers miner fees with sufficient margin. Minimums


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Added a new subsection clarifying which amounts have enforced limits, with explicit targets for submarine, reverse, and chain swaps.
- Clarified minimum amount behavior, noting dynamic adjustments based on current network fee conditions.
- Documented distinct "standard" and "batched" minimums for submarine swaps and the conditions under which batching applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->