### PR TITLE
feat: allow refunding commitments before linking

### DIFF
--- a/boltzr-cli/src/main.rs
+++ b/boltzr-cli/src/main.rs
@@ -380,6 +380,14 @@ enum EvmCommands {
         )]
         vrs: bool,
     },
+    #[command(about = "Formats a signature in v/r/s")]
+    PrintSignature {
+        #[arg(
+            help = "Signature to format (65-byte hex, with or without 0x prefix)",
+            value_parser = parsers::parse_signature
+        )]
+        signature: alloy::signers::Signature,
+    },
 }
 
 #[derive(Clone, Subcommand)]
@@ -645,7 +653,7 @@ async fn run_command(cli: Cli) -> Result<()> {
                         *lockup_tx_hash,
                     )
                     .await?;
-                    print_signature(signature, *vrs)?;
+                    print_signature(&signature, *vrs)?;
                 }
                 EvmCommands::SignRefund {
                     preimage_hash,
@@ -660,7 +668,10 @@ async fn run_command(cli: Cli) -> Result<()> {
                         *lockup_tx_hash,
                     )
                     .await?;
-                    print_signature(signature, *vrs)?;
+                    print_signature(&signature, *vrs)?;
+                }
+                EvmCommands::PrintSignature { signature } => {
+                    print_signature(signature, true)?;
                 }
             }
         }
@@ -1009,7 +1020,7 @@ fn print_pretty<T: Serialize>(value: &T) -> Result<()> {
     Ok(())
 }
 
-fn print_signature(signature: alloy::signers::Signature, split_vrs: bool) -> Result<()> {
+fn print_signature(signature: &alloy::signers::Signature, split_vrs: bool) -> Result<()> {
     let signature_bytes = signature.as_bytes();
     let encoded = format!("0x{}", alloy::hex::encode(signature_bytes));
 

--- a/boltzr-cli/src/parsers.rs
+++ b/boltzr-cli/src/parsers.rs
@@ -116,6 +116,12 @@ pub fn parse_public_key(public_key: &str) -> Result<PublicKey, String> {
     PublicKey::from_slice(&bytes).map_err(|e| format!("invalid public key: {e}"))
 }
 
+pub fn parse_signature(signature: &str) -> Result<alloy::signers::Signature, String> {
+    signature
+        .parse::<alloy::signers::Signature>()
+        .map_err(|e| format!("invalid signature: {e}"))
+}
+
 pub fn parse_json_object(json: &str) -> Result<serde_json::Value, String> {
     let value = serde_json::from_str(json).map_err(|e| format!("invalid json: {e}"))?;
     match value {
@@ -302,5 +308,29 @@ mod tests {
             expected_prefix,
             err
         );
+    }
+
+    #[rstest]
+    #[case(
+        "0xd8b4ed2186a0eb3c1dcff031a4753ef1813264b3e7f3df4ce915f2e09ebb93055e36dfc5f01fb7dcd43b209770f6c497ac6869dffaf51431c3e1ad92129a0be01c"
+    )]
+    #[case(
+        "d8b4ed2186a0eb3c1dcff031a4753ef1813264b3e7f3df4ce915f2e09ebb93055e36dfc5f01fb7dcd43b209770f6c497ac6869dffaf51431c3e1ad92129a0be01c"
+    )]
+    fn test_parse_signature_valid(#[case] input: &str) {
+        let signature = parse_signature(input).unwrap();
+        assert_eq!(signature.as_bytes().len(), 65);
+    }
+
+    #[rstest]
+    #[case("invalid")]
+    #[case("0x1234")]
+    #[case(
+        "0x50f29beaafa5f4e6780b4e477335dca0bfee4079cfa90fca991e4448230d171973de798da616df06125d2c570f3fc70647dfa3d06f5029907141b626372b0abf"
+    )]
+    fn test_parse_signature_invalid(#[case] input: &str) {
+        let result = parse_signature(input);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().starts_with("invalid signature:"));
     }
 }

