### PR TITLE
feat: hide pairs in list endpoints

### DIFF
--- a/docs/boltz.conf
+++ b/docs/boltz.conf
@@ -107,6 +107,7 @@ minSwapAmount = 50_000
 
 # invoiceExpiry = 3600  # Defaults to 50% of reverse swap expiry
 # swapTypes = ["submarine", "reverse", "chain"]
+# hidden = true  # Hide pair from pair list endpoints unless a referral enables it
 
 # Timeouts in blocks for different swap types
 [pairs.timeoutDelta]
@@ -510,6 +511,17 @@ default = 0.0035
 #
 # [nodeSwitch.preferredForNode]
 # "destination-node-pubkey" = "<cln-node-pubkey>"
+
+# =============================================================================
+# Referral Defaults (optional)
+# =============================================================================
+#
+# These defaults are merged with referral config from the database.
+# Database config overrides duplicate keys from this file.
+#
+# [referrals.pro.pairs."BTC/BTC"]
+# showHidden = true
+# maxRoutingFee = 0.001
 
 # =============================================================================
 # Exchange Rates

--- a/lib/Boltz.ts
+++ b/lib/Boltz.ts
@@ -21,6 +21,7 @@ import Database from './db/Database';
 import Redis from './db/Redis';
 import type ChainTip from './db/models/ChainTip';
 import ChainTipRepository from './db/repositories/ChainTipRepository';
+import ReferralRepository from './db/repositories/ReferralRepository';
 import GrpcServer from './grpc/GrpcServer';
 import GrpcService from './grpc/GrpcService';
 import type { LightningClient } from './lightning/LightningClient';
@@ -65,6 +66,7 @@ class Boltz {
 
   constructor(config: Arguments<any>) {
     this.config = new Config().load(config);
+    ReferralRepository.setConfiguredReferrals(this.config.referrals);
     this.logger = new Logger(
       this.config.loglevel,
       this.config.logpath,

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -9,6 +9,7 @@ import { Network } from './consts/Enums';
 import Errors from './consts/Errors';
 import type { PairConfig } from './consts/Types';
 import type { RedisConfig } from './db/Redis';
+import type { ReferralConfig } from './db/models/Referral';
 import type { LndConfig } from './lightning/LndClient';
 import type { Config as RoutingFeeConfig } from './lightning/RoutingFee';
 import type { ClnConfig } from './lightning/cln/Types';
@@ -225,6 +226,7 @@ type ConfigType = {
   notification: NotificationConfig;
 
   nodeSwitch?: NodeSwitchConfig;
+  referrals?: Record<string, ReferralConfig>;
 
   pairs: PairConfig[];
   currencies: CurrencyConfig[];

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -2494,7 +2494,7 @@ class SwapRouter extends RouterBase {
       RateProviderTaproot.serializePairs(
         this.service.rateProvider.providers[
           SwapVersion.Taproot
-        ].getSubmarinePairs(referral),
+        ].getSubmarinePairs(referral, true),
       ),
     );
   };
@@ -2677,16 +2677,16 @@ class SwapRouter extends RouterBase {
       RateProviderTaproot.serializePairs(
         this.service.rateProvider.providers[
           SwapVersion.Taproot
-        ].getReversePairs(referral),
+        ].getReversePairs(referral, true),
       ),
     );
   };
 
