### PR TITLE
chore: rm togglereverse mm command

### DIFF
--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -87,9 +87,7 @@ Response object:
     invoice for the miner fee to be paid before the actual hold invoice of a
     Reverse Swap is revealed.
 - `warnings`: An array of strings that indicate that some feature of Boltz might
-  be disabled or restricted. An example is:
-  - `reverse.swaps.disabled`: Means that all reverse swaps (from Lightning to
-    the chain) are disabled.
+  be disabled or restricted.
 - `pairs`: An object containing the supported pairs. The keys of the values are
   the IDs of the pairs (`BTC/BTC` is a special case with mainchain bitcoin as
   _base asset_ and Lightning bitcoin as _quote asset_) and the values itself

--- a/lib/consts/Enums.ts
+++ b/lib/consts/Enums.ts
@@ -87,9 +87,7 @@ export const FinalChainSwapEvents = [
   SwapUpdateEvent.TransactionRefunded,
 ];
 
-export enum ServiceWarning {
-  ReverseSwapsDisabled = 'reverse.swaps.disabled',
-}
+export enum ServiceWarning {}
 
 export enum ServiceInfo {
   PrepayMinerFee = 'prepay.minerfee',

--- a/lib/notifications/CommandHandler.ts
+++ b/lib/notifications/CommandHandler.ts
@@ -53,7 +53,6 @@ enum Command {
   Backup = 'backup',
   GetAddress = 'getaddress',
   SweepSwaps = 'sweepswaps',
-  ToggleReverseSwaps = 'togglereverse',
 }
 
 type Usage = {
@@ -203,13 +202,6 @@ class CommandHandler {
           ],
           executor: this.sweepSwaps,
           description: 'sweeps deferred swap claims',
-        },
-      ],
-      [
-        Command.ToggleReverseSwaps,
-        {
-          executor: this.toggleReverseSwaps,
-          description: 'enables or disables reverse swaps',
         },
       ],
     ]);
@@ -665,17 +657,6 @@ class CommandHandler {
         `Could not sweep swaps: ${formatError(e)}`,
       );
     }