--- a/docs/commitment-swaps.md
+++ b/docs/commitment-swaps.md
@@ -215,8 +215,59 @@ hash.
 
 ## Refunding Commitment Swaps
 
-Refunds work the same as standard EVM swaps:
+### Commitment Not Linked to a Swap
 
-- **After timelock expires**: Call `refund` with the lockup parameters
-- **Cooperative refund**: Request an EIP-712 refund signature from Boltz via
-  `GET /v2/swap/submarine/{id}/refund` and use `refundCooperative`
+If the lockup is not linked to any swap yet, request a cooperative refund
+signature using the lockup transaction:
+
+```
+POST /v2/commitment/{currency}/refund
+```
+
+**Request body:**
+
+```json
+{
+  "transactionHash": "0x...",
+  "logIndex": 0,
+  "refundAddressSignature": "0x..."
+}
+```
+
+- `transactionHash`: transaction containing the lockup event
+- `logIndex`: optional, required when multiple lockups are in the same
+  transaction
+- `refundAddressSignature`: signature from your `refundAddress` over:
+
+  ```
+  Boltz commitment refund authorization
+  chain: {currency}
+  transactionHash: {transactionHash}
+  logIndex: {logIndex or "none"}
+  ```
+
+**Response:**
+
+```json
+{
+  "signature": "0x..."
+}
+```
+
+Use that signature with `refundCooperative` and the exact lockup values from the
+transaction.
+
+### Commitment Linked to a Swap
+
+Once the commitment is linked to a swap, use the swap refund endpoint:
+
+```
+GET /v2/swap/submarine/{id}/refund
+```
+
+Then execute `refundCooperative` with the returned signature.
+
+### Timelock Refund
+
+After timelock expiry, refunds work the same as standard EVM swaps by calling
+`refund` with the lockup parameters

--- a/lib/db/repositories/CommitmentRepository.ts
+++ b/lib/db/repositories/CommitmentRepository.ts
@@ -37,7 +37,11 @@ class CommitmentRepository {
         },
       },
     });
-    return new Map(commitments.map((c) => [c.swapId, c]));
+    return new Map(
+      commitments
+        .filter((c): c is Commitment & { swapId: string } => c.swapId !== null)
+        .map((c) => [c.swapId, c]),
+    );
   };
 
   public static getByLockupHash = async (
@@ -48,6 +52,44 @@ class CommitmentRepository {
         lockupHash,
       },
     });
+  };
+
+  public static markRefunded = async (
+    lockupHash: string,
+    transactionHash: string,
+  ): Promise<Commitment> => {
+    return await Database.sequelize.transaction(
+      {
+        isolationLevel: Transaction.ISOLATION_LEVELS.SERIALIZABLE,
+      },
+      async (transaction) => {
+        const existing = await Commitment.findOne({
+          where: { lockupHash },
+          transaction,
+          lock: transaction.LOCK.UPDATE,
+        });
+
+        if (existing !== null) {
+          if (existing.swapId !== null) {
+            throw new Error('linked commitment cannot be marked as refunded');
+          }
+
+          existing.refunded = true;
+          existing.transactionHash = transactionHash;
+          await existing.save({ transaction });
+          return existing;
+        }
+
+        return await Commitment.create(
+          {
+            lockupHash,
+            transactionHash,
+            refunded: true,
+          },
+          { transaction },
+        );
+      },
+    );
   };
 }
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -233,6 +233,11 @@ class Service {
       this.sidecar,
       this.balanceCheck,
     );
+    this.walletManager.ethereumManagers.forEach((manager) => {
+      manager.commitments.setRefundSignatureLock(
+        this.swapManager.eipSigner.refundSignatureLock,
+      );
+    });
 
     this.eventHandler = new EventHandler(this.logger, this.swapManager.nursery);
 

--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -1,4 +1,5 @@
 import AsyncLock from 'async-lock';