-  private getReverseExpiry = async (_req: Request, res: Response) => {
-    const pairs =
-      this.service.rateProvider.providers[
-        SwapVersion.Taproot
-      ].getReversePairs();
+  private getReverseExpiry = async (req: Request, res: Response) => {
+    const referral = await this.getReferralFromHeader(req);
+    const pairs = this.service.rateProvider.providers[
+      SwapVersion.Taproot
+    ].getReversePairs(referral, true);
 
     const result: Record<string, Record<string, InvoiceExpiryRange>> = {};
 
@@ -2872,6 +2872,7 @@ class SwapRouter extends RouterBase {
       RateProviderTaproot.serializePairs(
         this.service.rateProvider.providers[SwapVersion.Taproot].getChainPairs(
           referral,
+          true,
         ),
       ),
     );

--- a/lib/consts/Types.ts
+++ b/lib/consts/Types.ts
@@ -46,6 +46,7 @@ export type ChainSwapPairConfig = PairLimits & {
 export type PairConfig = {
   base: string;
   quote: string;
+  hidden?: boolean;
 
   // Percentage of the amount that will be charged as fee
   fee?: number;

--- a/lib/db/models/Referral.ts
+++ b/lib/db/models/Referral.ts
@@ -33,9 +33,13 @@ type ReferralPairConfig = {
   expirations?: CustomExpirations;
 };
 
+type ReferralPairConfigWithHidden = ReferralPairConfig & {
+  showHidden?: boolean;
+};
+
 type ReferralConfig = ReferralPairConfig & {
   // Pair configs beat the ones of the type
-  pairs?: Record<string, ReferralPairConfig>;
+  pairs?: Record<string, ReferralPairConfigWithHidden>;
 };
 
 type ReferralType = {
@@ -190,6 +194,7 @@ export {
   ReferralType,
   ReferralConfig,
   ReferralPairConfig,
+  ReferralPairConfigWithHidden,
   DirectionalPremium,
   Premiums,
 };

--- a/lib/db/repositories/ReferralRepository.ts
+++ b/lib/db/repositories/ReferralRepository.ts
@@ -1,4 +1,5 @@
 import { QueryTypes } from 'sequelize';
+import { deepMerge } from '../../Utils';
 import {
   OrderSide,
   SuccessSwapUpdateEvents,
@@ -8,7 +9,7 @@ import Database from '../Database';
 import type {
   DirectionalPremium,
   ReferralConfig,
-  ReferralPairConfig,
+  ReferralPairConfigWithHidden,
 } from '../models/Referral';
 import Referral, { ReferralType } from '../models/Referral';
 import type { StatsDate } from './StatsRepository';
@@ -50,6 +51,23 @@ class ReferralRepository {
   private static readonly minRoutingFee = 0;
   private static readonly maxRoutingFee = 0.005;
 
+  private static referralConfigs: Record<string, ReferralConfig> = {};
+
+  public static setConfiguredReferrals = (
+    referrals?: Record<string, ReferralConfig>,
+  ) => {
+    ReferralRepository.referralConfigs = {};
+
+    if (referrals === undefined || referrals === null) {
+      return;
+    }
+
+    for (const [id, config] of Object.entries(referrals)) {
+      ReferralRepository.sanityCheckConfig(config);
+      ReferralRepository.referralConfigs[id] = config;
+    }
+  };
+
   public static addReferral = async (
     referral: ReferralType,
   ): Promise<Referral> => {
@@ -58,36 +76,73 @@ class ReferralRepository {
     return await Referral.create(referral);
   };
 
-  public static getReferrals = (): Promise<Referral[]> => {
-    return Referral.findAll();
+  public static getReferrals = async (): Promise<Referral[]> => {
+    return (await Referral.findAll()).map(
+      ReferralRepository.mergeWithConfigFile,
+    );
   };
 
-  public static getReferralById = (id: string): Promise<Referral | null> => {
-    return Referral.findOne({
-      where: {
-        id,
-      },
-    });
+  public static getReferralById = async (
+    id: string,
+  ): Promise<Referral | null> => {
+    return ReferralRepository.mergeWithConfigFile(
+      await Referral.findOne({
+        where: {
+          id,
+        },
+      }),
+    );
   };
 
-  public static getReferralByApiKey = (
+  public static getReferralByApiKey = async (
     apiKey: string,
   ): Promise<Referral | null> => {
-    return Referral.findOne({
-      where: {
-        apiKey,
-      },
-    });
+    return ReferralRepository.mergeWithConfigFile(
+      await Referral.findOne({
+        where: {
+          apiKey,
+        },
+      }),
+    );
   };
 
-  public static getReferralByRoutingNode = (
+  public static getReferralByRoutingNode = async (
     routingNode: string,
   ): Promise<Referral | null> => {
-    return Referral.findOne({
-      where: {
-        routingNode,
-      },
-    });
+    return ReferralRepository.mergeWithConfigFile(
+      await Referral.findOne({
+        where: {
+          routingNode,
+        },
+      }),
+    );
+  };
+
+  private static mergeWithConfigFile = <T extends Referral | null>(
+    referral: T,
+  ): T => {
+    if (referral === null) {
+      return referral;
+    }
+
+    referral.config = ReferralRepository.mergeConfig(
+      referral.id,
+      referral.config,
+    );
+
+    return referral;
+  };
+
+  private static mergeConfig = (
+    referralId: string,
+    dbConfig: ReferralConfig | null,
+  ): ReferralConfig | null => {
+    const fileConfig = ReferralRepository.referralConfigs[referralId];
+    if (fileConfig === undefined) {
+      return dbConfig;
+    }
+
+    return deepMerge({}, fileConfig, dbConfig ?? {}) as ReferralConfig;
   };
 
   public static getReferralSum = async (
@@ -142,7 +197,11 @@ class ReferralRepository {
       return premium as DirectionalPremium;
     };
 
-    const sanityCheckPairConfig = (cfg: ReferralPairConfig) => {
+    const sanityCheckPairConfig = (cfg: ReferralPairConfigWithHidden) => {
+      if (cfg.showHidden !== undefined && typeof cfg.showHidden !== 'boolean') {
+        throw 'showHidden must be a boolean';
+      }
+
       if (
         cfg.maxRoutingFee !== undefined &&
         (cfg.maxRoutingFee < ReferralRepository.minRoutingFee ||

--- a/lib/rates/providers/RateProviderTaproot.ts
+++ b/lib/rates/providers/RateProviderTaproot.ts
@@ -105,44 +105,46 @@ class RateProviderTaproot extends RateProviderBase<SwapTypes> {
 
   public getSubmarinePairs = (
     referral?: Referral | null,
+    filterHidden: boolean = false,
   ): typeof this.submarinePairs => {
-    if (referral === null || referral === undefined) {
-      return this.submarinePairs;
-    }
+    const pairs =
+      referral === null || referral === undefined
+        ? this.submarinePairs
+        : this.deepCloneWithReferral(
+            this.submarinePairs,
+            SwapType.Submarine,
+            referral,
+          );
 
-    return this.deepCloneWithReferral(
-      this.submarinePairs,
-      SwapType.Submarine,
-      referral,
-    );
+    return filterHidden ? this.filterHiddenPairs(pairs, referral) : pairs;
   };
 
   public getReversePairs = (
     referral?: Referral | null,
+    filterHidden: boolean = false,
   ): typeof this.reversePairs => {
-    if (referral === null || referral === undefined) {
-      return this.reversePairs;
-    }
+    const pairs =
+      referral === null || referral === undefined
+        ? this.reversePairs
+        : this.deepCloneWithReferral(
+            this.reversePairs,
+            SwapType.ReverseSubmarine,
+            referral,
+          );
 
-    return this.deepCloneWithReferral(
-      this.reversePairs,
-      SwapType.ReverseSubmarine,
-      referral,
-    );
+    return filterHidden ? this.filterHiddenPairs(pairs, referral) : pairs;
   };
 
   public getChainPairs = (
     referral?: Referral | null,
+    filterHidden: boolean = false,
   ): typeof this.chainPairs => {
-    if (referral === null || referral === undefined) {
-      return this.chainPairs;
-    }
+    const pairs =
+      referral === null || referral === undefined
+        ? this.chainPairs
+        : this.deepCloneWithReferral(this.chainPairs, SwapType.Chain, referral);
 
-    return this.deepCloneWithReferral(
-      this.chainPairs,
-      SwapType.Chain,
-      referral,
-    );
+    return filterHidden ? this.filterHiddenPairs(pairs, referral) : pairs;
   };
 
   public static serializePairs = <T>(
@@ -536,21 +538,8 @@ class RateProviderTaproot extends RateProviderBase<SwapTypes> {
         from,
         new Map(
           Array.from(nested.entries()).map(([to, value]) => {
-            const pairIds = [
-              [from, to],
-              [to, from],
-            ].map(([base, quote]) => getPairId({ base, quote }));
-
-            const getConfigPairId = (pairIds: string[]) => {
-              for (const pairId of pairIds) {
-                if (this.pairConfigs.has(pairId)) {
-                  return pairId;
-                }
-              }
-              throw new Error('could not find pair id');
-            };
-
-            const { quote } = splitPairId(getConfigPairId(pairIds));
+            const pairIds = this.getPairIds(from, to);
+            const { quote } = splitPairId(this.getConfigPairId(pairIds)!);
 
             const premium = referral?.premiumForPairs(
               pairIds,
@@ -604,6 +593,54 @@ class RateProviderTaproot extends RateProviderBase<SwapTypes> {
         ),
       ]),
     ) as K;
+  };
+
+  private filterHiddenPairs = <T, K extends Map<string, Map<string, T>>>(
+    map: K,
+    referral?: Referral | null,
+  ): K => {
+    return new Map(
+      Array.from(map.entries()).map(([from, nested]) => [
+        from,
+        new Map(
+          Array.from(nested.entries()).filter(([to]) =>
+            this.isVisiblePair(this.getPairIds(from, to), referral),
+          ),
+        ),
+      ]),
+    ) as K;
+  };
+
+  private isVisiblePair = (
+    pairIds: string[],
+    referral?: Referral | null,
+  ): boolean => {
+    const configPairId = this.getConfigPairId(pairIds);
+    if (
+      configPairId === undefined ||
+      !this.pairConfigs.get(configPairId)?.hidden
+    ) {
+      return true;
+    }
+
+    if (referral === null || referral === undefined) {
+      return false;
+    }
+
+    return pairIds.some(
+      (pairId) => referral.config?.pairs?.[pairId]?.showHidden === true,
+    );
+  };
+
+  private getPairIds = (from: string, to: string): string[] => {
+    return [
+      [from, to],
+      [to, from],
+    ].map(([base, quote]) => getPairId({ base, quote }));
+  };
+
+  private getConfigPairId = (pairIds: string[]): string | undefined => {
+    return pairIds.find((pairId) => this.pairConfigs.has(pairId));
   };
 
   private applyOverride = (

--- a/test/integration/db/repositories/ReferralRepository.spec.ts
+++ b/test/integration/db/repositories/ReferralRepository.spec.ts
@@ -21,6 +21,7 @@ describe('ReferralRepository', () => {
 
   beforeEach(async () => {
     await Referral.truncate();
+    ReferralRepository.setConfiguredReferrals(undefined);
   });
 
   afterAll(async () => {
@@ -93,6 +94,48 @@ describe('ReferralRepository', () => {
           ).rejects.toEqual('premium out of range');
         },
       );
+
+      test.each`
+        value
+        ${'true'}
+        ${1}
+        ${{}}
+      `(
+        'should throw if showHidden has invalid type ($value)',
+        async ({ value }) => {
+          await expect(
+            ReferralRepository.addReferral({
+              ...fixture,
+              config: {
+                pairs: {
+                  'BTC/BTC': {
+                    showHidden: value as any,
+                  },
+                },
+              },
+            }),
+          ).rejects.toEqual('showHidden must be a boolean');
+        },
+      );
+
+      test.each`
+        value
+        ${true}
+        ${false}
+      `('should accept valid showHidden values ($value)', async ({ value }) => {
+        const ref = await ReferralRepository.addReferral({
+          ...fixture,
+          config: {
+            pairs: {
+              'BTC/BTC': {
+                showHidden: value,
+              },
+            },
+          },
+        });
+
+        expect(ref.config?.pairs?.['BTC/BTC']?.showHidden).toEqual(value);
+      });
 
       test.each`
         value
@@ -222,6 +265,248 @@ describe('ReferralRepository', () => {
           });
         },
       );
+    });
+
+    describe('config file merge', () => {
+      test('should apply file config when db config is empty', async () => {
+        ReferralRepository.setConfiguredReferrals({
+          test: {
+            pairs: {
+              'BTC/BTC': {
+                showHidden: true,
+              },
+            },
+          },
+        });
+
+        await ReferralRepository.addReferral({
+          ...fixture,
+          config: undefined,
+        });
+
+        const ref = await ReferralRepository.getReferralById('test');
+        expect(ref?.config).toEqual({
+          pairs: {
+            'BTC/BTC': {
+              showHidden: true,
+            },
+          },
+        });
+      });
+
+      test('should prefer db config for duplicate values', async () => {
+        ReferralRepository.setConfiguredReferrals({
+          test: {
+            maxRoutingFee: 0.001,
+            pairs: {
+              'BTC/BTC': {
+                showHidden: false,
+                maxRoutingFee: 0.001,
+              },
+            },
+          },
+        });
+
+        await ReferralRepository.addReferral({
+          ...fixture,
+          config: {
+            maxRoutingFee: 0.002,
+            pairs: {
+              'BTC/BTC': {
+                showHidden: true,
+                maxRoutingFee: 0.002,
+              },
+            },
+          },
+        });
+
+        const ref = await ReferralRepository.getReferralById('test');
+        expect(ref?.config).toEqual({
+          maxRoutingFee: 0.002,
+          pairs: {
+            'BTC/BTC': {
+              showHidden: true,
+              maxRoutingFee: 0.002,
+            },
+          },
+        });
+      });
+
+      test('should preserve non-conflicting nested values from both configs', async () => {
+        ReferralRepository.setConfiguredReferrals({
+          test: {
+            pairs: {
+              'BTC/BTC': {
+                showHidden: true,
+              },
+            },
+          },
+        });
+
+        await ReferralRepository.addReferral({
+          ...fixture,
+          config: {
+            pairs: {
+              'BTC/BTC': {
+                premiums: {
+                  [SwapType.Submarine]: 1,
+                },
+              },
+            },
+          },
+        });
+
+        const ref = await ReferralRepository.getReferralById('test');
+        expect(ref?.config).toEqual({
+          pairs: {
+            'BTC/BTC': {
+              showHidden: true,
+              premiums: {
+                [SwapType.Submarine]: 1,
+              },
+            },
+          },
+        });
+      });
+
+      test('should return db config unchanged when no file config exists for referral', async () => {
+        ReferralRepository.setConfiguredReferrals({
+          other: {
+            maxRoutingFee: 0.001,
+          },
+        });
+
+        const dbConfig = {
+          maxRoutingFee: 0.003,
+        };
+
+        await ReferralRepository.addReferral({
+          ...fixture,
+          config: dbConfig,
+        });
+
+        const ref = await ReferralRepository.getReferralById('test');
+        expect(ref?.config).toEqual(dbConfig);
+      });
+
+      test('should merge config in getReferrals', async () => {
+        ReferralRepository.setConfiguredReferrals({
+          test: {
+            pairs: {
+              'BTC/BTC': {
+                showHidden: true,
+              },
+            },
+          },
+        });
+
+        await ReferralRepository.addReferral({
+          ...fixture,
+          config: undefined,
+        });
+
+        const refs = await ReferralRepository.getReferrals();
+        expect(refs).toHaveLength(1);
+        expect(refs[0].config).toEqual({
+          pairs: {
+            'BTC/BTC': {
+              showHidden: true,
+            },
+          },
+        });
+      });
+
+      test('should merge config in getReferralByApiKey', async () => {
+        ReferralRepository.setConfiguredReferrals({
+          test: {
+            pairs: {
+              'BTC/BTC': {
+                showHidden: true,
+              },
+            },
+          },
+        });
+
+        await ReferralRepository.addReferral({
+          ...fixture,
+          apiKey: 'testKey',
+          config: undefined,
+        });
+
+        const ref = await ReferralRepository.getReferralByApiKey('testKey');
+        expect(ref?.config).toEqual({
+          pairs: {
+            'BTC/BTC': {
+              showHidden: true,
+            },
+          },
+        });
+      });
+
+      test('should merge config in getReferralByRoutingNode', async () => {
+        ReferralRepository.setConfiguredReferrals({
+          test: {
+            pairs: {
+              'BTC/BTC': {
+                showHidden: true,
+              },
+            },
+          },
+        });
+
+        await ReferralRepository.addReferral({
+          ...fixture,
+          routingNode: '02abc',
+          config: undefined,
+        });
+
+        const ref = await ReferralRepository.getReferralByRoutingNode('02abc');
+        expect(ref?.config).toEqual({
+          pairs: {
+            'BTC/BTC': {
+              showHidden: true,
+            },
+          },
+        });
+      });
+
+      test('should reject invalid file config in setConfiguredReferrals', () => {
+        expect(() =>
+          ReferralRepository.setConfiguredReferrals({
+            bad: {
+              maxRoutingFee: 1,
+            },
+          }),
+        ).toThrow('maxRoutingFee out of range');
+      });
+
+      test('should reject file config with invalid showHidden type', () => {
+        expect(() =>
+          ReferralRepository.setConfiguredReferrals({
+            bad: {
+              pairs: {
+                'BTC/BTC': {
+                  showHidden: 'yes' as any,
+                },
+              },
+            },
+          }),
+        ).toThrow('showHidden must be a boolean');
+      });
+    });
+
+    describe('lookups', () => {
+      test('should return null when referral does not exist', async () => {
+        await expect(
+          ReferralRepository.getReferralById('missing'),
+        ).resolves.toBe(null);
+        await expect(
+          ReferralRepository.getReferralByApiKey('missing-key'),
+        ).resolves.toBe(null);
+        await expect(
+          ReferralRepository.getReferralByRoutingNode('missing-node'),
+        ).resolves.toBe(null);
+      });
     });
   });
 });

--- a/test/integration/swap/RefundWatcher.spec.ts
+++ b/test/integration/swap/RefundWatcher.spec.ts
@@ -248,11 +248,11 @@ describe('RefundWatcher', () => {
 
     test('should get confirmations for EVM currencies', async () => {
       const tx = await setup.signer.sendTransaction({});
-      await tx.wait(1);
+      await evmProvider.waitForTransaction(tx.hash, 1, 10_000);
 
       await expect(
         getConfirmations(watcher['currencies'].get('RBTC')!, tx.hash),
-      ).resolves.toEqual(1);
+      ).resolves.toBeGreaterThanOrEqual(1);
     });
 
     test('should always return required confirmations + 1 for ARK', async () => {

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -10,7 +10,6 @@ import ChainSwapRepository from '../../../../../lib/db/repositories/ChainSwapRep
 import MarkedSwapRepository from '../../../../../lib/db/repositories/MarkedSwapRepository';
 import ReferralRepository from '../../../../../lib/db/repositories/ReferralRepository';
 import SwapRepository from '../../../../../lib/db/repositories/SwapRepository';
-import RateProviderTaproot from '../../../../../lib/rates/providers/RateProviderTaproot';
 import Errors from '../../../../../lib/service/Errors';
 import type Service from '../../../../../lib/service/Service';
 import { mockRequest, mockResponse } from '../../Utils';
@@ -421,12 +420,17 @@ describe('SwapRouter', () => {
     const res = mockResponse();
     await swapRouter['getSubmarine'](mockRequest(), res);
 
+    expect(
+      service.rateProvider.providers[SwapVersion.Taproot].getSubmarinePairs,
+    ).toHaveBeenCalledWith(null, true);
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(
-      RateProviderTaproot.serializePairs(
-        service.rateProvider.providers[SwapVersion.Taproot].getSubmarinePairs(),
-      ),
-    );
+    expect(res.json).toHaveBeenCalledWith({
+      'L-BTC': {
+        BTC: {
+          some: 'submarine data',
+        },
+      },
+    });
   });
 
   test.each`
@@ -1135,12 +1139,17 @@ describe('SwapRouter', () => {
     const res = mockResponse();
     await swapRouter['getReverse'](mockRequest(), res);
 
+    expect(
+      service.rateProvider.providers[SwapVersion.Taproot].getReversePairs,
+    ).toHaveBeenCalledWith(null, true);
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(
-      RateProviderTaproot.serializePairs(
-        service.rateProvider.providers[SwapVersion.Taproot].getReversePairs(),
-      ),
-    );
+    expect(res.json).toHaveBeenCalledWith({
+      BTC: {
+        'L-BTC': {
+          some: 'reverse data',
+        },
+      },
+    });
   });
 
   test('should get reverse expiry map', async () => {
@@ -1154,6 +1163,9 @@ describe('SwapRouter', () => {
     expect(
       service.rateProvider.providers[SwapVersion.Taproot].getReversePairs,
     ).toHaveBeenCalledTimes(1);
+    expect(
+      service.rateProvider.providers[SwapVersion.Taproot].getReversePairs,
+    ).toHaveBeenCalledWith(null, true);
 
     expect(service.convertToPairAndSide).toHaveBeenCalledTimes(1);
     expect(service.convertToPairAndSide).toHaveBeenCalledWith('BTC', 'L-BTC');
@@ -1773,12 +1785,17 @@ describe('SwapRouter', () => {
     const res = mockResponse();
     await swapRouter['getChain'](mockRequest(), res);
 
+    expect(
+      service.rateProvider.providers[SwapVersion.Taproot].getChainPairs,
+    ).toHaveBeenCalledWith(null, true);
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(
-      RateProviderTaproot.serializePairs(
-        service.rateProvider.providers[SwapVersion.Taproot].getChainPairs(),
-      ),
-    );
+    expect(res.json).toHaveBeenCalledWith({
+      BTC: {
+        'L-BTC': {
+          some: 'chain data',
+        },
+      },
+    });
   });
 
   test.each`

--- a/test/unit/rates/providers/RateProviderTaproot.spec.ts
+++ b/test/unit/rates/providers/RateProviderTaproot.spec.ts
@@ -68,6 +68,14 @@ describe('RateProviderTaproot', () => {
         minBatchedAmount: 1_000,
       },
     },
+    {
+      base: 'BTC',
+      quote: 'BTC',
+      hidden: true,
+      rate: 1,
+      minSwapAmount: 1_000,
+      maxSwapAmount: 1_000_000,
+    },
   ];
 
   const mockedRoutingFee = {
@@ -126,6 +134,144 @@ describe('RateProviderTaproot', () => {
         } as any,
         [SwapType.Submarine, SwapType.ReverseSubmarine, SwapType.Chain],
       );
+      provider.setHardcodedPair(
+        {
+          base: 'BTC',
+          quote: 'BTC',
+          rate: 1,
+        } as any,
+        [SwapType.Submarine, SwapType.ReverseSubmarine, SwapType.Chain],
+      );
+    });
+
+    test('should include hidden pairs by default', () => {
+      expect(provider.getSubmarinePairs().get('BTC')!.get('BTC')).toEqual(
+        expect.objectContaining({ rate: 1 }),
+      );
+      expect(provider.getReversePairs().get('BTC')!.get('BTC')).toEqual(
+        expect.objectContaining({ rate: 1 }),
+      );
+      expect(provider.getChainPairs().get('BTC')?.get('BTC')).toEqual(
+        undefined,
+      );
+    });
+
+    test('should hide hidden pairs when hidden filter is enabled', () => {
+      expect(
+        provider.getSubmarinePairs(undefined, true).get('BTC')?.get('BTC'),
+      ).toEqual(undefined);
+      expect(
+        provider.getReversePairs(undefined, true).get('BTC')?.get('BTC'),
+      ).toEqual(undefined);
+    });
+
+    test('should keep non-hidden pairs visible without referral', () => {
+      expect(
+        provider.getSubmarinePairs().get('L-BTC')!.get('BTC'),
+      ).toBeDefined();
+      expect(provider.getReversePairs().get('BTC')!.get('L-BTC')).toBeDefined();
+      expect(provider.getChainPairs().get('BTC')!.get('L-BTC')).toBeDefined();
+    });
+
+    test('should keep non-hidden pairs visible when referral is provided', () => {
+      const referral = {
+        config: {},
+        premiumForPairs: jest.fn().mockReturnValue(undefined),
+        limitsForPairs: jest.fn().mockReturnValue(undefined),
+        maxRoutingFeeRatioForPairs: jest.fn().mockReturnValue(undefined),
+      } as any as Referral;
+
+      expect(
+        provider.getSubmarinePairs(referral).get('L-BTC')!.get('BTC'),
+      ).toBeDefined();
+      expect(
+        provider.getReversePairs(referral).get('BTC')!.get('L-BTC'),
+      ).toBeDefined();
+      expect(
+        provider.getChainPairs(referral).get('BTC')!.get('L-BTC'),
+      ).toBeDefined();
+    });
+
+    test('should show hidden pairs when referral allows it and hidden filter is enabled', () => {
+      const referral = {
+        config: {
+          pairs: {
+            'BTC/BTC': {
+              showHidden: true,
+            },
+          },
+        },
+        premiumForPairs: jest.fn().mockReturnValue(undefined),
+        limitsForPairs: jest.fn().mockReturnValue(undefined),
+        maxRoutingFeeRatioForPairs: jest.fn().mockReturnValue(undefined),
+      } as any as Referral;
+
+      expect(
+        provider.getSubmarinePairs(referral, true).get('BTC')!.get('BTC'),
+      ).toEqual(expect.objectContaining({ rate: 1 }));
+      expect(
+        provider.getReversePairs(referral, true).get('BTC')!.get('BTC'),
+      ).toEqual(expect.objectContaining({ rate: 1 }));
+      expect(
+        provider.getChainPairs(referral, true).get('BTC')!.get('BTC'),
+      ).toEqual(undefined);
+    });
+
+    test('should keep hidden pairs hidden when referral has no showHidden and hidden filter is enabled', () => {
+      const referral = {
+        config: {
+          pairs: {
+            'BTC/BTC': {
+              maxRoutingFee: 0.001,
+            },
+          },
+        },
+        premiumForPairs: jest.fn().mockReturnValue(undefined),
+        limitsForPairs: jest.fn().mockReturnValue(undefined),
+        maxRoutingFeeRatioForPairs: jest.fn().mockReturnValue(undefined),
+      } as any as Referral;
+
+      expect(
+        provider.getSubmarinePairs(referral, true).get('BTC')?.get('BTC'),
+      ).toEqual(undefined);
+      expect(
+        provider.getReversePairs(referral, true).get('BTC')?.get('BTC'),
+      ).toEqual(undefined);
+    });
+
+    test('should keep hidden pairs hidden when referral has showHidden false and hidden filter is enabled', () => {
+      const referral = {
+        config: {
+          pairs: {
+            'BTC/BTC': {
+              showHidden: false,
+            },
+          },
+        },
+        premiumForPairs: jest.fn().mockReturnValue(undefined),
+        limitsForPairs: jest.fn().mockReturnValue(undefined),
+        maxRoutingFeeRatioForPairs: jest.fn().mockReturnValue(undefined),
+      } as any as Referral;
+
+      expect(
+        provider.getSubmarinePairs(referral, true).get('BTC')?.get('BTC'),
+      ).toEqual(undefined);
+      expect(
+        provider.getReversePairs(referral, true).get('BTC')?.get('BTC'),
+      ).toEqual(undefined);
+    });
+
+    test('should keep hidden pairs hidden when referral has empty config and hidden filter is enabled', () => {
+      const referral = {
+        config: null,
+        premiumForPairs: jest.fn().mockReturnValue(undefined),
+        limitsForPairs: jest.fn().mockReturnValue(undefined),
+        maxRoutingFeeRatioForPairs: jest.fn().mockReturnValue(undefined),
+      } as any as Referral;
+
+      expect(
+        provider.getSubmarinePairs(referral, true).get('BTC')?.get('BTC'),
+      ).toEqual(undefined);
     });
 
     test.each`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hide trading pairs from public pair lists with referral-based override; API endpoints now respect referral context when returning pair lists and expiries.
  * Added pair-level hidden flag and referral-controlled visibility settings.

* **Documentation**
  * Added "Referral Defaults" sample showing showHidden and maxRoutingFee and how file defaults merge with stored referral configs.

* **Tests**
  * Expanded tests for config merging, showHidden validation, pair visibility, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->