-  };
-
-  private toggleReverseSwaps = async () => {
-    this.service.allowReverseSwaps = !this.service.allowReverseSwaps;
-
-    const message = `${
-      this.service.allowReverseSwaps ? 'Enabled' : 'Disabled'
-    } Reverse Swaps`;
-
-    this.logger.info(message);
-    await this.notificationClient.sendMessage(message);
   };
 
   /*

--- a/lib/service/Errors.ts
+++ b/lib/service/Errors.ts
@@ -35,10 +35,6 @@ export default {
     message: `${amount} is less than minimal of ${minimalAmount}`,
     code: concatErrorCode(ErrorCodePrefix.Service, 7),
   }),
-  REVERSE_SWAPS_DISABLED: (): Error => ({
-    message: 'reverse swaps are disabled',
-    code: concatErrorCode(ErrorCodePrefix.Service, 8),
-  }),
   ONCHAIN_AMOUNT_TOO_LOW: (): Error => ({
     message: 'onchain amount is too low',
     code: concatErrorCode(ErrorCodePrefix.Service, 9),

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -43,7 +43,7 @@ import {
   OrderSide,
   PercentageFeeType,
   ServiceInfo,
-  ServiceWarning,
+  type ServiceWarning,
   SwapType,
   SwapUpdateEvent,
   SwapVersion,
@@ -143,8 +143,6 @@ type SomePair =
   | ChainPairTypeTaproot;
 
 class Service {
-  public allowReverseSwaps = true;
-
   private nodeInfo: NodeInfo;
   public swapManager: SwapManager;
   public eventHandler: EventHandler;
@@ -660,15 +658,7 @@ class Service {
     return infos;
   };
 
-  public getWarnings = (): ServiceWarning[] => {
-    const warnings: ServiceWarning[] = [];
-
-    if (!this.allowReverseSwaps) {
-      warnings.push(ServiceWarning.ReverseSwapsDisabled);
-    }
-
-    return warnings;
-  };
+  public getWarnings = (): ServiceWarning[] => [];
 
   public getNodes = () => this.nodeInfo.uris;
 
@@ -1765,10 +1755,6 @@ class Service {
 
     referralId?: string;
   }> => {
-    if (!this.allowReverseSwaps) {
-      throw Errors.REVERSE_SWAPS_DISABLED();
-    }
-
     const side = this.getOrderSide(args.orderSide);
     const referralId = await this.getReferralId(
       args.referralId,

--- a/test/unit/notifications/CommandHandler.spec.ts
+++ b/test/unit/notifications/CommandHandler.spec.ts
@@ -195,7 +195,6 @@ Stats.generate = jest.fn().mockResolvedValue({
 
 describe('CommandHandler', () => {
   const service = mockedService();
-  service.allowReverseSwaps = true;
 
   new CommandHandler(
     Logger.disabledLogger,
@@ -257,8 +256,7 @@ describe('CommandHandler', () => {
         '**pendingsweeps**: gets all pending sweeps\n' +
         '**getreferrals**: gets stats for all referral IDs\n' +
         '**getaddress**: gets an address for a currency\n' +
-        '**sweepswaps**: sweeps deferred swap claims\n' +
-        '**togglereverse**: enables or disables reverse swaps',
+        '**sweepswaps**: sweeps deferred swap claims',
     );
   });
 
@@ -666,24 +664,6 @@ describe('CommandHandler', () => {
         `${codeBlock}${stringify({ [symbol.toUpperCase()]: await service.swapManager.deferredClaimer.sweepSymbol(symbol.toUpperCase()) })}${codeBlock}`,
       );
     });
-  });
-
-  test('should toggle reverse swaps', async () => {
-    sendMessage('togglereverse');
-    await wait(commandWaitMs);
-
-    expect(service.allowReverseSwaps).toBeFalsy();
-
-    expect(mockSendMessage).toHaveBeenCalledTimes(1);
-    expect(mockSendMessage).toHaveBeenCalledWith('Disabled Reverse Swaps');
-
-    sendMessage('togglereverse');
-    await wait(commandWaitMs);
-
-    expect(service.allowReverseSwaps).toBeTruthy();
-
-    expect(mockSendMessage).toHaveBeenCalledTimes(2);
-    expect(mockSendMessage).toHaveBeenCalledWith('Enabled Reverse Swaps');
   });
 
   afterAll(async () => {

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -29,7 +29,6 @@ import {
   OrderSide,
   PercentageFeeType,
   ServiceInfo,
-  ServiceWarning,
   SwapType,
   SwapUpdateEvent,
   SwapVersion,
@@ -1285,16 +1284,6 @@ describe('Service', () => {
       warnings: [],
     });
 
-    service.allowReverseSwaps = false;
-
-    expect(service.getPairs()).toEqual({
-      pairs,
-      info: [],
-      warnings: [ServiceWarning.ReverseSwapsDisabled],
-    });
-
-    service.allowReverseSwaps = true;
-
     service['prepayMinerFee'] = true;
 
     expect(service.getPairs()).toEqual({
@@ -2455,8 +2444,6 @@ describe('Service', () => {
     mockGetSwapResult = null;
     mockGetReverseSwapResult = null;
 
-    service.allowReverseSwaps = true;
-
     let pair = 'BTC/BTC';
     const orderSide = 'buy';
     const referralId = 'asdf';
@@ -2640,22 +2627,6 @@ describe('Service', () => {
       }),
     ).rejects.toEqual(Errors.BENEATH_MINIMAL_AMOUNT(invoiceAmountLimit, 1));
 
-    // Throw if reverse swaps are disabled
-    service.allowReverseSwaps = false;
-
-    await expect(
-      service.createReverseSwap({
-        orderSide,
-        preimageHash,
-        invoiceAmount,
-        claimPublicKey,
-        pairId: pair,
-        version: SwapVersion.Legacy,
-      }),
-    ).rejects.toEqual(Errors.REVERSE_SWAPS_DISABLED());
-
-    service.allowReverseSwaps = true;
-
     const invalidNumber = 3.141;
 
     // Throw if invoice amount is not a whole number
@@ -2687,8 +2658,6 @@ describe('Service', () => {
     ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
     mockGetSwapResult = null;
     mockGetReverseSwapResult = null;
-
-    service.allowReverseSwaps = true;
 
     const pair = 'BTC/BTC';
     const orderSide = 'buy';
@@ -2943,8 +2912,6 @@ describe('Service', () => {
   });
 
   test('should create Reverse Swaps with specified onchain amount', async () => {
-    service.allowReverseSwaps = true;
-
     const pair = 'BTC/BTC';
     const orderSide = 'buy';
     const onchainAmount = 97680;
@@ -3147,8 +3114,6 @@ describe('Service', () => {
 
   describe('createReverseSwap BOLT12', () => {
     test('should create reverse swaps with bolt12 invoices', async () => {
-      service.allowReverseSwaps = true;
-
       const paymentHash = randomBytes(32);
       const decodedInvoice = {
         type: InvoiceType.Bolt12Invoice,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Revert**
  * Removed the ToggleReverseSwaps command and associated toggle functionality for disabling reverse swaps.
  * Removed reverse swap disable warnings and related error handling from service configuration.
  * Simplified API by eliminating the configuration flag controlling reverse swap availability.
  * Updated API documentation to reflect changes to service warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->