+import { verifyMessage } from 'ethers';
 import { Op } from 'sequelize';
 import type Logger from '../../Logger';
 import {
@@ -12,19 +13,38 @@ import type { ERC20SwapValues } from '../../consts/Types';
 import type Swap from '../../db/models/Swap';
 import type { ChainSwapInfo } from '../../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../../db/repositories/ChainSwapRepository';
+import CommitmentRepository from '../../db/repositories/CommitmentRepository';
 import SwapRepository from '../../db/repositories/SwapRepository';
 import type Sidecar from '../../sidecar/Sidecar';
 import type { Currency } from '../../wallet/WalletManager';
 import type WalletManager from '../../wallet/WalletManager';
 import {
+  computeLockupHash,
+  isCommitmentPreimageHash,
   queryERC20SwapValuesFromLock,
+  queryERC20SwapValuesFromTransaction,
   queryEtherSwapValuesFromLock,
+  queryEtherSwapValuesFromTransaction,
 } from '../../wallet/ethereum/contracts/ContractUtils';
 import Errors from '../Errors';
 import MusigSigner from './MusigSigner';
 
+export type RefundSignatureLock = <T>(cb: () => Promise<T>) => Promise<T>;
+
 class EipSigner {
   private static readonly refundSignatureLock = 'refundSignature';
+
+  public static commitmentRefundAddressProofMessage = (
+    chainSymbol: string,
+    transactionHash: string,
+    logIndex?: number,
+  ): string =>
+    [
+      'Boltz commitment refund authorization',
+      `chain: ${chainSymbol}`,
+      `transactionHash: ${transactionHash}`,
+      `logIndex: ${logIndex ?? 'none'}`,
+    ].join('\n');
 
   private readonly lock = new AsyncLock();
 
@@ -125,6 +145,147 @@ class EipSigner {
 
       return `0x${getHexString(sidecarRes)}`;
     });
+
+  public signCommitmentRefund = async (
+    chainSymbol: string,
+    transactionHash: string,
+    refundAddressSignature: string,
+    logIndex?: number,
+  ) =>
+    this.refundSignatureLock(async () => {
+      const manager = this.walletManager.ethereumManagers.find((man) =>
+        man.hasSymbol(chainSymbol),
+      );
+
+      if (manager === undefined) {
+        throw 'chain currency is not EVM based';
+      }
+
+      const transaction =
+        await manager.provider.getTransaction(transactionHash);
+      if (transaction?.to === undefined || transaction.to === null) {
+        throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+          'lockup transaction not found',
+        );
+      }
+
+      const contracts = await manager.contractsForAddress(transaction.to);
+      if (contracts === undefined) {
+        throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND('contract not found');
+      }
+
+      const isEtherSwap = manager.networkDetails.symbol === chainSymbol;
+      const lockupValues = isEtherSwap
+        ? await queryEtherSwapValuesFromTransaction(
+            manager.provider,
+            contracts.etherSwap,
+            transactionHash,
+            logIndex,
+          )
+        : await queryERC20SwapValuesFromTransaction(
+            manager.provider,
+            contracts.erc20Swap,
+            transactionHash,
+            logIndex,
+          );
+
+      if (
+        lockupValues.claimAddress.toLowerCase() !==
+        manager.address.toLowerCase()
+      ) {
+        throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+          'claim address mismatch',
+        );
+      }
+
+      if (!isCommitmentPreimageHash(lockupValues.preimageHash)) {
+        throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+          'commitment preimage hash has to be all zeros',
+        );
+      }
+      this.validateRefundAddressSignature(
+        chainSymbol,
+        transactionHash,
+        logIndex,
+        lockupValues.refundAddress,
+        refundAddressSignature,
+      );
+
+      const tokenAddress = !isEtherSwap
+        ? (lockupValues as ERC20SwapValues).tokenAddress
+        : undefined;
+      if (!isEtherSwap) {
+        const expectedTokenAddress = manager.tokenAddresses.get(chainSymbol);
+        if (expectedTokenAddress === undefined) {
+          throw Errors.NOT_SUPPORTED_BY_SYMBOL(chainSymbol);
+        }
+        if (
+          tokenAddress!.toLowerCase() !== expectedTokenAddress.toLowerCase()
+        ) {
+          throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+            'token address mismatch',
+          );
+        }
+      }
+
+      const lockupHash = await computeLockupHash(
+        isEtherSwap ? contracts.etherSwap : contracts.erc20Swap,
+        {
+          preimageHash: lockupValues.preimageHash,
+          amount: lockupValues.amount,
+          claimAddress: lockupValues.claimAddress,
+          refundAddress: lockupValues.refundAddress,
+          timelock: BigInt(lockupValues.timelock),
+          tokenAddress,
+        },
+      );
+
+      this.logger.debug(
+        `Creating EIP-712 signature for refund of unlinked commitment ${lockupHash}: ${transactionHash}`,
+      );
+
+      const sidecarRes = await this.sidecar.signEvmRefund(
+        manager.networkDetails.symbol,
+        transaction.to,
+        lockupValues.preimageHash,
+        lockupValues.amount,
+        tokenAddress,
+        lockupValues.timelock,
+      );
+      await CommitmentRepository.markRefunded(lockupHash, transactionHash);
+
+      return `0x${getHexString(sidecarRes)}`;
+    });
+
+  private validateRefundAddressSignature = (
+    chainSymbol: string,
+    transactionHash: string,
+    logIndex: number | undefined,
+    refundAddress: string,
+    refundAddressSignature: string,
+  ) => {
+    let recoveredAddress: string;
+    try {
+      recoveredAddress = verifyMessage(
+        EipSigner.commitmentRefundAddressProofMessage(
+          chainSymbol,
+          transactionHash,
+          logIndex,
+        ),
+        refundAddressSignature,
+      );
+    } catch {
+      throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+        'invalid refund address signature',
+      );
+    }
+
+    if (recoveredAddress.toLowerCase() !== refundAddress.toLowerCase()) {
+      throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+        'refund address signature mismatch',
+      );
+    }
+  };
 
   private getSwap = async (
     swapIdOrPreimageHash: string,

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -3201,7 +3201,7 @@
                     "description": "Transaction hash of the lockup transaction"
                   },
                   "logIndex": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "Log index of the lockup event if there are multiple in the transaction"
                   },
                   "maxOverpaymentPercentage": {
@@ -3228,6 +3228,82 @@
           },
           "400": {
             "description": "Error that caused the request to fail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commitment/{currency}/refund": {
+      "post": {
+        "tags": [
+          "Commitment"
+        ],
+        "description": "Get an EIP-712 signature for a cooperative refund of an unlinked commitment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "currency",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "transactionHash",
+                  "refundAddressSignature"
+                ],
+                "properties": {
+                  "transactionHash": {
+                    "type": "string",
+                    "description": "Transaction hash containing the lockup event"
+                  },
+                  "logIndex": {
+                    "type": "integer",
+                    "description": "Optional log index in case of multiple lockups in one transaction"
+                  },
+                  "refundAddressSignature": {
+                    "type": "string",
+                    "description": "Signature of the refund address over the commitment refund authorization message"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "EIP-712 signature",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "signature"
+                  ],
+                  "properties": {
+                    "signature": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error that caused signature request to fail",
             "content": {
               "application/json": {
                 "schema": {

--- a/test/integration/db/repositories/CommitmentRepository.spec.ts
+++ b/test/integration/db/repositories/CommitmentRepository.spec.ts
@@ -11,17 +11,22 @@ describe('CommitmentRepository', () => {
 
   const createCommitment = (
     overrides?: Partial<{
-      swapId: string;
+      swapId: string | null;
       lockupHash: string;
       transactionHash: string;
       signature: Buffer;
+      refunded: boolean;
     }>,
   ) => ({
-    swapId: overrides?.swapId ?? `swap-${randomBytes(8).toString('hex')}`,
+    swapId:
+      overrides?.swapId === undefined
+        ? `swap-${randomBytes(8).toString('hex')}`
+        : overrides.swapId,
     lockupHash: overrides?.lockupHash ?? `0x${randomBytes(32).toString('hex')}`,
     transactionHash:
       overrides?.transactionHash ?? `0x${randomBytes(32).toString('hex')}`,
     signature: overrides?.signature ?? randomBytes(65),
+    refunded: overrides?.refunded ?? false,
   });
 
   beforeAll(async () => {
@@ -49,6 +54,7 @@ describe('CommitmentRepository', () => {
       expect(result.lockupHash).toEqual(commitment.lockupHash);
       expect(result.transactionHash).toEqual(commitment.transactionHash);
       expect(result.signature).toEqual(commitment.signature);
+      expect(result.refunded).toEqual(false);
       expect(result.createdAt).toBeDefined();
       expect(result.updatedAt).toBeDefined();
     });
@@ -85,6 +91,15 @@ describe('CommitmentRepository', () => {
 
       expect(result.transactionHash).toEqual(transactionHash);
     });
+
+    test('should create an unlinked commitment without swapId', async () => {
+      const commitment = createCommitment({ swapId: null });
+
+      const result = await CommitmentRepository.create(commitment);
+
+      expect(result.swapId).toBeNull();
+      expect(result.lockupHash).toEqual(commitment.lockupHash);
+    });
   });
 
   describe('getBySwapId', () => {
@@ -92,7 +107,7 @@ describe('CommitmentRepository', () => {
       const commitment = createCommitment();
       await CommitmentRepository.create(commitment);
 
-      const result = await CommitmentRepository.getBySwapId(commitment.swapId);
+      const result = await CommitmentRepository.getBySwapId(commitment.swapId!);
 
       expect(result).not.toBeNull();
       expect(result!.swapId).toEqual(commitment.swapId);
@@ -120,19 +135,19 @@ describe('CommitmentRepository', () => {
       await CommitmentRepository.create(commitment3);
 
       const result = await CommitmentRepository.getBySwapIds([
-        commitment1.swapId,
-        commitment2.swapId,
-        commitment3.swapId,
+        commitment1.swapId!,
+        commitment2.swapId!,
+        commitment3.swapId!,
       ]);
 
       expect(result.size).toEqual(3);
-      expect(result.get(commitment1.swapId)!.swapId).toEqual(
+      expect(result.get(commitment1.swapId!)!.swapId).toEqual(
         commitment1.swapId,
       );
-      expect(result.get(commitment2.swapId)!.swapId).toEqual(
+      expect(result.get(commitment2.swapId!)!.swapId).toEqual(
         commitment2.swapId,
       );
-      expect(result.get(commitment3.swapId)!.swapId).toEqual(
+      expect(result.get(commitment3.swapId!)!.swapId).toEqual(
         commitment3.swapId,
       );
     });
@@ -160,16 +175,16 @@ describe('CommitmentRepository', () => {
       await CommitmentRepository.create(commitment2);
 
       const result = await CommitmentRepository.getBySwapIds([
-        commitment1.swapId,
+        commitment1.swapId!,
         'non-existent',
-        commitment2.swapId,
+        commitment2.swapId!,
       ]);
 
       expect(result.size).toEqual(2);
-      expect(result.get(commitment1.swapId)!.swapId).toEqual(
+      expect(result.get(commitment1.swapId!)!.swapId).toEqual(
         commitment1.swapId,
       );
-      expect(result.get(commitment2.swapId)!.swapId).toEqual(
+      expect(result.get(commitment2.swapId!)!.swapId).toEqual(
         commitment2.swapId,
       );
       expect(result.get('non-existent')).toBeUndefined();
@@ -211,6 +226,49 @@ describe('CommitmentRepository', () => {
       });
       const result = await CommitmentRepository.create(commitment);
       expect(result.signatureEthers.serialized).toEqual(signature.serialized);
+    });
+  });
+
+  describe('markRefunded', () => {
+    test('should create refunded marker for unknown lockup hash', async () => {
+      const lockupHash = `0x${randomBytes(32).toString('hex')}`;
+      const transactionHash = `0x${randomBytes(32).toString('hex')}`;
+
+      const result = await CommitmentRepository.markRefunded(
+        lockupHash,
+        transactionHash,
+      );
+
+      expect(result.lockupHash).toEqual(lockupHash);
+      expect(result.transactionHash).toEqual(transactionHash);
+      expect(result.swapId).toBeNull();
+      expect(result.refunded).toEqual(true);
+      expect(result.signature).toBeNull();
+    });
+
+    test('should mark existing unlinked commitment as refunded', async () => {
+      const commitment = createCommitment({ swapId: null, refunded: false });
+      await CommitmentRepository.create(commitment);
+
+      const result = await CommitmentRepository.markRefunded(
+        commitment.lockupHash,
+        commitment.transactionHash,
+      );
+
+      expect(result.refunded).toEqual(true);
+      expect(result.swapId).toBeNull();
+    });
+
+    test('should throw when commitment is already linked to a swap', async () => {
+      const commitment = createCommitment({ swapId: 'linked-swap' });
+      await CommitmentRepository.create(commitment);
+
+      await expect(
+        CommitmentRepository.markRefunded(
+          commitment.lockupHash,
+          commitment.transactionHash,
+        ),
+      ).rejects.toThrow('linked commitment cannot be marked as refunded');
     });
   });
 });

--- a/test/integration/wallet/ethereum/contracts/Commitments.spec.ts
+++ b/test/integration/wallet/ethereum/contracts/Commitments.spec.ts
@@ -777,6 +777,9 @@ describe('Commitments', () => {
         [contract],
         new Map(),
       );
+      commitments.setRefundSignatureLock(async <T>(cb: () => Promise<T>) =>
+        cb(),
+      );
 
       return commitments;
     };

--- a/test/unit/api/v2/routers/CommitmentRouter.spec.ts
+++ b/test/unit/api/v2/routers/CommitmentRouter.spec.ts
@@ -36,6 +36,11 @@ describe('CommitmentRouter', () => {
         },
       ],
     },
+    swapManager: {
+      eipSigner: {
+        signCommitmentRefund: jest.fn().mockResolvedValue('0xrefundsignature'),
+      },
+    },
   } as unknown as Service;
 
   const commitmentRouter = new CommitmentRouter(Logger.disabledLogger, service);
@@ -60,9 +65,13 @@ describe('CommitmentRouter', () => {
       expect.anything(),
     );
 
-    expect(mockedRouter.post).toHaveBeenCalledTimes(1);
+    expect(mockedRouter.post).toHaveBeenCalledTimes(2);
     expect(mockedRouter.post).toHaveBeenCalledWith(
       '/:currency',
+      expect.anything(),
+    );
+    expect(mockedRouter.post).toHaveBeenCalledWith(
+      '/:currency/refund',
       expect.anything(),
     );
   });
@@ -124,24 +133,26 @@ describe('CommitmentRouter', () => {
   });
 
   describe('POST /:currency', () => {
+    const validTransactionHash = `0x${'a'.repeat(64)}`;
+
     test.each`
       error                                            | params                  | body
-      ${'undefined parameter: currency'}               | ${{}}                   | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx' }}
-      ${'invalid parameter: currency'}                 | ${{ currency: 123 }}    | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx' }}
-      ${'undefined parameter: swapId'}                 | ${{ currency: 'RBTC' }} | ${{ signature: 'sig', transactionHash: 'tx' }}
-      ${'invalid parameter: swapId'}                   | ${{ currency: 'RBTC' }} | ${{ swapId: 123, signature: 'sig', transactionHash: 'tx' }}
-      ${'undefined parameter: signature'}              | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', transactionHash: 'tx' }}
-      ${'invalid parameter: signature'}                | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 123, transactionHash: 'tx' }}
+      ${'undefined parameter: currency'}               | ${{}}                   | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash }}
+      ${'invalid parameter: currency'}                 | ${{ currency: 123 }}    | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash }}
+      ${'undefined parameter: swapId'}                 | ${{ currency: 'RBTC' }} | ${{ signature: 'sig', transactionHash: validTransactionHash }}
+      ${'invalid parameter: swapId'}                   | ${{ currency: 'RBTC' }} | ${{ swapId: 123, signature: 'sig', transactionHash: validTransactionHash }}
+      ${'undefined parameter: signature'}              | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', transactionHash: validTransactionHash }}
+      ${'invalid parameter: signature'}                | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 123, transactionHash: validTransactionHash }}
       ${'undefined parameter: transactionHash'}        | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig' }}
       ${'invalid parameter: transactionHash'}          | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 123 }}
-      ${'invalid parameter: logIndex'}                 | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx', logIndex: 'invalid' }}
-      ${'invalid parameter: logIndex'}                 | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx', logIndex: -1 }}
-      ${'invalid parameter: logIndex'}                 | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx', logIndex: 1.5 }}
-      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx', maxOverpaymentPercentage: 'invalid' }}
-      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx', maxOverpaymentPercentage: -1 }}
-      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx', maxOverpaymentPercentage: 11 }}
-      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx', maxOverpaymentPercentage: Infinity }}
-      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: 'tx', maxOverpaymentPercentage: NaN }}
+      ${'invalid parameter: logIndex'}                 | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash, logIndex: 'invalid' }}
+      ${'invalid parameter: logIndex'}                 | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash, logIndex: -1 }}
+      ${'invalid parameter: logIndex'}                 | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash, logIndex: 1.5 }}
+      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash, maxOverpaymentPercentage: 'invalid' }}
+      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash, maxOverpaymentPercentage: -1 }}
+      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash, maxOverpaymentPercentage: 11 }}
+      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash, maxOverpaymentPercentage: Infinity }}
+      ${'invalid parameter: maxOverpaymentPercentage'} | ${{ currency: 'RBTC' }} | ${{ swapId: 'id', signature: 'sig', transactionHash: validTransactionHash, maxOverpaymentPercentage: NaN }}
     `(
       'should not post commitment with invalid parameters ($error)',
       async ({ params, body, error }) => {
@@ -158,7 +169,7 @@ describe('CommitmentRouter', () => {
       const currency = 'RBTC';
       const swapId = 'swap123';
       const signature = '0xsignature';
-      const transactionHash = '0xtxhash';
+      const transactionHash = validTransactionHash;
 
       const res = mockResponse();
       await commitmentRouter['postCommitment'](
@@ -197,7 +208,7 @@ describe('CommitmentRouter', () => {
       const currency = 'RBTC';
       const swapId = 'swap123';
       const signature = '0xsignature';
-      const transactionHash = '0xtxhash';
+      const transactionHash = validTransactionHash;
       const logIndex = 2;
 
       const res = mockResponse();
@@ -229,7 +240,7 @@ describe('CommitmentRouter', () => {
       const currency = 'RBTC';
       const swapId = 'swap123';
       const signature = '0xsignature';
-      const transactionHash = '0xtxhash';
+      const transactionHash = validTransactionHash;
       const maxOverpaymentPercentage = 3.5;
 
       const res = mockResponse();
@@ -262,13 +273,113 @@ describe('CommitmentRouter', () => {
       await expect(
         commitmentRouter['postCommitment'](
           mockRequest(
-            { swapId: 'id', signature: 'sig', transactionHash: 'tx' },
+            {
+              swapId: 'id',
+              signature: 'sig',
+              transactionHash: validTransactionHash,
+            },
             undefined,
             { currency: 'BTC' },
           ),
           res,
         ),
       ).rejects.toThrow('currency does not support commitment swaps');
+    });
+  });
+
+  describe('POST /:currency/refund', () => {
+    const refundAddressSignature = 'signed-proof';
+
+    test.each`
+      error                                            | params                  | body
+      ${'undefined parameter: currency'}               | ${{}}                   | ${{ transactionHash: `0x${'1'.repeat(64)}`, refundAddressSignature }}
+      ${'undefined parameter: transactionHash'}        | ${{ currency: 'RBTC' }} | ${{ refundAddressSignature }}
+      ${'undefined parameter: refundAddressSignature'} | ${{ currency: 'RBTC' }} | ${{ transactionHash: `0x${'1'.repeat(64)}` }}
+      ${'invalid parameter: refundAddressSignature'}   | ${{ currency: 'RBTC' }} | ${{ transactionHash: `0x${'1'.repeat(64)}`, refundAddressSignature: 123 }}
+      ${'invalid parameter: transactionHash'}          | ${{ currency: 'RBTC' }} | ${{ transactionHash: 'invalid', refundAddressSignature }}
+      ${'invalid parameter: transactionHash'}          | ${{ currency: 'RBTC' }} | ${{ transactionHash: '0x1234', refundAddressSignature }}
+      ${'invalid parameter: logIndex'}                 | ${{ currency: 'RBTC' }} | ${{ transactionHash: `0x${'1'.repeat(64)}`, refundAddressSignature, logIndex: -1 }}
+      ${'invalid parameter: logIndex'}                 | ${{ currency: 'RBTC' }} | ${{ transactionHash: `0x${'1'.repeat(64)}`, refundAddressSignature, logIndex: 1.5 }}
+    `(
+      'should not refund commitment with invalid parameters ($error)',
+      async ({ params, body, error }) => {
+        await expect(
+          commitmentRouter['refundCommitment'](
+            mockRequest(body, undefined, params),
+            mockResponse(),
+          ),
+        ).rejects.toEqual(error);
+      },
+    );
+
+    test('should refund commitment', async () => {
+      const currency = 'RBTC';
+      const transactionHash = `0x${'1'.repeat(64)}`;
+
+      const res = mockResponse();
+      await commitmentRouter['refundCommitment'](
+        mockRequest({ transactionHash, refundAddressSignature }, undefined, {
+          currency,
+        }),
+        res,
+      );
+
+      expect(
+        service.walletManager.ethereumManagers[0].hasSymbol,
+      ).toHaveBeenCalledWith(currency);
+      expect(
+        service.swapManager.eipSigner.signCommitmentRefund,
+      ).toHaveBeenCalledWith(
+        currency,
+        transactionHash,
+        refundAddressSignature,
+        undefined,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        signature: '0xrefundsignature',
+      });
+    });
+
+    test('should throw for unsupported currency', async () => {
+      await expect(
+        commitmentRouter['refundCommitment'](
+          mockRequest(
+            {
+              transactionHash: `0x${'2'.repeat(64)}`,
+              refundAddressSignature,
+            },
+            undefined,
+            { currency: 'BTC' },
+          ),
+          mockResponse(),
+        ),
+      ).rejects.toThrow('currency does not support commitment swaps');
+    });
+
+    test('should refund commitment with logIndex', async () => {
+      const currency = 'RBTC';
+      const transactionHash = `0x${'3'.repeat(64)}`;
+      const logIndex = 2;
+
+      await commitmentRouter['refundCommitment'](
+        mockRequest(
+          { transactionHash, refundAddressSignature, logIndex },
+          undefined,
+          { currency },
+        ),
+        mockResponse(),
+      );
+
+      expect(
+        service.swapManager.eipSigner.signCommitmentRefund,
+      ).toHaveBeenCalledWith(
+        currency,
+        transactionHash,
+        refundAddressSignature,
+        logIndex,
+      );
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New POST endpoint to obtain cooperative refund signatures for commitments not linked to swaps.
  * CLI command to format/print EVM signatures.

* **Database**
  * Commitments can be unlinked (swap id nullable) and now track a refunded flag; refunds can be recorded.

* **Documentation**
  * Expanded commitment refund docs with separate flows for linked vs. standalone commitments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->