### PR TITLE
feat: disable signers RPC

### DIFF
--- a/boltzr-cli/src/grpc/mod.rs
+++ b/boltzr-cli/src/grpc/mod.rs
@@ -20,6 +20,35 @@ const CA_FILE_NAME: &str = "ca.pem";
 const CERT_FILE_NAME: &str = "client.pem";
 const KEY_FILE_NAME: &str = "client-key.pem";
 
+fn map_signer(signer: crate::parsers::Signer) -> i32 {
+    match signer {
+        crate::parsers::Signer::SubmarineRefundCoop => {
+            boltz_rpc::Signer::SubmarineRefundCooperative
+        }
+        crate::parsers::Signer::ReverseClaimCoop => boltz_rpc::Signer::ReverseClaimCooperative,
+        crate::parsers::Signer::ChainRefundCoop => boltz_rpc::Signer::ChainRefundCooperative,
+        crate::parsers::Signer::ChainClaimCoop => boltz_rpc::Signer::ChainClaimCooperative,
+        crate::parsers::Signer::DeferredClaimCoop => boltz_rpc::Signer::DeferredClaimCooperative,
+        crate::parsers::Signer::EvmRefundCoop => boltz_rpc::Signer::EvmRefundCooperative,
+        crate::parsers::Signer::EvmCommitmentRefundCoop => {
+            boltz_rpc::Signer::EvmCommitmentRefundCooperative
+        }
+        crate::parsers::Signer::ReverseLockup => boltz_rpc::Signer::ReverseLockup,
+        crate::parsers::Signer::ChainLockup => boltz_rpc::Signer::ChainLockup,
+        crate::parsers::Signer::SubmarineInvoicePayment => {
+            boltz_rpc::Signer::SubmarineInvoicePayment
+        }
+    }
+    .into()
+}
+
+pub fn signer_name(signer: i32) -> String {
+    match boltz_rpc::Signer::try_from(signer) {
+        Ok(signer) => signer.as_str_name().to_string(),
+        Err(_) => format!("UNKNOWN({signer})"),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BoltzClient {
     client: boltz_rpc::boltz_client::BoltzClient<Channel>,
@@ -88,6 +117,40 @@ impl BoltzClient {
         let response = self
             .client
             .allow_refund(boltz_rpc::AllowRefundRequest { id })
+            .await?;
+        Ok(response.into_inner())
+    }
+
+    pub async fn disable_signers(
+        &mut self,
+        signers: Vec<crate::parsers::Signer>,
+    ) -> Result<boltz_rpc::DisableSignersResponse> {
+        let response = self
+            .client
+            .disable_signers(boltz_rpc::DisableSignersRequest {
+                signers: signers.into_iter().map(map_signer).collect(),
+            })
+            .await?;
+        Ok(response.into_inner())
+    }
+
+    pub async fn enable_signers(
+        &mut self,
+        signers: Vec<crate::parsers::Signer>,
+    ) -> Result<boltz_rpc::EnableSignersResponse> {
+        let response = self
+            .client
+            .enable_signers(boltz_rpc::EnableSignersRequest {
+                signers: signers.into_iter().map(map_signer).collect(),
+            })
+            .await?;
+        Ok(response.into_inner())
+    }
+
+    pub async fn get_disabled_signers(&mut self) -> Result<boltz_rpc::GetDisabledSignersResponse> {
+        let response = self
+            .client
+            .get_disabled_signers(boltz_rpc::GetDisabledSignersRequest {})
             .await?;
         Ok(response.into_inner())
     }
@@ -352,17 +415,6 @@ impl BoltzClient {
         let response = self
             .client
             .dev_clear_swap_update_cache(boltz_rpc::DevClearSwapUpdateCacheRequest { id })
-            .await?;
-        Ok(response.into_inner())
-    }
-
-    pub async fn dev_disable_cooperative(
-        &mut self,
-        disabled: bool,
-    ) -> Result<boltz_rpc::DevDisableCooperativeResponse> {
-        let response = self
-            .client
-            .dev_disable_cooperative(boltz_rpc::DevDisableCooperativeRequest { disabled })
             .await?;
         Ok(response.into_inner())
     }

--- a/boltzr-cli/src/grpc/mod.rs
+++ b/boltzr-cli/src/grpc/mod.rs
@@ -20,26 +20,30 @@ const CA_FILE_NAME: &str = "ca.pem";
 const CERT_FILE_NAME: &str = "client.pem";
 const KEY_FILE_NAME: &str = "client-key.pem";
 
-fn map_signer(signer: crate::parsers::Signer) -> i32 {
-    match signer {
-        crate::parsers::Signer::SubmarineRefundCoop => {
-            boltz_rpc::Signer::SubmarineRefundCooperative
+impl From<crate::parsers::Signer> for i32 {
+    fn from(signer: crate::parsers::Signer) -> Self {
+        match signer {
+            crate::parsers::Signer::SubmarineRefundCoop => {
+                boltz_rpc::Signer::SubmarineRefundCooperative
+            }
+            crate::parsers::Signer::ReverseClaimCoop => boltz_rpc::Signer::ReverseClaimCooperative,
+            crate::parsers::Signer::ChainRefundCoop => boltz_rpc::Signer::ChainRefundCooperative,
+            crate::parsers::Signer::ChainClaimCoop => boltz_rpc::Signer::ChainClaimCooperative,
+            crate::parsers::Signer::DeferredClaimCoop => {
+                boltz_rpc::Signer::DeferredClaimCooperative
+            }
+            crate::parsers::Signer::EvmRefundCoop => boltz_rpc::Signer::EvmRefundCooperative,
+            crate::parsers::Signer::EvmCommitmentRefundCoop => {
+                boltz_rpc::Signer::EvmCommitmentRefundCooperative
+            }
+            crate::parsers::Signer::ReverseLockup => boltz_rpc::Signer::ReverseLockup,
+            crate::parsers::Signer::ChainLockup => boltz_rpc::Signer::ChainLockup,
+            crate::parsers::Signer::SubmarineInvoicePayment => {
+                boltz_rpc::Signer::SubmarineInvoicePayment
+            }
         }
-        crate::parsers::Signer::ReverseClaimCoop => boltz_rpc::Signer::ReverseClaimCooperative,
-        crate::parsers::Signer::ChainRefundCoop => boltz_rpc::Signer::ChainRefundCooperative,
-        crate::parsers::Signer::ChainClaimCoop => boltz_rpc::Signer::ChainClaimCooperative,
-        crate::parsers::Signer::DeferredClaimCoop => boltz_rpc::Signer::DeferredClaimCooperative,
-        crate::parsers::Signer::EvmRefundCoop => boltz_rpc::Signer::EvmRefundCooperative,
-        crate::parsers::Signer::EvmCommitmentRefundCoop => {
-            boltz_rpc::Signer::EvmCommitmentRefundCooperative
-        }
-        crate::parsers::Signer::ReverseLockup => boltz_rpc::Signer::ReverseLockup,
-        crate::parsers::Signer::ChainLockup => boltz_rpc::Signer::ChainLockup,
-        crate::parsers::Signer::SubmarineInvoicePayment => {
-            boltz_rpc::Signer::SubmarineInvoicePayment
-        }
+        .into()
     }
-    .into()
 }
 
 pub fn signer_name(signer: i32) -> String {
@@ -128,7 +132,7 @@ impl BoltzClient {
         let response = self
             .client
             .disable_signers(boltz_rpc::DisableSignersRequest {
-                signers: signers.into_iter().map(map_signer).collect(),
+                signers: signers.into_iter().map(Into::into).collect(),
             })
             .await?;
         Ok(response.into_inner())
@@ -141,7 +145,7 @@ impl BoltzClient {
         let response = self
             .client
             .enable_signers(boltz_rpc::EnableSignersRequest {
-                signers: signers.into_iter().map(map_signer).collect(),
+                signers: signers.into_iter().map(Into::into).collect(),
             })
             .await?;
         Ok(response.into_inner())

--- a/boltzr-cli/src/main.rs
+++ b/boltzr-cli/src/main.rs
@@ -1030,30 +1030,16 @@ async fn run_command(cli: Cli) -> Result<()> {
         },
         Commands::Signer { ref command } => match command {
             SignerCommands::Disable { signers } => {
-                let response = get_grpc_client(&cli)
+                get_grpc_client(&cli)
                     .await?
                     .disable_signers(signers.clone())
                     .await?;
-                print_pretty(
-                    &response
-                        .disabled_signers
-                        .into_iter()
-                        .map(grpc::signer_name)
-                        .collect::<Vec<String>>(),
-                )?;
             }
             SignerCommands::Enable { signers } => {
-                let response = get_grpc_client(&cli)
+                get_grpc_client(&cli)
                     .await?
                     .enable_signers(signers.clone())
                     .await?;
-                print_pretty(
-                    &response
-                        .disabled_signers
-                        .into_iter()
-                        .map(grpc::signer_name)
-                        .collect::<Vec<String>>(),
-                )?;
             }
             SignerCommands::ListDisabled {} => {
                 let response = get_grpc_client(&cli).await?.get_disabled_signers().await?;

--- a/boltzr-cli/src/main.rs
+++ b/boltzr-cli/src/main.rs
@@ -146,6 +146,11 @@ enum Commands {
         #[command(subcommand)]
         command: SwapCommands,
     },
+    #[command(about = "Signer control commands")]
+    Signer {
+        #[command(subcommand)]
+        command: SignerCommands,
+    },
     #[command(about = "Rescans the chain of a symbol")]
     Rescan {
         symbol: String,
@@ -166,11 +171,6 @@ enum Commands {
 enum DevCommands {
     #[command(about = "Clears the swap update cache")]
     ClearSwapUpdateCache { id: Option<String> },
-    #[command(about = "Toggles cooperative swap signatures")]
-    ToggleCooperative {
-        #[arg(short, long, default_value_t = false)]
-        disabled: bool,
-    },
     #[command(about = "Dumps the heap of the daemon into a file")]
     HeapDump { path: Option<String> },
     #[command(about = "Sets the log level")]
@@ -455,6 +455,22 @@ enum SwapCommands {
     SetStatus { id: String, status: String },
     #[command(about = "Sweeps all deferred swap claims")]
     Sweep { symbol: Option<String> },
+}
+
+#[derive(Clone, Subcommand)]
+enum SignerCommands {
+    #[command(about = "Disables one or more signer controls")]
+    Disable {
+        #[arg(required = true, num_args = 1.., value_enum)]
+        signers: Vec<parsers::Signer>,
+    },
+    #[command(about = "Enables one or more signer controls")]
+    Enable {
+        #[arg(required = true, num_args = 1.., value_enum)]
+        signers: Vec<parsers::Signer>,
+    },
+    #[command(about = "Lists all disabled signer controls")]
+    ListDisabled {},
 }
 
 #[tokio::main]
@@ -1012,6 +1028,44 @@ async fn run_command(cli: Cli) -> Result<()> {
                 print_pretty(&response.claimed_symbols)?;
             }
         },
+        Commands::Signer { ref command } => match command {
+            SignerCommands::Disable { signers } => {
+                let response = get_grpc_client(&cli)
+                    .await?
+                    .disable_signers(signers.clone())
+                    .await?;
+                print_pretty(
+                    &response
+                        .disabled_signers
+                        .into_iter()
+                        .map(grpc::signer_name)
+                        .collect::<Vec<String>>(),
+                )?;
+            }
+            SignerCommands::Enable { signers } => {
+                let response = get_grpc_client(&cli)
+                    .await?
+                    .enable_signers(signers.clone())
+                    .await?;
+                print_pretty(
+                    &response
+                        .disabled_signers
+                        .into_iter()
+                        .map(grpc::signer_name)
+                        .collect::<Vec<String>>(),
+                )?;
+            }
+            SignerCommands::ListDisabled {} => {
+                let response = get_grpc_client(&cli).await?.get_disabled_signers().await?;
+                print_pretty(
+                    &response
+                        .disabled_signers
+                        .into_iter()
+                        .map(grpc::signer_name)
+                        .collect::<Vec<String>>(),
+                )?;
+            }
+        },
         Commands::Rescan {
             ref symbol,
             start_height,
@@ -1032,13 +1086,6 @@ async fn run_command(cli: Cli) -> Result<()> {
                 let response = get_grpc_client(&cli)
                     .await?
                     .dev_clear_swap_update_cache(id.clone())
-                    .await?;
-                print_pretty(&response)?;
-            }
-            DevCommands::ToggleCooperative { disabled } => {
-                let response = get_grpc_client(&cli)
-                    .await?
-                    .dev_disable_cooperative(*disabled)
                     .await?;
                 print_pretty(&response)?;
             }

--- a/boltzr-cli/src/parsers.rs
+++ b/boltzr-cli/src/parsers.rs
@@ -14,6 +14,20 @@ pub enum SwapType {
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum Signer {
+    SubmarineRefundCoop,
+    ReverseClaimCoop,
+    ChainRefundCoop,
+    ChainClaimCoop,
+    DeferredClaimCoop,
+    EvmRefundCoop,
+    EvmCommitmentRefundCoop,
+    ReverseLockup,
+    ChainLockup,
+    SubmarineInvoicePayment,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum Network {
     Mainnet,
     Testnet,

--- a/boltzr/migrations/2026-05-12-000000-0000_disabled_signers/down.sql
+++ b/boltzr/migrations/2026-05-12-000000-0000_disabled_signers/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE disabled_signers;

--- a/boltzr/migrations/2026-05-12-000000-0000_disabled_signers/up.sql
+++ b/boltzr/migrations/2026-05-12-000000-0000_disabled_signers/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE disabled_signers (
+  signer TEXT PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);

--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -11,6 +11,7 @@ import ChainTip from './models/ChainTip';
 import ClaimTransaction from './models/ClaimTransaction';
 import Commitment from './models/Commitment';
 import DatabaseVersion from './models/DatabaseVersion';
+import DisabledSigner from './models/DisabledSigner';
 import ExtraFee from './models/ExtraFee';
 import KeyProvider from './models/KeyProvider';
 import LightningPayment from './models/LightningPayment';
@@ -160,6 +161,7 @@ class Database {
     MarkedSwap.load(Database.sequelize);
     KeyProvider.load(Database.sequelize);
     DatabaseVersion.load(Database.sequelize);
+    DisabledSigner.load(Database.sequelize);
     ReverseRoutingHint.load(Database.sequelize);
     PendingLockupTransaction.load(Database.sequelize);
     PendingEthereumTransaction.load(Database.sequelize);

--- a/lib/db/models/DisabledSigner.ts
+++ b/lib/db/models/DisabledSigner.ts
@@ -1,0 +1,29 @@
+import { DataTypes, Model, type Sequelize } from 'sequelize';
+
+type DisabledSignerType = {
+  signer: string;
+};
+
+class DisabledSigner extends Model implements DisabledSignerType {
+  declare signer: string;
+
+  public static load = (sequelize: Sequelize): void => {
+    DisabledSigner.init(
+      {
+        signer: {
+          type: new DataTypes.TEXT(),
+          primaryKey: true,
+          allowNull: false,
+        },
+      },
+      {
+        sequelize,
+        timestamps: false,
+        tableName: 'disabled_signers',
+      },
+    );
+  };
+}
+
+export default DisabledSigner;
+export { DisabledSignerType };

--- a/lib/db/repositories/DisabledSignerRepository.ts
+++ b/lib/db/repositories/DisabledSignerRepository.ts
@@ -1,0 +1,39 @@
+import { Op } from 'sequelize';
+import DisabledSigner from '../models/DisabledSigner';
+
+class DisabledSignerRepository {
+  public static getDisabledSigners = async (): Promise<string[]> => {
+    const disabledSigners = await DisabledSigner.findAll({
+      attributes: ['signer'],
+    });
+
+    return disabledSigners.map(({ signer }) => signer);
+  };
+
+  public static addSigners = async (signers: string[]): Promise<void> => {
+    if (signers.length === 0) {
+      return;
+    }
+
+    await DisabledSigner.bulkCreate(
+      signers.map((signer) => ({ signer })),
+      { ignoreDuplicates: true },
+    );
+  };
+
+  public static removeSigners = async (signers: string[]): Promise<void> => {
+    if (signers.length === 0) {
+      return;
+    }
+
+    await DisabledSigner.destroy({
+      where: {
+        signer: {
+          [Op.in]: signers,
+        },
+      },
+    });
+  };
+}
+
+export default DisabledSignerRepository;

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -39,6 +39,9 @@ class GrpcServer {
       checkTransaction: grpcService.checkTransaction,
       setSwapStatus: grpcService.setSwapStatus,
       allowRefund: grpcService.allowRefund,
+      disableSigners: grpcService.disableSigners,
+      enableSigners: grpcService.enableSigners,
+      getDisabledSigners: grpcService.getDisabledSigners,
       devHeapDump: grpcService.devHeapDump,
       getLockedFunds: grpcService.getLockedFunds,
       getPendingSweeps: grpcService.getPendingSweeps,
@@ -54,7 +57,6 @@ class GrpcServer {
       setReferral: grpcService.setReferral,
       invoiceClnThreshold: grpcService.invoiceClnThreshold,
       devClearSwapUpdateCache: grpcService.devClearSwapUpdateCache,
-      devDisableCooperative: grpcService.devDisableCooperative,
     });
   }
 

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -8,6 +8,7 @@ import type Logger from '../Logger';
 import { LogLevel as BackendLevel } from '../Logger';
 import { wait } from '../PromiseUtils';
 import {
+  formatError,
   fromOptionalProtoInt,
   fromProtoInt,
   getHexBuffer,
@@ -228,10 +229,8 @@ class GrpcService {
       const { signers } = call.request;
       GrpcService.assertValidSigners(signers);
 
-      return {
-        disabledSigners:
-          await this.service.signerControlRegistry.disableSigners(signers),
-      };
+      await this.service.signerControlRegistry.disableSigners(signers);
+      return {};
     });
   };
 
@@ -243,10 +242,8 @@ class GrpcService {
       const { signers } = call.request;
       GrpcService.assertValidSigners(signers);
 
-      return {
-        disabledSigners:
-          await this.service.signerControlRegistry.enableSigners(signers),
-      };
+      await this.service.signerControlRegistry.enableSigners(signers);
+      return {};
     });
   };
 
@@ -678,7 +675,7 @@ class GrpcService {
   };
 
   private static invalidArgument = (error: unknown) => {
-    const message = error instanceof Error ? error.message : `${error}`;
+    const message = formatError(error);
     return {
       code: status.INVALID_ARGUMENT,
       details: message,

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -1,3 +1,4 @@
+import { status } from '@grpc/grpc-js';
 import type { ServerDuplexStream, handleUnaryCall } from '@grpc/grpc-js';
 import type { Transaction as TransactionLiquid } from 'liquidjs-lib';
 import process from 'process';
@@ -30,6 +31,7 @@ import TransactionLabelRepository from '../db/repositories/TransactionLabelRepos
 import type * as boltzrpc from '../proto/boltzrpc';
 import { LogLevel } from '../proto/boltzrpc';
 import type Service from '../service/Service';
+import { isValidSigner } from '../service/SignerControlUtils';
 import Sidecar from '../sidecar/Sidecar';
 
 class GrpcService {
@@ -215,6 +217,48 @@ class GrpcService {
       await this.service.allowRefund(id);
 
       return {};
+    });
+  };
+
+  public disableSigners: handleUnaryCall<
+    boltzrpc.DisableSignersRequest,
+    boltzrpc.DisableSignersResponse
+  > = async (call, callback) => {
+    await GrpcService.handleCallback(call, callback, async () => {
+      const { signers } = call.request;
+      GrpcService.assertValidSigners(signers);
+
+      return {
+        disabledSigners:
+          await this.service.signerControlRegistry.disableSigners(signers),
+      };
+    });
+  };
+
+  public enableSigners: handleUnaryCall<
+    boltzrpc.EnableSignersRequest,
+    boltzrpc.EnableSignersResponse
+  > = async (call, callback) => {
+    await GrpcService.handleCallback(call, callback, async () => {
+      const { signers } = call.request;
+      GrpcService.assertValidSigners(signers);
+
+      return {
+        disabledSigners:
+          await this.service.signerControlRegistry.enableSigners(signers),
+      };
+    });
+  };
+
+  public getDisabledSigners: handleUnaryCall<
+    boltzrpc.GetDisabledSignersRequest,
+    boltzrpc.GetDisabledSignersResponse
+  > = async (_call, callback) => {
+    await GrpcService.handleCallback(_call, callback, async () => {
+      return {
+        disabledSigners:
+          this.service.signerControlRegistry.getDisabledSigners(),
+      };
     });
   };
 
@@ -633,26 +677,27 @@ class GrpcService {
     });
   };
 
-  public devDisableCooperative: handleUnaryCall<
-    boltzrpc.DevDisableCooperativeRequest,
-    boltzrpc.DevDisableCooperativeResponse
-  > = async (call, callback) => {
-    await GrpcService.handleCallback(call, callback, async () => {
-      const { disabled } = call.request;
-      this.logger.warn(
-        `${disabled ? 'Dis' : 'En'}abling cooperative swap signatures`,
+  private static invalidArgument = (error: unknown) => {
+    const message = error instanceof Error ? error.message : `${error}`;
+    return {
+      code: status.INVALID_ARGUMENT,
+      details: message,
+      message,
+    };
+  };
+
+  private static assertValidSigners = (signers: boltzrpc.Signer[]) => {
+    if (signers.length === 0) {
+      throw GrpcService.invalidArgument(
+        'at least one signer must be specified',
       );
+    }
 
-      for (const signer of [
-        this.service.musigSigner,
-        this.service.swapManager.chainSwapSigner,
-        this.service.swapManager.deferredClaimer,
-      ]) {
-        signer.setDisableCooperative(disabled);
+    for (const signer of signers) {
+      if (!isValidSigner(signer)) {
+        throw GrpcService.invalidArgument(`invalid signer: ${signer}`);
       }
-
-      return {};
-    });
+    }
   };
 
   private static handleCallback = async <R, T>(

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -32,10 +32,13 @@ import TransactionLabelRepository from '../db/repositories/TransactionLabelRepos
 import type * as boltzrpc from '../proto/boltzrpc';
 import { LogLevel } from '../proto/boltzrpc';
 import type Service from '../service/Service';
+import SignerControlRegistry from '../service/SignerControlRegistry';
 import { isValidSigner } from '../service/SignerControlUtils';
 import Sidecar from '../sidecar/Sidecar';
 
 class GrpcService {
+  private readonly signerControlRegistry = SignerControlRegistry.getInstance();
+
   constructor(
     private readonly logger: Logger,
     private readonly service: Service,
@@ -229,7 +232,7 @@ class GrpcService {
       const { signers } = call.request;
       GrpcService.assertValidSigners(signers);
 
-      await this.service.signerControlRegistry.disableSigners(signers);
+      await this.signerControlRegistry.disableSigners(signers);
       return {};
     });
   };
@@ -242,7 +245,7 @@ class GrpcService {
       const { signers } = call.request;
       GrpcService.assertValidSigners(signers);
 
-      await this.service.signerControlRegistry.enableSigners(signers);
+      await this.signerControlRegistry.enableSigners(signers);
       return {};
     });
   };
@@ -253,8 +256,7 @@ class GrpcService {
   > = async (_call, callback) => {
     await GrpcService.handleCallback(_call, callback, async () => {
       return {
-        disabledSigners:
-          this.service.signerControlRegistry.getDisabledSigners(),
+        disabledSigners: this.signerControlRegistry.getDisabledSigners(),
       };
     });
   };

--- a/lib/lightning/SelfPaymentClient.ts
+++ b/lib/lightning/SelfPaymentClient.ts
@@ -22,6 +22,7 @@ import RefundTransactionRepository from '../db/repositories/RefundTransactionRep
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
 import SwapRepository from '../db/repositories/SwapRepository';
 import { Signer } from '../proto/boltzrpc';
+import SignerControlRegistry from '../service/SignerControlRegistry';
 import { disabledSignerMessage } from '../service/SignerControlUtils';
 import type DecodedInvoiceSidecar from '../sidecar/DecodedInvoice';
 import LightningNursery from '../swap/LightningNursery';
@@ -73,7 +74,6 @@ class SelfPaymentClient
     decoded: DecodedInvoiceSidecar,
     cltvLimit: number,
     payments: LightningPayment[],
-    isSubmarineInvoicePaymentSignerDisabled: boolean,
   ): Promise<{
     isSelf: boolean;
     result: PaymentResponse | undefined;
@@ -106,7 +106,11 @@ class SelfPaymentClient
         );
 
         if (reverseSwap.status === SwapUpdateEvent.SwapCreated) {
-          if (isSubmarineInvoicePaymentSignerDisabled) {
+          if (
+            SignerControlRegistry.getInstance().isDisabled(
+              Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+            )
+          ) {
             throw new Error(
               disabledSignerMessage(Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT),
             );

--- a/lib/lightning/SelfPaymentClient.ts
+++ b/lib/lightning/SelfPaymentClient.ts
@@ -21,6 +21,8 @@ import type Swap from '../db/models/Swap';
 import RefundTransactionRepository from '../db/repositories/RefundTransactionRepository';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
 import SwapRepository from '../db/repositories/SwapRepository';
+import { Signer } from '../proto/boltzrpc';
+import { disabledSignerMessage } from '../service/SignerControlUtils';
 import type DecodedInvoiceSidecar from '../sidecar/DecodedInvoice';
 import LightningNursery from '../swap/LightningNursery';
 import NodeSwitch from '../swap/NodeSwitch';
@@ -71,6 +73,7 @@ class SelfPaymentClient
     decoded: DecodedInvoiceSidecar,
     cltvLimit: number,
     payments: LightningPayment[],
+    isSubmarineInvoicePaymentSignerDisabled = false,
   ): Promise<{
     isSelf: boolean;
     result: PaymentResponse | undefined;
@@ -103,6 +106,12 @@ class SelfPaymentClient
         );
 
         if (reverseSwap.status === SwapUpdateEvent.SwapCreated) {
+          if (isSubmarineInvoicePaymentSignerDisabled) {
+            throw new Error(
+              disabledSignerMessage(Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT),
+            );
+          }
+
           // Only check the CLTV limit on the first attempt
           if (cltvLimit <= decoded.minFinalCltv) {
             throw new Error('CLTV limit too small');

--- a/lib/lightning/SelfPaymentClient.ts
+++ b/lib/lightning/SelfPaymentClient.ts
@@ -73,7 +73,7 @@ class SelfPaymentClient
     decoded: DecodedInvoiceSidecar,
     cltvLimit: number,
     payments: LightningPayment[],
-    isSubmarineInvoicePaymentSignerDisabled = false,
+    isSubmarineInvoicePaymentSignerDisabled: boolean,
   ): Promise<{
     isSelf: boolean;
     result: PaymentResponse | undefined;

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -171,7 +171,6 @@ class Service {
   public readonly transactionFetcher: TransactionFetcher;
 
   public readonly musigSigner: MusigSigner;
-  public readonly signerControlRegistry: SignerControlRegistry;
   public readonly rateProvider: RateProvider;
   public readonly lockupTransactionTracker: LockupTransactionTracker;
 
@@ -236,8 +235,7 @@ class Service {
     );
 
     this.balanceCheck = new BalanceCheck(this.logger, this.walletManager);
-    this.signerControlRegistry = SignerControlRegistry.getInstance();
-    this.signerControlRegistry.init(this.logger);
+    SignerControlRegistry.getInstance().init(this.logger);
     this.swapManager = new SwapManager(
       this.logger,
       notifications,
@@ -285,7 +283,7 @@ class Service {
   }
 
   public init = async (configPairs: PairConfig[]): Promise<void> => {
-    await this.signerControlRegistry.load();
+    await SignerControlRegistry.getInstance().load();
 
     const dbPairSet = new Set<string>();
     const dbPairs = await PairRepository.getPairs();

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -257,7 +257,6 @@ class Service {
       this.sidecar,
       this.balanceCheck,
       overpaymentProtector,
-      this.signerControlRegistry,
     );
     this.walletManager.ethereumManagers.forEach((manager) => {
       manager.commitments.setRefundSignatureLock(
@@ -282,7 +281,6 @@ class Service {
       this.currencies,
       this.walletManager,
       this.swapManager.nursery,
-      this.signerControlRegistry,
     );
   }
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -109,6 +109,7 @@ import Errors from './Errors';
 import EventHandler from './EventHandler';
 import NodeInfo from './NodeInfo';
 import PaymentRequestUtils from './PaymentRequestUtils';
+import SignerControlRegistry from './SignerControlRegistry';
 import TimeoutDeltaProvider from './TimeoutDeltaProvider';
 import TransactionFetcher from './TransactionFetcher';
 import { calculateTimeoutDate, getCurrency } from './Utils';
@@ -170,6 +171,7 @@ class Service {
   public readonly transactionFetcher: TransactionFetcher;
 
   public readonly musigSigner: MusigSigner;
+  public readonly signerControlRegistry: SignerControlRegistry;
   public readonly rateProvider: RateProvider;
   public readonly lockupTransactionTracker: LockupTransactionTracker;
 
@@ -234,6 +236,8 @@ class Service {
     );
 
     this.balanceCheck = new BalanceCheck(this.logger, this.walletManager);
+    this.signerControlRegistry = SignerControlRegistry.getInstance();
+    this.signerControlRegistry.init(this.logger);
     this.swapManager = new SwapManager(
       this.logger,
       notifications,
@@ -253,6 +257,7 @@ class Service {
       this.sidecar,
       this.balanceCheck,
       overpaymentProtector,
+      this.signerControlRegistry,
     );
     this.walletManager.ethereumManagers.forEach((manager) => {
       manager.commitments.setRefundSignatureLock(
@@ -277,10 +282,13 @@ class Service {
       this.currencies,
       this.walletManager,
       this.swapManager.nursery,
+      this.signerControlRegistry,
     );
   }
 
   public init = async (configPairs: PairConfig[]): Promise<void> => {
+    await this.signerControlRegistry.load();
+
     const dbPairSet = new Set<string>();
     const dbPairs = await PairRepository.getPairs();
 

--- a/lib/service/SignerControlRegistry.ts
+++ b/lib/service/SignerControlRegistry.ts
@@ -39,7 +39,11 @@ class SignerControlRegistry {
 
     this.disabledSigners.clear();
     for (const signer of await this.repository.getDisabledSigners()) {
-      this.disabledSigners.add(signerFromName(signer));
+      try {
+        this.disabledSigners.add(signerFromName(signer));
+      } catch {
+        this.logger.warn(`Ignoring unknown disabled signer: ${signer}`);
+      }
     }
   };
 
@@ -76,12 +80,6 @@ class SignerControlRegistry {
 
   public isDisabled = (signer: Signer): boolean =>
     this.disabledSigners.has(signer);
-
-  // Tests use this to clear singleton state between cases.
-  public reset = () => {
-    this.disabledSigners.clear();
-    this.repository = undefined;
-  };
 
   private formatLogMessage = (
     action: 'Disabled' | 'Enabled',

--- a/lib/service/SignerControlRegistry.ts
+++ b/lib/service/SignerControlRegistry.ts
@@ -1,0 +1,102 @@
+import LoggerClass from '../Logger';
+import type Logger from '../Logger';
+import DisabledSignerRepository from '../db/repositories/DisabledSignerRepository';
+import type { Signer } from '../proto/boltzrpc';
+import { signerFromName, signerName } from './SignerControlUtils';
+
+class SignerControlRegistry {
+  private static instance: SignerControlRegistry | undefined;
+
+  private readonly disabledSigners = new Set<Signer>();
+  private logger = LoggerClass.disabledLogger;
+  private repository: typeof DisabledSignerRepository | undefined =
+    DisabledSignerRepository;
+
+  private constructor() {}
+
+  public static getInstance = (): SignerControlRegistry => {
+    if (SignerControlRegistry.instance === undefined) {
+      SignerControlRegistry.instance = new SignerControlRegistry();
+    }
+
+    return SignerControlRegistry.instance;
+  };
+
+  public init = (
+    logger: Logger,
+    repository:
+      | typeof DisabledSignerRepository
+      | undefined = DisabledSignerRepository,
+  ) => {
+    this.logger = logger;
+    this.repository = repository;
+  };
+
+  public load = async (): Promise<void> => {
+    if (this.repository === undefined) {
+      return;
+    }
+
+    this.disabledSigners.clear();
+    for (const signer of await this.repository.getDisabledSigners()) {
+      this.disabledSigners.add(signerFromName(signer));
+    }
+  };
+
+  public disableSigners = async (signers: Signer[]): Promise<Signer[]> => {
+    await this.repository?.addSigners(signers.map(signerName));
+
+    for (const signer of signers) {
+      this.disabledSigners.add(signer);
+    }
+
+    const disabledSigners = this.getDisabledSigners();
+    this.logger.info(
+      this.formatLogMessage('Disabled', signers, disabledSigners),
+    );
+    return disabledSigners;
+  };
+
+  public enableSigners = async (signers: Signer[]): Promise<Signer[]> => {
+    await this.repository?.removeSigners(signers.map(signerName));
+
+    for (const signer of signers) {
+      this.disabledSigners.delete(signer);
+    }
+
+    const disabledSigners = this.getDisabledSigners();
+    this.logger.info(
+      this.formatLogMessage('Enabled', signers, disabledSigners),
+    );
+    return disabledSigners;
+  };
+
+  public getDisabledSigners = (): Signer[] =>
+    Array.from(this.disabledSigners).sort((a, b) => a - b);
+
+  public isDisabled = (signer: Signer): boolean =>
+    this.disabledSigners.has(signer);
+
+  // Tests use this to clear singleton state between cases.
+  public reset = () => {
+    this.disabledSigners.clear();
+    this.repository = undefined;
+  };
+
+  private formatLogMessage = (
+    action: 'Disabled' | 'Enabled',
+    signers: Signer[],
+    disabledSigners: Signer[],
+  ) => {
+    const changed = signers.map(signerName).join(', ');
+    if (disabledSigners.length === 0) {
+      return `${action} signers: ${changed}. No signers are disabled`;
+    }
+
+    return `${action} signers: ${changed}. Disabled signer set: ${disabledSigners
+      .map(signerName)
+      .join(', ')}`;
+  };
+}
+
+export default SignerControlRegistry;

--- a/lib/service/SignerControlUtils.ts
+++ b/lib/service/SignerControlUtils.ts
@@ -1,0 +1,31 @@
+import { Signer, signerFromJSON } from '../proto/boltzrpc';
+
+const signerNames = new Map<Signer, string>(
+  Object.entries(Signer)
+    .filter(([, value]) => typeof value === 'number' && value > 0)
+    .map(([name, value]) => [value as Signer, name]),
+);
+
+export const isValidSigner = (signer: number): signer is Signer =>
+  signerNames.has(signer as Signer);
+
+export const signerName = (signer: Signer): string => {
+  const name = signerNames.get(signer);
+  if (name === undefined) {
+    throw new Error(`invalid signer: ${signer}`);
+  }
+
+  return name;
+};
+
+export const signerFromName = (name: string): Signer => {
+  const signer = signerFromJSON(name);
+  if (!isValidSigner(signer)) {
+    throw new Error(`invalid signer: ${name}`);
+  }
+
+  return signer;
+};
+
+export const disabledSignerMessage = (signer: Signer): string =>
+  `signer ${signerName(signer)} is disabled`;

--- a/lib/service/cooperative/ChainSwapSigner.ts
+++ b/lib/service/cooperative/ChainSwapSigner.ts
@@ -18,7 +18,7 @@ import type SwapOutputType from '../../swap/SwapOutputType';
 import type { Currency } from '../../wallet/WalletManager';
 import type WalletManager from '../../wallet/WalletManager';
 import Errors from '../Errors';
-import type SignerControlRegistry from '../SignerControlRegistry';
+import SignerControlRegistry from '../SignerControlRegistry';
 import type {
   CooperativeClientDetails,
   CooperativeDetails,
@@ -54,6 +54,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
   ) => Promise<void>;
 
   private readonly lock = new AsyncLock();
+  private readonly signerControlRegistry = SignerControlRegistry.getInstance();
   private readonly swapsToClaim = new Map<string, SwapToClaim<ChainSwapInfo>>();
 
   constructor(
@@ -61,7 +62,6 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
     private readonly currencies: Map<string, Currency>,
     walletManager: WalletManager,
     swapOutputType: SwapOutputType,
-    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {
     super(logger, walletManager, swapOutputType);
   }
@@ -106,7 +106,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
       }
 
       if (
-        this.signerControlRegistry?.isDisabled(
+        this.signerControlRegistry.isDisabled(
           Signer.SIGNER_CHAIN_REFUND_COOPERATIVE,
         )
       ) {
@@ -169,7 +169,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
       }
 
       if (
-        this.signerControlRegistry?.isDisabled(
+        this.signerControlRegistry.isDisabled(
           Signer.SIGNER_CHAIN_REFUND_COOPERATIVE,
         )
       ) {
@@ -240,7 +240,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
     swap: ChainSwapInfo,
   ): Promise<CooperativeClientDetails> => {
     if (
-      this.signerControlRegistry?.isDisabled(
+      this.signerControlRegistry.isDisabled(
         Signer.SIGNER_CHAIN_CLAIM_COOPERATIVE,
       )
     ) {
@@ -282,7 +282,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
       ChainSwapSigner.cooperativeBroadcastLock,
       async () => {
         if (
-          this.signerControlRegistry?.isDisabled(
+          this.signerControlRegistry.isDisabled(
             Signer.SIGNER_CHAIN_CLAIM_COOPERATIVE,
           )
         ) {

--- a/lib/service/cooperative/ChainSwapSigner.ts
+++ b/lib/service/cooperative/ChainSwapSigner.ts
@@ -13,10 +13,12 @@ import type Swap from '../../db/models/Swap';
 import type { ChainSwapInfo } from '../../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../../db/repositories/ChainSwapRepository';
 import WrappedSwapRepository from '../../db/repositories/WrappedSwapRepository';
+import { Signer } from '../../proto/boltzrpc';
 import type SwapOutputType from '../../swap/SwapOutputType';
 import type { Currency } from '../../wallet/WalletManager';
 import type WalletManager from '../../wallet/WalletManager';
 import Errors from '../Errors';
+import type SignerControlRegistry from '../SignerControlRegistry';
 import type {
   CooperativeClientDetails,
   CooperativeDetails,
@@ -53,20 +55,16 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
 
   private readonly lock = new AsyncLock();
   private readonly swapsToClaim = new Map<string, SwapToClaim<ChainSwapInfo>>();
-  private disableCooperative = false;
 
   constructor(
     logger: Logger,
     private readonly currencies: Map<string, Currency>,
     walletManager: WalletManager,
     swapOutputType: SwapOutputType,
+    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {
     super(logger, walletManager, swapOutputType);
   }
-
-  public setDisableCooperative = (disabled: boolean) => {
-    this.disableCooperative = disabled;
-  };
 
   public refundSignatureLock = <T>(cb: () => Promise<T>): Promise<T> =>
     this.lock.acquire(ChainSwapSigner.refundSignatureLock, cb);
@@ -107,7 +105,11 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
         throw Errors.CURRENCY_NOT_UTXO_BASED();
       }
 
-      if (this.disableCooperative) {
+      if (
+        this.signerControlRegistry?.isDisabled(
+          Signer.SIGNER_CHAIN_REFUND_COOPERATIVE,
+        )
+      ) {
         throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
           cooperativeSignaturesDisabledMessage,
         );
@@ -166,7 +168,11 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
         );
       }
 
-      if (this.disableCooperative) {
+      if (
+        this.signerControlRegistry?.isDisabled(
+          Signer.SIGNER_CHAIN_REFUND_COOPERATIVE,
+        )
+      ) {
         throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
           cooperativeSignaturesDisabledMessage,
         );
@@ -233,7 +239,11 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
   public getCooperativeDetails = async (
     swap: ChainSwapInfo,
   ): Promise<CooperativeClientDetails> => {
-    if (this.disableCooperative) {
+    if (
+      this.signerControlRegistry?.isDisabled(
+        Signer.SIGNER_CHAIN_CLAIM_COOPERATIVE,
+      )
+    ) {
       throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_CLAIM(
         cooperativeSignaturesDisabledMessage,
       );
@@ -271,7 +281,11 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
     return await this.lock.acquire(
       ChainSwapSigner.cooperativeBroadcastLock,
       async () => {
-        if (this.disableCooperative) {
+        if (
+          this.signerControlRegistry?.isDisabled(
+            Signer.SIGNER_CHAIN_CLAIM_COOPERATIVE,
+          )
+        ) {
           throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_CLAIM(
             cooperativeSignaturesDisabledMessage,
           );

--- a/lib/service/cooperative/DeferredClaimer.ts
+++ b/lib/service/cooperative/DeferredClaimer.ts
@@ -26,6 +26,7 @@ import type { ChainSwapInfo } from '../../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../../db/repositories/ChainSwapRepository';
 import CommitmentRepository from '../../db/repositories/CommitmentRepository';
 import SwapRepository from '../../db/repositories/SwapRepository';
+import { Signer } from '../../proto/boltzrpc';
 import type RateProvider from '../../rates/RateProvider';
 import type Sidecar from '../../sidecar/Sidecar';
 import type SwapOutputType from '../../swap/SwapOutputType';
@@ -37,6 +38,7 @@ import {
 } from '../../wallet/ethereum/contracts/ContractUtils';
 import type ERC20WalletProvider from '../../wallet/providers/ERC20WalletProvider';
 import Errors from '../Errors';
+import type SignerControlRegistry from '../SignerControlRegistry';
 import type { SwapToClaim } from './CoopSignerBase';
 import CoopSignerBase, {
   cooperativeSignaturesDisabledMessage,
@@ -80,8 +82,6 @@ class DeferredClaimer extends CoopSignerBase<{
   >();
   private readonly sweepTriggers: SweepTrigger[];
 
-  private disableCooperative = false;
-
   constructor(
     logger: Logger,
     private readonly sidecar: Sidecar,
@@ -90,6 +90,7 @@ class DeferredClaimer extends CoopSignerBase<{
     walletManager: WalletManager,
     swapOutputType: SwapOutputType,
     private readonly config: SwapConfig,
+    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {
     super(logger, walletManager, swapOutputType);
 
@@ -124,10 +125,6 @@ class DeferredClaimer extends CoopSignerBase<{
         },
       ),
     ];
-  }
-
-  public setDisableCooperative(disabled: boolean) {
-    this.disableCooperative = disabled;
   }
 
   public init = async () => {
@@ -296,7 +293,11 @@ class DeferredClaimer extends CoopSignerBase<{
     publicKey: Buffer;
     transactionHash: Buffer;
   }> => {
-    if (this.disableCooperative) {
+    if (
+      this.signerControlRegistry?.isDisabled(
+        Signer.SIGNER_DEFERRED_CLAIM_COOPERATIVE,
+      )
+    ) {
       throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_CLAIM(
         cooperativeSignaturesDisabledMessage,
       );
@@ -327,7 +328,11 @@ class DeferredClaimer extends CoopSignerBase<{
     theirPartialSignature: Buffer,
   ) => {
     await this.lock.acquire(DeferredClaimer.batchClaimLock, async () => {
-      if (this.disableCooperative) {
+      if (
+        this.signerControlRegistry?.isDisabled(
+          Signer.SIGNER_DEFERRED_CLAIM_COOPERATIVE,
+        )
+      ) {
         throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_CLAIM(
           cooperativeSignaturesDisabledMessage,
         );

--- a/lib/service/cooperative/DeferredClaimer.ts
+++ b/lib/service/cooperative/DeferredClaimer.ts
@@ -38,7 +38,7 @@ import {
 } from '../../wallet/ethereum/contracts/ContractUtils';
 import type ERC20WalletProvider from '../../wallet/providers/ERC20WalletProvider';
 import Errors from '../Errors';
-import type SignerControlRegistry from '../SignerControlRegistry';
+import SignerControlRegistry from '../SignerControlRegistry';
 import type { SwapToClaim } from './CoopSignerBase';
 import CoopSignerBase, {
   cooperativeSignaturesDisabledMessage,
@@ -80,6 +80,7 @@ class DeferredClaimer extends CoopSignerBase<{
     string,
     Map<string, ChainSwapToClaimPreimage>
   >();
+  private readonly signerControlRegistry = SignerControlRegistry.getInstance();
   private readonly sweepTriggers: SweepTrigger[];
 
   constructor(
@@ -90,7 +91,6 @@ class DeferredClaimer extends CoopSignerBase<{
     walletManager: WalletManager,
     swapOutputType: SwapOutputType,
     private readonly config: SwapConfig,
-    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {
     super(logger, walletManager, swapOutputType);
 
@@ -294,7 +294,7 @@ class DeferredClaimer extends CoopSignerBase<{
     transactionHash: Buffer;
   }> => {
     if (
-      this.signerControlRegistry?.isDisabled(
+      this.signerControlRegistry.isDisabled(
         Signer.SIGNER_DEFERRED_CLAIM_COOPERATIVE,
       )
     ) {
@@ -329,7 +329,7 @@ class DeferredClaimer extends CoopSignerBase<{
   ) => {
     await this.lock.acquire(DeferredClaimer.batchClaimLock, async () => {
       if (
-        this.signerControlRegistry?.isDisabled(
+        this.signerControlRegistry.isDisabled(
           Signer.SIGNER_DEFERRED_CLAIM_COOPERATIVE,
         )
       ) {

--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -31,7 +31,7 @@ import {
   queryEtherSwapValuesFromTransaction,
 } from '../../wallet/ethereum/contracts/ContractUtils';
 import Errors from '../Errors';
-import type SignerControlRegistry from '../SignerControlRegistry';
+import SignerControlRegistry from '../SignerControlRegistry';
 import { cooperativeSignaturesDisabledMessage } from './CoopSignerBase';
 import MusigSigner from './MusigSigner';
 
@@ -53,13 +53,13 @@ class EipSigner {
     ].join('\n');
 
   private readonly lock = new AsyncLock();
+  private readonly signerControlRegistry = SignerControlRegistry.getInstance();
 
   constructor(
     private readonly logger: Logger,
     private readonly currencies: Map<string, Currency>,
     private readonly walletManager: WalletManager,
     private readonly sidecar: Sidecar,
-    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {}
 
   public refundSignatureLock = <T>(cb: () => Promise<T>): Promise<T> =>
@@ -68,7 +68,7 @@ class EipSigner {
   public signSwapRefund = async (swapIdOrPreimageHash: string) =>
     this.refundSignatureLock(async () => {
       if (
-        this.signerControlRegistry?.isDisabled(
+        this.signerControlRegistry.isDisabled(
           Signer.SIGNER_EVM_REFUND_COOPERATIVE,
         )
       ) {
@@ -177,7 +177,7 @@ class EipSigner {
   ) =>
     this.refundSignatureLock(async () => {
       if (
-        this.signerControlRegistry?.isDisabled(
+        this.signerControlRegistry.isDisabled(
           Signer.SIGNER_EVM_COMMITMENT_REFUND_COOPERATIVE,
         )
       ) {

--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -17,6 +17,7 @@ import type { ChainSwapInfo } from '../../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../../db/repositories/ChainSwapRepository';
 import CommitmentRepository from '../../db/repositories/CommitmentRepository';
 import SwapRepository from '../../db/repositories/SwapRepository';
+import { Signer } from '../../proto/boltzrpc';
 import type Sidecar from '../../sidecar/Sidecar';
 import type { Currency } from '../../wallet/WalletManager';
 import type WalletManager from '../../wallet/WalletManager';
@@ -30,6 +31,8 @@ import {
   queryEtherSwapValuesFromTransaction,
 } from '../../wallet/ethereum/contracts/ContractUtils';
 import Errors from '../Errors';
+import type SignerControlRegistry from '../SignerControlRegistry';
+import { cooperativeSignaturesDisabledMessage } from './CoopSignerBase';
 import MusigSigner from './MusigSigner';
 
 export type RefundSignatureLock = <T>(cb: () => Promise<T>) => Promise<T>;
@@ -56,6 +59,7 @@ class EipSigner {
     private readonly currencies: Map<string, Currency>,
     private readonly walletManager: WalletManager,
     private readonly sidecar: Sidecar,
+    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {}
 
   public refundSignatureLock = <T>(cb: () => Promise<T>): Promise<T> =>
@@ -63,6 +67,16 @@ class EipSigner {
 
   public signSwapRefund = async (swapIdOrPreimageHash: string) =>
     this.refundSignatureLock(async () => {
+      if (
+        this.signerControlRegistry?.isDisabled(
+          Signer.SIGNER_EVM_REFUND_COOPERATIVE,
+        )
+      ) {
+        throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+          cooperativeSignaturesDisabledMessage,
+        );
+      }
+
       const { swap, chainSymbol, lightningCurrency } =
         await this.getSwap(swapIdOrPreimageHash);
       const manager = this.walletManager.ethereumManagers.find((man) =>
@@ -162,6 +176,16 @@ class EipSigner {
     logIndex?: number,
   ) =>
     this.refundSignatureLock(async () => {
+      if (
+        this.signerControlRegistry?.isDisabled(
+          Signer.SIGNER_EVM_COMMITMENT_REFUND_COOPERATIVE,
+        )
+      ) {
+        throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+          cooperativeSignaturesDisabledMessage,
+        );
+      }
+
       const manager = this.walletManager.ethereumManagers.find((man) =>
         man.hasSymbol(chainSymbol),
       );

--- a/lib/service/cooperative/MusigSigner.ts
+++ b/lib/service/cooperative/MusigSigner.ts
@@ -25,12 +25,14 @@ import ReverseSwapRepository from '../../db/repositories/ReverseSwapRepository';
 import SwapRepository from '../../db/repositories/SwapRepository';
 import WrappedSwapRepository from '../../db/repositories/WrappedSwapRepository';
 import ClnClient from '../../lightning/cln/ClnClient';
+import { Signer } from '../../proto/boltzrpc';
 import { Payment_PaymentStatus } from '../../proto/lnd/rpc';
 import NodeSwitch from '../../swap/NodeSwitch';
 import SwapNursery from '../../swap/SwapNursery';
 import type { Currency } from '../../wallet/WalletManager';
 import type WalletManager from '../../wallet/WalletManager';
 import Errors from '../Errors';
+import type SignerControlRegistry from '../SignerControlRegistry';
 import { cooperativeSignaturesDisabledMessage } from './CoopSignerBase';
 import {
   checkArkTransaction,
@@ -58,18 +60,14 @@ class MusigSigner {
 
   private readonly lock = new AsyncLock();
   private readonly allowedRefunds = new Set<string>();
-  private disableCooperative = false;
 
   constructor(
     private readonly logger: Logger,
     private readonly currencies: Map<string, Currency>,
     private readonly walletManager: WalletManager,
     private readonly nursery: SwapNursery,
+    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {}
-
-  public setDisableCooperative = (disabled: boolean) => {
-    this.disableCooperative = disabled;
-  };
 
   public allowRefund = async (id: string) => {
     const swap = await SwapRepository.getSwap({ id });
@@ -105,7 +103,11 @@ class MusigSigner {
       throw Errors.SWAP_NOT_FOUND(swapId);
     }
 
-    if (this.disableCooperative) {
+    if (
+      this.signerControlRegistry?.isDisabled(
+        Signer.SIGNER_SUBMARINE_REFUND_COOPERATIVE,
+      )
+    ) {
       throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
         cooperativeSignaturesDisabledMessage,
       );
@@ -154,7 +156,11 @@ class MusigSigner {
       throw Errors.SWAP_NOT_FOUND(swapId);
     }
 
-    if (this.disableCooperative) {
+    if (
+      this.signerControlRegistry?.isDisabled(
+        Signer.SIGNER_SUBMARINE_REFUND_COOPERATIVE,
+      )
+    ) {
       throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
         cooperativeSignaturesDisabledMessage,
       );
@@ -213,7 +219,12 @@ class MusigSigner {
           throw Errors.SWAP_NOT_FOUND(swapId);
         }
 
-        if (this.disableCooperative) {
+        if (
+          toSign !== undefined &&
+          this.signerControlRegistry?.isDisabled(
+            Signer.SIGNER_REVERSE_CLAIM_COOPERATIVE,
+          )
+        ) {
           throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_CLAIM(
             cooperativeSignaturesDisabledMessage,
           );

--- a/lib/service/cooperative/MusigSigner.ts
+++ b/lib/service/cooperative/MusigSigner.ts
@@ -32,7 +32,7 @@ import SwapNursery from '../../swap/SwapNursery';
 import type { Currency } from '../../wallet/WalletManager';
 import type WalletManager from '../../wallet/WalletManager';
 import Errors from '../Errors';
-import type SignerControlRegistry from '../SignerControlRegistry';
+import SignerControlRegistry from '../SignerControlRegistry';
 import { cooperativeSignaturesDisabledMessage } from './CoopSignerBase';
 import {
   checkArkTransaction,
@@ -59,6 +59,7 @@ class MusigSigner {
     'reverseSwapClaimSignature';
 
   private readonly lock = new AsyncLock();
+  private readonly signerControlRegistry = SignerControlRegistry.getInstance();
   private readonly allowedRefunds = new Set<string>();
 
   constructor(
@@ -66,7 +67,6 @@ class MusigSigner {
     private readonly currencies: Map<string, Currency>,
     private readonly walletManager: WalletManager,
     private readonly nursery: SwapNursery,
-    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {}
 
   public allowRefund = async (id: string) => {
@@ -104,7 +104,7 @@ class MusigSigner {
     }
 
     if (
-      this.signerControlRegistry?.isDisabled(
+      this.signerControlRegistry.isDisabled(
         Signer.SIGNER_SUBMARINE_REFUND_COOPERATIVE,
       )
     ) {
@@ -157,7 +157,7 @@ class MusigSigner {
     }
 
     if (
-      this.signerControlRegistry?.isDisabled(
+      this.signerControlRegistry.isDisabled(
         Signer.SIGNER_SUBMARINE_REFUND_COOPERATIVE,
       )
     ) {
@@ -221,7 +221,7 @@ class MusigSigner {
 
         if (
           toSign !== undefined &&
-          this.signerControlRegistry?.isDisabled(
+          this.signerControlRegistry.isDisabled(
             Signer.SIGNER_REVERSE_CLAIM_COOPERATIVE,
           )
         ) {

--- a/lib/swap/PaymentHandler.ts
+++ b/lib/swap/PaymentHandler.ts
@@ -24,7 +24,10 @@ import LndClient from '../lightning/LndClient';
 import type PendingPaymentTracker from '../lightning/PendingPaymentTracker';
 import SelfPaymentClient from '../lightning/SelfPaymentClient';
 import ClnClient from '../lightning/cln/ClnClient';
+import { Signer } from '../proto/boltzrpc';
 import { PaymentFailureReason, Payment_PaymentStatus } from '../proto/lnd/rpc';
+import type SignerControlRegistry from '../service/SignerControlRegistry';
+import { disabledSignerMessage } from '../service/SignerControlUtils';
 import type TimeoutDeltaProvider from '../service/TimeoutDeltaProvider';
 import type DecodedInvoice from '../sidecar/DecodedInvoice';
 import type Sidecar from '../sidecar/Sidecar';
@@ -92,6 +95,7 @@ class PaymentHandler {
     private readonly timeoutDeltaProvider: TimeoutDeltaProvider,
     private readonly pendingPaymentTracker: PendingPaymentTracker,
     private readonly swapNursery: SwapNursery,
+    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {
     this.selfPaymentClient = new SelfPaymentClient(this.logger, swapNursery);
   }
@@ -139,12 +143,18 @@ class PaymentHandler {
         preferredNode.client,
       );
 
+    const isSubmarineInvoicePaymentSignerDisabled =
+      this.signerControlRegistry?.isDisabled(
+        Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+      ) ?? false;
+
     try {
       const res = await this.selfPaymentClient.handleSelfPayment(
         swap,
         decoded,
         cltvLimit,
         payments,
+        isSubmarineInvoicePaymentSignerDisabled,
       );
       if (res.isSelf) {
         if (res.result !== undefined) {
@@ -157,6 +167,15 @@ class PaymentHandler {
       const msg = formatError(error);
       this.logPaymentFailure(swap, msg);
       await this.abandonSwap(swap, msg);
+      return undefined;
+    }
+
+    if (isSubmarineInvoicePaymentSignerDisabled && payments.length === 0) {
+      const errorMessage = disabledSignerMessage(
+        Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+      );
+      this.logPaymentFailure(swap, errorMessage);
+      await this.abandonSwap(swap, errorMessage);
       return undefined;
     }
 

--- a/lib/swap/PaymentHandler.ts
+++ b/lib/swap/PaymentHandler.ts
@@ -26,7 +26,7 @@ import SelfPaymentClient from '../lightning/SelfPaymentClient';
 import ClnClient from '../lightning/cln/ClnClient';
 import { Signer } from '../proto/boltzrpc';
 import { PaymentFailureReason, Payment_PaymentStatus } from '../proto/lnd/rpc';
-import type SignerControlRegistry from '../service/SignerControlRegistry';
+import SignerControlRegistry from '../service/SignerControlRegistry';
 import { disabledSignerMessage } from '../service/SignerControlUtils';
 import type TimeoutDeltaProvider from '../service/TimeoutDeltaProvider';
 import type DecodedInvoice from '../sidecar/DecodedInvoice';
@@ -95,7 +95,6 @@ class PaymentHandler {
     private readonly timeoutDeltaProvider: TimeoutDeltaProvider,
     private readonly pendingPaymentTracker: PendingPaymentTracker,
     private readonly swapNursery: SwapNursery,
-    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {
     this.selfPaymentClient = new SelfPaymentClient(this.logger, swapNursery);
   }
@@ -144,9 +143,9 @@ class PaymentHandler {
       );
 
     const isSubmarineInvoicePaymentSignerDisabled =
-      this.signerControlRegistry?.isDisabled(
+      SignerControlRegistry.getInstance().isDisabled(
         Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
-      ) ?? false;
+      );
 
     try {
       const res = await this.selfPaymentClient.handleSelfPayment(
@@ -154,7 +153,6 @@ class PaymentHandler {
         decoded,
         cltvLimit,
         payments,
-        isSubmarineInvoicePaymentSignerDisabled,
       );
       if (res.isSelf) {
         if (res.result !== undefined) {

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -77,6 +77,7 @@ import ServiceErrors from '../service/Errors';
 import InvoiceExpiryHelper from '../service/InvoiceExpiryHelper';
 import type PaymentRequestUtils from '../service/PaymentRequestUtils';
 import Renegotiator from '../service/Renegotiator';
+import type SignerControlRegistry from '../service/SignerControlRegistry';
 import TimeoutDeltaProvider from '../service/TimeoutDeltaProvider';
 import ChainSwapSigner from '../service/cooperative/ChainSwapSigner';
 import DeferredClaimer from '../service/cooperative/DeferredClaimer';
@@ -215,6 +216,7 @@ class SwapManager {
     private readonly sidecar: Sidecar,
     balanceCheck: BalanceCheck,
     overpaymentProtector: OverpaymentProtector,
+    signerControlRegistry?: SignerControlRegistry,
   ) {
     this.deferredClaimer = new DeferredClaimer(
       this.logger,
@@ -224,6 +226,7 @@ class SwapManager {
       this.walletManager,
       this.swapOutputType,
       swapConfig,
+      signerControlRegistry,
     );
 
     this.chainSwapSigner = new ChainSwapSigner(
@@ -231,12 +234,14 @@ class SwapManager {
       this.currencies,
       this.walletManager,
       this.swapOutputType,
+      signerControlRegistry,
     );
     this.eipSigner = new EipSigner(
       this.logger,
       this.currencies,
       this.walletManager,
       sidecar,
+      signerControlRegistry,
     );
 
     this.nursery = new SwapNursery(
@@ -254,6 +259,7 @@ class SwapManager {
       lockupTransactionTracker,
       overpaymentProtector,
       swapConfig.paymentTimeoutMinutes,
+      signerControlRegistry,
     );
 
     this.renegotiator = new Renegotiator(

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -77,7 +77,6 @@ import ServiceErrors from '../service/Errors';
 import InvoiceExpiryHelper from '../service/InvoiceExpiryHelper';
 import type PaymentRequestUtils from '../service/PaymentRequestUtils';
 import Renegotiator from '../service/Renegotiator';
-import type SignerControlRegistry from '../service/SignerControlRegistry';
 import TimeoutDeltaProvider from '../service/TimeoutDeltaProvider';
 import ChainSwapSigner from '../service/cooperative/ChainSwapSigner';
 import DeferredClaimer from '../service/cooperative/DeferredClaimer';
@@ -216,7 +215,6 @@ class SwapManager {
     private readonly sidecar: Sidecar,
     balanceCheck: BalanceCheck,
     overpaymentProtector: OverpaymentProtector,
-    signerControlRegistry?: SignerControlRegistry,
   ) {
     this.deferredClaimer = new DeferredClaimer(
       this.logger,
@@ -226,7 +224,6 @@ class SwapManager {
       this.walletManager,
       this.swapOutputType,
       swapConfig,
-      signerControlRegistry,
     );
 
     this.chainSwapSigner = new ChainSwapSigner(
@@ -234,14 +231,12 @@ class SwapManager {
       this.currencies,
       this.walletManager,
       this.swapOutputType,
-      signerControlRegistry,
     );
     this.eipSigner = new EipSigner(
       this.logger,
       this.currencies,
       this.walletManager,
       sidecar,
-      signerControlRegistry,
     );
 
     this.nursery = new SwapNursery(
@@ -259,7 +254,6 @@ class SwapManager {
       lockupTransactionTracker,
       overpaymentProtector,
       swapConfig.paymentTimeoutMinutes,
-      signerControlRegistry,
     );
 
     this.renegotiator = new Renegotiator(

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -67,7 +67,7 @@ import { Signer } from '../proto/boltzrpc';
 import FeeProvider from '../rates/FeeProvider';
 import type LockupTransactionTracker from '../rates/LockupTransactionTracker';
 import type RateProvider from '../rates/RateProvider';
-import type SignerControlRegistry from '../service/SignerControlRegistry';
+import SignerControlRegistry from '../service/SignerControlRegistry';
 import { disabledSignerMessage } from '../service/SignerControlUtils';
 import type TimeoutDeltaProvider from '../service/TimeoutDeltaProvider';
 import type ChainSwapSigner from '../service/cooperative/ChainSwapSigner';
@@ -149,7 +149,6 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     lockupTransactionTracker: LockupTransactionTracker,
     overpaymentProtector: OverpaymentProtector,
     paymentTimeoutMinutes?: number,
-    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {
     super();
 
@@ -192,7 +191,6 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       timeoutDeltaProvider,
       this.pendingPaymentTracker,
       this,
-      this.signerControlRegistry,
     );
     this.lightningNursery = new LightningNursery(
       this.logger,
@@ -1074,9 +1072,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     switch (sendingCurrency.type) {
       case CurrencyType.BitcoinLike:
       case CurrencyType.Liquid:
-        if (await this.lockupUtxo(swap, sendingCurrency.chainClient!, wallet)) {
-          await this.chainSwapSigner.registerForClaim(swap);
-        }
+        await this.lockupUtxo(swap, sendingCurrency.chainClient!, wallet);
         break;
 
       case CurrencyType.Ether:
@@ -1368,22 +1364,15 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     }
   };
 
-  private lockupSignerEnabled = (swap: ReverseSwap | ChainSwapInfo) => {
-    if (this.signerControlRegistry === undefined) {
-      return true;
-    }
-
+  private assertLockupSignerEnabled = (swap: ReverseSwap | ChainSwapInfo) => {
     const signer =
       swap.type === SwapType.ReverseSubmarine
         ? Signer.SIGNER_REVERSE_LOCKUP
         : Signer.SIGNER_CHAIN_LOCKUP;
 
-    if (!this.signerControlRegistry.isDisabled(signer)) {
-      return true;
+    if (SignerControlRegistry.getInstance().isDisabled(signer)) {
+      throw new Error(disabledSignerMessage(signer));
     }
-
-    this.logger.info(disabledSignerMessage(signer));
-    return false;
   };
 
   private lockupUtxo = async (
@@ -1391,12 +1380,10 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     chainClient: IChainClient,
     wallet: Wallet,
     lightningClient?: LightningClient,
-  ): Promise<boolean> => {
-    if (!this.lockupSignerEnabled(swap)) {
-      return false;
-    }
-
+  ) => {
     try {
+      this.assertLockupSignerEnabled(swap);
+
       let feePerVbyte: number;
 
       if (
@@ -1454,7 +1441,6 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
           vout!,
         ),
       });
-      return true;
     } catch (error) {
       await this.handleSwapSendFailed(
         swap,
@@ -1462,7 +1448,11 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
         error,
         lightningClient,
       );
-      return false;
+      return;
+    }
+
+    if (swap.type === SwapType.Chain) {
+      await this.chainSwapSigner.registerForClaim(swap as ChainSwapInfo);
     }
   };
 
@@ -1471,11 +1461,9 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     wallet: Wallet,
     lightningClient?: LightningClient,
   ) => {
-    if (!this.lockupSignerEnabled(swap)) {
-      return;
-    }
-
     try {
+      this.assertLockupSignerEnabled(swap);
+
       const lockupAddress =
         swap.type === SwapType.ReverseSubmarine
           ? (swap as ReverseSwap).lockupAddress
@@ -1523,11 +1511,9 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     wallet: Wallet,
     lightningClient?: LightningClient,
   ) => {
-    if (!this.lockupSignerEnabled(swap)) {
-      return;
-    }
-
     try {
+      this.assertLockupSignerEnabled(swap);
+
       const nursery = this.findEthereumNursery(wallet.symbol)!;
       const lockupDetails =
         swap.type === SwapType.ReverseSubmarine
@@ -1595,11 +1581,9 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     wallet: Wallet,
     lightningClient?: LightningClient,
   ) => {
-    if (!this.lockupSignerEnabled(swap)) {
-      return;
-    }
-
     try {
+      this.assertLockupSignerEnabled(swap);
+
       const nursery = this.findEthereumNursery(wallet.symbol)!;
       const walletProvider = wallet.walletProvider as ERC20WalletProvider;
 

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -63,9 +63,12 @@ import type { LightningClient } from '../lightning/LightningClient';
 import { HtlcState, InvoiceState } from '../lightning/LightningClient';
 import PendingPaymentTracker from '../lightning/PendingPaymentTracker';
 import type NotificationClient from '../notifications/NotificationClient';
+import { Signer } from '../proto/boltzrpc';
 import FeeProvider from '../rates/FeeProvider';
 import type LockupTransactionTracker from '../rates/LockupTransactionTracker';
 import type RateProvider from '../rates/RateProvider';
+import type SignerControlRegistry from '../service/SignerControlRegistry';
+import { disabledSignerMessage } from '../service/SignerControlUtils';
 import type TimeoutDeltaProvider from '../service/TimeoutDeltaProvider';
 import type ChainSwapSigner from '../service/cooperative/ChainSwapSigner';
 import type DeferredClaimer from '../service/cooperative/DeferredClaimer';
@@ -146,6 +149,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     lockupTransactionTracker: LockupTransactionTracker,
     overpaymentProtector: OverpaymentProtector,
     paymentTimeoutMinutes?: number,
+    private readonly signerControlRegistry?: SignerControlRegistry,
   ) {
     super();
 
@@ -188,6 +192,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       timeoutDeltaProvider,
       this.pendingPaymentTracker,
       this,
+      this.signerControlRegistry,
     );
     this.lightningNursery = new LightningNursery(
       this.logger,
@@ -1362,12 +1367,34 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     }
   };
 
+  private lockupSignerEnabled = (swap: ReverseSwap | ChainSwapInfo) => {
+    if (this.signerControlRegistry === undefined) {
+      return true;
+    }
+
+    const signer =
+      swap.type === SwapType.ReverseSubmarine
+        ? Signer.SIGNER_REVERSE_LOCKUP
+        : Signer.SIGNER_CHAIN_LOCKUP;
+
+    if (!this.signerControlRegistry.isDisabled(signer)) {
+      return true;
+    }
+
+    this.logger.info(disabledSignerMessage(signer));
+    return false;
+  };
+
   private lockupUtxo = async (
     swap: ReverseSwap | ChainSwapInfo,
     chainClient: IChainClient,
     wallet: Wallet,
     lightningClient?: LightningClient,
   ) => {
+    if (!this.lockupSignerEnabled(swap)) {
+      return;
+    }
+
     try {
       let feePerVbyte: number;
 
@@ -1441,6 +1468,10 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     wallet: Wallet,
     lightningClient?: LightningClient,
   ) => {
+    if (!this.lockupSignerEnabled(swap)) {
+      return;
+    }
+
     try {
       const lockupAddress =
         swap.type === SwapType.ReverseSubmarine
@@ -1489,6 +1520,10 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     wallet: Wallet,
     lightningClient?: LightningClient,
   ) => {
+    if (!this.lockupSignerEnabled(swap)) {
+      return;
+    }
+
     try {
       const nursery = this.findEthereumNursery(wallet.symbol)!;
       const lockupDetails =
@@ -1557,6 +1592,10 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     wallet: Wallet,
     lightningClient?: LightningClient,
   ) => {
+    if (!this.lockupSignerEnabled(swap)) {
+      return;
+    }
+
     try {
       const nursery = this.findEthereumNursery(wallet.symbol)!;
       const walletProvider = wallet.walletProvider as ERC20WalletProvider;

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -1371,7 +1371,9 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
         : Signer.SIGNER_CHAIN_LOCKUP;
 
     if (SignerControlRegistry.getInstance().isDisabled(signer)) {
-      throw new Error(disabledSignerMessage(signer));
+      throw new Error(
+        `${disabledSignerMessage(signer)} for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
+      );
     }
   };
 

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -1074,8 +1074,9 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     switch (sendingCurrency.type) {
       case CurrencyType.BitcoinLike:
       case CurrencyType.Liquid:
-        await this.lockupUtxo(swap, sendingCurrency.chainClient!, wallet);
-        await this.chainSwapSigner.registerForClaim(swap);
+        if (await this.lockupUtxo(swap, sendingCurrency.chainClient!, wallet)) {
+          await this.chainSwapSigner.registerForClaim(swap);
+        }
         break;
 
       case CurrencyType.Ether:
@@ -1390,9 +1391,9 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     chainClient: IChainClient,
     wallet: Wallet,
     lightningClient?: LightningClient,
-  ) => {
+  ): Promise<boolean> => {
     if (!this.lockupSignerEnabled(swap)) {
-      return;
+      return false;
     }
 
     try {
@@ -1453,6 +1454,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
           vout!,
         ),
       });
+      return true;
     } catch (error) {
       await this.handleSwapSendFailed(
         swap,
@@ -1460,6 +1462,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
         error,
         lightningClient,
       );
+      return false;
     }
   };
 

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -36,6 +36,10 @@ service Boltz {
   /* Disables safety checks to allow for a cooperative refund for a swap */
   rpc AllowRefund (AllowRefundRequest) returns (AllowRefundResponse);
 
+  rpc DisableSigners (DisableSignersRequest) returns (DisableSignersResponse);
+  rpc EnableSigners (EnableSignersRequest) returns (EnableSignersResponse);
+  rpc GetDisabledSigners (GetDisabledSignersRequest) returns (GetDisabledSignersResponse);
+
   /* Gets funds locked by the server for swaps */
   rpc GetLockedFunds (GetLockedFundsRequest) returns (GetLockedFundsResponse);
 
@@ -69,14 +73,26 @@ service Boltz {
 
   rpc DevHeapDump (DevHeapDumpRequest) returns (DevHeapDumpResponse);
   rpc DevClearSwapUpdateCache (DevClearSwapUpdateCacheRequest) returns (DevClearSwapUpdateCacheResponse);
-
-  rpc DevDisableCooperative (DevDisableCooperativeRequest) returns (DevDisableCooperativeResponse);
 }
 
 enum OutputType {
   BECH32 = 0;
   COMPATIBILITY = 1;
   LEGACY = 2;
+}
+
+enum Signer {
+  SIGNER_UNSPECIFIED = 0;
+  SIGNER_SUBMARINE_REFUND_COOPERATIVE = 1;
+  SIGNER_REVERSE_CLAIM_COOPERATIVE = 2;
+  SIGNER_CHAIN_REFUND_COOPERATIVE = 3;
+  SIGNER_CHAIN_CLAIM_COOPERATIVE = 4;
+  SIGNER_DEFERRED_CLAIM_COOPERATIVE = 5;
+  SIGNER_EVM_REFUND_COOPERATIVE = 6;
+  SIGNER_EVM_COMMITMENT_REFUND_COOPERATIVE = 7;
+  SIGNER_REVERSE_LOCKUP = 8;
+  SIGNER_CHAIN_LOCKUP = 9;
+  SIGNER_SUBMARINE_INVOICE_PAYMENT = 10;
 }
 
 message StopRequest {}
@@ -267,6 +283,28 @@ message AllowRefundRequest {
 }
 
 message AllowRefundResponse {}
+
+message DisableSignersRequest {
+  repeated Signer signers = 1;
+}
+
+message DisableSignersResponse {
+  repeated Signer disabled_signers = 1;
+}
+
+message EnableSignersRequest {
+  repeated Signer signers = 1;
+}
+
+message EnableSignersResponse {
+  repeated Signer disabled_signers = 1;
+}
+
+message GetDisabledSignersRequest {}
+
+message GetDisabledSignersResponse {
+  repeated Signer disabled_signers = 1;
+}
 
 message GetLabelRequest {
   string tx_id = 1;
@@ -486,9 +524,3 @@ message DevClearSwapUpdateCacheRequest {
   optional string id = 1;
 }
 message DevClearSwapUpdateCacheResponse {}
-
-message DevDisableCooperativeRequest {
-  bool disabled = 1;
-}
-
-message DevDisableCooperativeResponse {}

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -288,17 +288,13 @@ message DisableSignersRequest {
   repeated Signer signers = 1;
 }
 
-message DisableSignersResponse {
-  repeated Signer disabled_signers = 1;
-}
+message DisableSignersResponse {}
 
 message EnableSignersRequest {
   repeated Signer signers = 1;
 }
 
-message EnableSignersResponse {
-  repeated Signer disabled_signers = 1;
-}
+message EnableSignersResponse {}
 
 message GetDisabledSignersRequest {}
 

--- a/test/integration/service/cooperative/ChainSwapSigner.spec.ts
+++ b/test/integration/service/cooperative/ChainSwapSigner.spec.ts
@@ -42,7 +42,9 @@ import type { ChainSwapInfo } from '../../../../lib/db/repositories/ChainSwapRep
 import ChainSwapRepository from '../../../../lib/db/repositories/ChainSwapRepository';
 import RefundTransactionRepository from '../../../../lib/db/repositories/RefundTransactionRepository';
 import WrappedSwapRepository from '../../../../lib/db/repositories/WrappedSwapRepository';
+import { Signer } from '../../../../lib/proto/boltzrpc';
 import Errors from '../../../../lib/service/Errors';
+import SignerControlRegistry from '../../../../lib/service/SignerControlRegistry';
 import ChainSwapSigner from '../../../../lib/service/cooperative/ChainSwapSigner';
 import { RefundRejectionReason } from '../../../../lib/service/cooperative/MusigSigner';
 import * as Utils from '../../../../lib/service/cooperative/Utils';
@@ -107,6 +109,7 @@ describe('ChainSwapSigner', () => {
   } as WalletManager;
 
   let signer: ChainSwapSigner;
+  let signerControlRegistry: SignerControlRegistry;
 
   beforeAll(async () => {
     await setup();
@@ -121,6 +124,8 @@ describe('ChainSwapSigner', () => {
   });
 
   beforeEach(() => {
+    signerControlRegistry = SignerControlRegistry.getInstance();
+    signerControlRegistry.reset();
     signer = new ChainSwapSigner(
       Logger.disabledLogger,
       new Map<string, Currency>([
@@ -129,6 +134,7 @@ describe('ChainSwapSigner', () => {
       ]),
       walletManager,
       new SwapOutputType(OutputType.Bech32),
+      signerControlRegistry,
     );
   });
 
@@ -369,7 +375,9 @@ describe('ChainSwapSigner', () => {
         },
       });
 
-      signer.setDisableCooperative(true);
+      await signerControlRegistry.disableSigners([
+        Signer.SIGNER_CHAIN_REFUND_COOPERATIVE,
+      ]);
 
       await expect(
         signer.signRefund('asdf', Buffer.alloc(0), Buffer.alloc(0), 0),
@@ -429,6 +437,7 @@ describe('ChainSwapSigner', () => {
         ]),
         walletManager,
         new SwapOutputType(OutputType.Bech32),
+        signerControlRegistry,
       );
     });
 
@@ -474,7 +483,9 @@ describe('ChainSwapSigner', () => {
         },
       });
 
-      signerWithArk.setDisableCooperative(true);
+      await signerControlRegistry.disableSigners([
+        Signer.SIGNER_CHAIN_REFUND_COOPERATIVE,
+      ]);
 
       await expect(
         signerWithArk.signRefundArk('asdf', 'transaction', 'checkpoint'),

--- a/test/integration/service/cooperative/ChainSwapSigner.spec.ts
+++ b/test/integration/service/cooperative/ChainSwapSigner.spec.ts
@@ -125,7 +125,8 @@ describe('ChainSwapSigner', () => {
 
   beforeEach(() => {
     signerControlRegistry = SignerControlRegistry.getInstance();
-    signerControlRegistry.reset();
+    (signerControlRegistry as any)['disabledSigners'].clear();
+    (signerControlRegistry as any)['repository'] = undefined;
     signer = new ChainSwapSigner(
       Logger.disabledLogger,
       new Map<string, Currency>([
@@ -134,7 +135,6 @@ describe('ChainSwapSigner', () => {
       ]),
       walletManager,
       new SwapOutputType(OutputType.Bech32),
-      signerControlRegistry,
     );
   });
 
@@ -437,7 +437,6 @@ describe('ChainSwapSigner', () => {
         ]),
         walletManager,
         new SwapOutputType(OutputType.Bech32),
-        signerControlRegistry,
       );
     });
 

--- a/test/integration/service/cooperative/DeferredClaimer.spec.ts
+++ b/test/integration/service/cooperative/DeferredClaimer.spec.ts
@@ -48,8 +48,10 @@ import CommitmentRepository from '../../../../lib/db/repositories/CommitmentRepo
 import PairRepository from '../../../../lib/db/repositories/PairRepository';
 import SwapRepository from '../../../../lib/db/repositories/SwapRepository';
 import TransactionLabelRepository from '../../../../lib/db/repositories/TransactionLabelRepository';
+import { Signer } from '../../../../lib/proto/boltzrpc';
 import type RateProvider from '../../../../lib/rates/RateProvider';
 import Errors from '../../../../lib/service/Errors';
+import SignerControlRegistry from '../../../../lib/service/SignerControlRegistry';
 import DeferredClaimer from '../../../../lib/service/cooperative/DeferredClaimer';
 import AmountTrigger from '../../../../lib/service/cooperative/triggers/AmountTrigger';
 import Sidecar from '../../../../lib/sidecar/Sidecar';
@@ -111,6 +113,7 @@ describe('DeferredClaimer', () => {
   const walletManager = {
     wallets: new Map<string, Wallet>([['BTC', btcWallet]]),
   } as WalletManager;
+  const signerControlRegistry = SignerControlRegistry.getInstance();
 
   const claimer = new DeferredClaimer(
     Logger.disabledLogger,
@@ -134,6 +137,7 @@ describe('DeferredClaimer', () => {
       batchClaimInterval: '*/15 * * * *',
       cltvDelta: 20,
     },
+    signerControlRegistry,
   );
 
   const createClaimableOutput = async (timeoutBlockHeight?: number) => {
@@ -646,6 +650,10 @@ describe('DeferredClaimer', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    signerControlRegistry.reset();
+    await signerControlRegistry.enableSigners([
+      Signer.SIGNER_DEFERRED_CLAIM_COOPERATIVE,
+    ]);
     claimer['swapsToClaim'].get('BTC')?.clear();
     claimer['chainSwapsToClaim'].get('BTC')?.clear();
     claimer['swapsToClaim'].get('ARK')?.clear();
@@ -1448,6 +1456,25 @@ describe('DeferredClaimer', () => {
   });
 
   describe('getCooperativeDetails', () => {
+    test('should throw when deferred cooperative claims are disabled', async () => {
+      await signerControlRegistry.disableSigners([
+        Signer.SIGNER_DEFERRED_CLAIM_COOPERATIVE,
+      ]);
+
+      await expect(
+        claimer.getCooperativeDetails({
+          id: 'disabled',
+          pair: 'BTC/BTC',
+          type: SwapType.Submarine,
+          orderSide: OrderSide.BUY,
+        } as any),
+      ).rejects.toEqual(
+        Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_CLAIM(
+          'cooperative signatures are disabled',
+        ),
+      );
+    });
+
     test.each`
       name           | type
       ${'Submarine'} | ${SwapType.Submarine}

--- a/test/integration/service/cooperative/DeferredClaimer.spec.ts
+++ b/test/integration/service/cooperative/DeferredClaimer.spec.ts
@@ -137,7 +137,6 @@ describe('DeferredClaimer', () => {
       batchClaimInterval: '*/15 * * * *',
       cltvDelta: 20,
     },
-    signerControlRegistry,
   );
 
   const createClaimableOutput = async (timeoutBlockHeight?: number) => {
@@ -650,10 +649,8 @@ describe('DeferredClaimer', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    signerControlRegistry.reset();
-    await signerControlRegistry.enableSigners([
-      Signer.SIGNER_DEFERRED_CLAIM_COOPERATIVE,
-    ]);
+    (signerControlRegistry as any)['disabledSigners'].clear();
+    (signerControlRegistry as any)['repository'] = undefined;
     claimer['swapsToClaim'].get('BTC')?.clear();
     claimer['chainSwapsToClaim'].get('BTC')?.clear();
     claimer['swapsToClaim'].get('ARK')?.clear();

--- a/test/integration/service/cooperative/EipSigner.spec.ts
+++ b/test/integration/service/cooperative/EipSigner.spec.ts
@@ -132,7 +132,6 @@ describe('EipSigner', () => {
         ethereumManagers: [ethereumManager],
       } as unknown as WalletManager,
       sidecar,
-      signerControlRegistry,
     );
   });
 
@@ -142,11 +141,8 @@ describe('EipSigner', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    signerControlRegistry.reset();
-    await signerControlRegistry.enableSigners([
-      Signer.SIGNER_EVM_REFUND_COOPERATIVE,
-      Signer.SIGNER_EVM_COMMITMENT_REFUND_COOPERATIVE,
-    ]);
+    (signerControlRegistry as any)['disabledSigners'].clear();
+    (signerControlRegistry as any)['repository'] = undefined;
 
     SwapRepository.getSwap = jest.fn().mockResolvedValue(null);
     SwapRepository.setRefundSignatureCreated = jest.fn();

--- a/test/integration/service/cooperative/EipSigner.spec.ts
+++ b/test/integration/service/cooperative/EipSigner.spec.ts
@@ -16,7 +16,9 @@ import ChainSwapRepository from '../../../../lib/db/repositories/ChainSwapReposi
 import CommitmentRepository from '../../../../lib/db/repositories/CommitmentRepository';
 import RefundTransactionRepository from '../../../../lib/db/repositories/RefundTransactionRepository';
 import SwapRepository from '../../../../lib/db/repositories/SwapRepository';
+import { Signer } from '../../../../lib/proto/boltzrpc';
 import Errors from '../../../../lib/service/Errors';
+import SignerControlRegistry from '../../../../lib/service/SignerControlRegistry';
 import EipSigner from '../../../../lib/service/cooperative/EipSigner';
 import { RefundRejectionReason } from '../../../../lib/service/cooperative/MusigSigner';
 import Sidecar from '../../../../lib/sidecar/Sidecar';
@@ -60,6 +62,7 @@ describe('EipSigner', () => {
   let ethereumManager: EthereumManager;
 
   let eipSigner: EipSigner;
+  let signerControlRegistry: SignerControlRegistry;
 
   beforeAll(async () => {
     await startSidecar();
@@ -106,6 +109,8 @@ describe('EipSigner', () => {
       false,
     );
 
+    signerControlRegistry = SignerControlRegistry.getInstance();
+
     eipSigner = new EipSigner(
       Logger.disabledLogger,
       new Map<string, any>([
@@ -127,6 +132,7 @@ describe('EipSigner', () => {
         ethereumManagers: [ethereumManager],
       } as unknown as WalletManager,
       sidecar,
+      signerControlRegistry,
     );
   });
 
@@ -134,8 +140,13 @@ describe('EipSigner', () => {
     await Sidecar.stop();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
+    signerControlRegistry.reset();
+    await signerControlRegistry.enableSigners([
+      Signer.SIGNER_EVM_REFUND_COOPERATIVE,
+      Signer.SIGNER_EVM_COMMITMENT_REFUND_COOPERATIVE,
+    ]);
 
     SwapRepository.getSwap = jest.fn().mockResolvedValue(null);
     SwapRepository.setRefundSignatureCreated = jest.fn();
@@ -210,6 +221,36 @@ describe('EipSigner', () => {
     });
     await expect(eipSigner.signSwapRefund('no signer')).rejects.toEqual(
       'chain currency is not EVM based',
+    );
+  });
+
+  test('should throw when EVM cooperative refunds are disabled', async () => {
+    await signerControlRegistry.disableSigners([
+      Signer.SIGNER_EVM_REFUND_COOPERATIVE,
+    ]);
+
+    await expect(eipSigner.signSwapRefund('disabled')).rejects.toEqual(
+      Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+        'cooperative signatures are disabled',
+      ),
+    );
+  });
+
+  test('should throw when EVM commitment cooperative refunds are disabled', async () => {
+    await signerControlRegistry.disableSigners([
+      Signer.SIGNER_EVM_COMMITMENT_REFUND_COOPERATIVE,
+    ]);
+
+    await expect(
+      eipSigner.signCommitmentRefund(
+        'RBTC',
+        `0x${randomBytes(32).toString('hex')}`,
+        '0x',
+      ),
+    ).rejects.toEqual(
+      Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+        'cooperative signatures are disabled',
+      ),
     );
   });
 

--- a/test/unit/grpc/GrpcService.spec.ts
+++ b/test/unit/grpc/GrpcService.spec.ts
@@ -1,3 +1,4 @@
+import { status } from '@grpc/grpc-js';
 import type { ServiceError } from '@grpc/grpc-js';
 import { randomBytes } from 'crypto';
 import Logger from '../../../lib/Logger';
@@ -36,6 +37,10 @@ const mockDeriveKeysData = {
   method: 'deriveKeys',
 };
 const mockDeriveKeys = jest.fn().mockReturnValue(mockDeriveKeysData);
+
+const mockDisableSigners = jest.fn().mockImplementation((signers) => signers);
+const mockEnableSigners = jest.fn().mockImplementation(() => []);
+const mockGetDisabledSigners = jest.fn().mockReturnValue([]);
 
 const gewAddressData = 'address';
 const mockGetAddress = jest.fn().mockResolvedValue(gewAddressData);
@@ -132,6 +137,11 @@ jest.mock('../../../lib/service/Service', () => {
           ),
           sweepSymbol: jest.fn().mockResolvedValue(['currency1', 'currency2']),
         },
+      },
+      signerControlRegistry: {
+        disableSigners: mockDisableSigners,
+        enableSigners: mockEnableSigners,
+        getDisabledSigners: mockGetDisabledSigners,
       },
       getInfo: mockGetInfo,
       getBalance: mockGetBalance,
@@ -1242,6 +1252,134 @@ describe('GrpcService', () => {
           threshold: 123,
         },
       ]);
+    });
+  });
+
+  describe('signer controls', () => {
+    test('should disable signers', async () => {
+      const signers = [boltzrpc.Signer.SIGNER_CHAIN_LOCKUP];
+      mockDisableSigners.mockResolvedValueOnce(signers);
+
+      const request = { signers };
+
+      await new Promise<void>((resolve, reject) => {
+        grpcService.disableSigners({ request } as any, (error, response) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          expect(response?.disabledSigners).toEqual(signers);
+          resolve();
+        });
+      });
+
+      expect(mockDisableSigners).toHaveBeenCalledTimes(1);
+      expect(mockDisableSigners).toHaveBeenCalledWith(signers);
+    });
+
+    test('should enable signers', async () => {
+      const toEnable = [boltzrpc.Signer.SIGNER_CHAIN_LOCKUP];
+      const disabledSigners = [boltzrpc.Signer.SIGNER_REVERSE_LOCKUP];
+      mockEnableSigners.mockResolvedValueOnce(disabledSigners);
+
+      const request = { signers: toEnable };
+
+      await new Promise<void>((resolve, reject) => {
+        grpcService.enableSigners({ request } as any, (error, response) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          expect(response?.disabledSigners).toEqual(disabledSigners);
+          resolve();
+        });
+      });
+
+      expect(mockEnableSigners).toHaveBeenCalledTimes(1);
+      expect(mockEnableSigners).toHaveBeenCalledWith(toEnable);
+    });
+
+    test('should list disabled signers', async () => {
+      const disabledSigners = [
+        boltzrpc.Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+      ];
+      mockGetDisabledSigners.mockReturnValueOnce(disabledSigners);
+
+      await new Promise<void>((resolve, reject) => {
+        grpcService.getDisabledSigners(
+          { request: {} } as any,
+          (error, response) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+
+            expect(response?.disabledSigners).toEqual(disabledSigners);
+            resolve();
+          },
+        );
+      });
+
+      expect(mockGetDisabledSigners).toHaveBeenCalledTimes(1);
+      expect(mockGetDisabledSigners).toHaveBeenCalledWith();
+    });
+
+    test('should return INVALID_ARGUMENT for invalid signer input', async () => {
+      const errorMessage = 'at least one signer must be specified';
+
+      const request = { signers: [] };
+
+      await new Promise<void>((resolve) => {
+        grpcService.disableSigners({ request } as any, (error, response) => {
+          expect(response).toEqual(null);
+          expect(error).toEqual({
+            code: status.INVALID_ARGUMENT,
+            details: errorMessage,
+            message: errorMessage,
+          });
+          resolve();
+        });
+      });
+
+      expect(mockDisableSigners).not.toHaveBeenCalled();
+    });
+
+    test('should reject unknown signer values before mutating registry', async () => {
+      const request = { signers: [123_456 as any] };
+
+      await new Promise<void>((resolve) => {
+        grpcService.disableSigners({ request } as any, (error, response) => {
+          expect(response).toEqual(null);
+          expect(error).toEqual({
+            code: status.INVALID_ARGUMENT,
+            details: 'invalid signer: 123456',
+            message: 'invalid signer: 123456',
+          });
+          resolve();
+        });
+      });
+
+      expect(mockDisableSigners).not.toHaveBeenCalled();
+    });
+
+    test('should reject unspecified signer before mutating registry', async () => {
+      const request = { signers: [boltzrpc.Signer.SIGNER_UNSPECIFIED] };
+
+      await new Promise<void>((resolve) => {
+        grpcService.disableSigners({ request } as any, (error, response) => {
+          expect(response).toEqual(null);
+          expect(error).toEqual({
+            code: status.INVALID_ARGUMENT,
+            details: 'invalid signer: 0',
+            message: 'invalid signer: 0',
+          });
+          resolve();
+        });
+      });
+
+      expect(mockDisableSigners).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/grpc/GrpcService.spec.ts
+++ b/test/unit/grpc/GrpcService.spec.ts
@@ -16,6 +16,7 @@ import TransactionLabelRepository from '../../../lib/db/repositories/Transaction
 import GrpcService from '../../../lib/grpc/GrpcService';
 import * as boltzrpc from '../../../lib/proto/boltzrpc';
 import Service from '../../../lib/service/Service';
+import SignerControlRegistry from '../../../lib/service/SignerControlRegistry';
 import type NodeSwitch from '../../../lib/swap/NodeSwitch';
 import type CreationHook from '../../../lib/swap/hooks/CreationHook';
 import type InvoiceCreationHook from '../../../lib/swap/hooks/InvoiceCreationHook';
@@ -41,6 +42,16 @@ const mockDeriveKeys = jest.fn().mockReturnValue(mockDeriveKeysData);
 const mockDisableSigners = jest.fn().mockImplementation((signers) => signers);
 const mockEnableSigners = jest.fn().mockImplementation(() => []);
 const mockGetDisabledSigners = jest.fn().mockReturnValue([]);
+const signerControlRegistry = SignerControlRegistry.getInstance();
+jest
+  .spyOn(signerControlRegistry, 'disableSigners')
+  .mockImplementation((signers) => mockDisableSigners(signers));
+jest
+  .spyOn(signerControlRegistry, 'enableSigners')
+  .mockImplementation((signers) => mockEnableSigners(signers));
+jest
+  .spyOn(signerControlRegistry, 'getDisabledSigners')
+  .mockImplementation(() => mockGetDisabledSigners());
 
 const gewAddressData = 'address';
 const mockGetAddress = jest.fn().mockResolvedValue(gewAddressData);
@@ -137,11 +148,6 @@ jest.mock('../../../lib/service/Service', () => {
           ),
           sweepSymbol: jest.fn().mockResolvedValue(['currency1', 'currency2']),
         },
-      },
-      signerControlRegistry: {
-        disableSigners: mockDisableSigners,
-        enableSigners: mockEnableSigners,
-        getDisabledSigners: mockGetDisabledSigners,
       },
       getInfo: mockGetInfo,
       getBalance: mockGetBalance,

--- a/test/unit/grpc/GrpcService.spec.ts
+++ b/test/unit/grpc/GrpcService.spec.ts
@@ -1269,7 +1269,7 @@ describe('GrpcService', () => {
             return;
           }
 
-          expect(response?.disabledSigners).toEqual(signers);
+          expect(response).toEqual({});
           resolve();
         });
       });
@@ -1280,8 +1280,7 @@ describe('GrpcService', () => {
 
     test('should enable signers', async () => {
       const toEnable = [boltzrpc.Signer.SIGNER_CHAIN_LOCKUP];
-      const disabledSigners = [boltzrpc.Signer.SIGNER_REVERSE_LOCKUP];
-      mockEnableSigners.mockResolvedValueOnce(disabledSigners);
+      mockEnableSigners.mockResolvedValueOnce([]);
 
       const request = { signers: toEnable };
 
@@ -1292,7 +1291,7 @@ describe('GrpcService', () => {
             return;
           }
 
-          expect(response?.disabledSigners).toEqual(disabledSigners);
+          expect(response).toEqual({});
           resolve();
         });
       });

--- a/test/unit/lightning/SelfPaymentClient.spec.ts
+++ b/test/unit/lightning/SelfPaymentClient.spec.ts
@@ -87,6 +87,7 @@ describe('SelfPaymentClient', () => {
           mockDecoded as any,
           100,
           mockPayments as any,
+          true,
         ),
       ).resolves.toEqual({
         isSelf: false,
@@ -96,9 +97,68 @@ describe('SelfPaymentClient', () => {
       expect(getReverseSwapSpy).not.toHaveBeenCalled();
     });
 
-    test.each([[null], [undefined]])(
-      'should return isSelf: false when reverse swap is %s',
-      async (reverseSwapValue) => {
+    test('should block synthetic self lockup when signer is disabled', async () => {
+      const mockReverseSwap = {
+        id: 'rev',
+        preimageHash,
+        invoice: mockSwap.invoice,
+        status: SwapUpdateEvent.SwapCreated,
+      };
+
+      client['getReverseSwap'] = jest.fn().mockResolvedValue(mockReverseSwap);
+      const emitSpy = jest.spyOn(client, 'emit');
+
+      await expect(
+        client.handleSelfPayment(
+          mockSwap as any,
+          mockDecoded as any,
+          100,
+          [],
+          true,
+        ),
+      ).rejects.toThrow('signer SIGNER_SUBMARINE_INVOICE_PAYMENT is disabled');
+
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(LightningNursery.cancelReverseInvoices).not.toHaveBeenCalled();
+    });
+
+    test('should allow in-progress self payment when signer is disabled', async () => {
+      const mockReverseSwap = {
+        id: 'rev',
+        preimageHash,
+        invoice: mockSwap.invoice,
+        status: SwapUpdateEvent.InvoiceSettled,
+      };
+
+      client['getReverseSwap'] = jest.fn().mockResolvedValue(mockReverseSwap);
+      const emitSpy = jest.spyOn(client, 'emit');
+
+      await expect(
+        client.handleSelfPayment(
+          mockSwap as any,
+          mockDecoded as any,
+          100,
+          [],
+          true,
+        ),
+      ).resolves.toEqual({
+        isSelf: true,
+        result: undefined,
+      });
+
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(LightningNursery.cancelReverseInvoices).not.toHaveBeenCalled();
+    });
+
+    test.each`
+      reverseSwapValue | signerDisabled
+      ${null}          | ${false}
+      ${undefined}     | ${false}
+      ${null}          | ${true}
+      ${undefined}     | ${true}
+    `(
+      'should return isSelf: false when reverse swap is $reverseSwapValue (signer disabled: $signerDisabled)',
+      async ({ reverseSwapValue, signerDisabled }) => {
         client['getReverseSwap'] = jest
           .fn()
           .mockResolvedValue(reverseSwapValue);
@@ -108,6 +168,7 @@ describe('SelfPaymentClient', () => {
           mockDecoded as any,
           100,
           [],
+          signerDisabled,
         );
 
         expect(result).toEqual({

--- a/test/unit/lightning/SelfPaymentClient.spec.ts
+++ b/test/unit/lightning/SelfPaymentClient.spec.ts
@@ -19,6 +19,8 @@ import {
 } from '../../../lib/lightning/LightningClient';
 import PendingPaymentTracker from '../../../lib/lightning/PendingPaymentTracker';
 import SelfPaymentClient from '../../../lib/lightning/SelfPaymentClient';
+import { Signer } from '../../../lib/proto/boltzrpc';
+import SignerControlRegistry from '../../../lib/service/SignerControlRegistry';
 import LightningNursery from '../../../lib/swap/LightningNursery';
 import type SwapNursery from '../../../lib/swap/SwapNursery';
 
@@ -34,9 +36,12 @@ describe('SelfPaymentClient', () => {
 
   let nursery: SwapNursery;
   let client: SelfPaymentClient;
+  const signerControlRegistry = SignerControlRegistry.getInstance();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (signerControlRegistry as any)['disabledSigners'].clear();
+    (signerControlRegistry as any)['repository'] = undefined;
     nursery = {
       on: jest.fn(),
       removeListener: jest.fn(),
@@ -87,7 +92,6 @@ describe('SelfPaymentClient', () => {
           mockDecoded as any,
           100,
           mockPayments as any,
-          true,
         ),
       ).resolves.toEqual({
         isSelf: false,
@@ -107,15 +111,12 @@ describe('SelfPaymentClient', () => {
 
       client['getReverseSwap'] = jest.fn().mockResolvedValue(mockReverseSwap);
       const emitSpy = jest.spyOn(client, 'emit');
+      await signerControlRegistry.disableSigners([
+        Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+      ]);
 
       await expect(
-        client.handleSelfPayment(
-          mockSwap as any,
-          mockDecoded as any,
-          100,
-          [],
-          true,
-        ),
+        client.handleSelfPayment(mockSwap as any, mockDecoded as any, 100, []),
       ).rejects.toThrow('signer SIGNER_SUBMARINE_INVOICE_PAYMENT is disabled');
 
       expect(emitSpy).not.toHaveBeenCalled();
@@ -132,15 +133,12 @@ describe('SelfPaymentClient', () => {
 
       client['getReverseSwap'] = jest.fn().mockResolvedValue(mockReverseSwap);
       const emitSpy = jest.spyOn(client, 'emit');
+      await signerControlRegistry.disableSigners([
+        Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+      ]);
 
       await expect(
-        client.handleSelfPayment(
-          mockSwap as any,
-          mockDecoded as any,
-          100,
-          [],
-          true,
-        ),
+        client.handleSelfPayment(mockSwap as any, mockDecoded as any, 100, []),
       ).resolves.toEqual({
         isSelf: true,
         result: undefined,
@@ -159,6 +157,11 @@ describe('SelfPaymentClient', () => {
     `(
       'should return isSelf: false when reverse swap is $reverseSwapValue (signer disabled: $signerDisabled)',
       async ({ reverseSwapValue, signerDisabled }) => {
+        if (signerDisabled) {
+          await signerControlRegistry.disableSigners([
+            Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+          ]);
+        }
         client['getReverseSwap'] = jest
           .fn()
           .mockResolvedValue(reverseSwapValue);
@@ -168,7 +171,6 @@ describe('SelfPaymentClient', () => {
           mockDecoded as any,
           100,
           [],
-          signerDisabled,
         );
 
         expect(result).toEqual({
@@ -202,7 +204,6 @@ describe('SelfPaymentClient', () => {
           mockDecoded as any,
           100,
           [],
-          false,
         ),
       ).rejects.toThrow('invoice mismatch');
 
@@ -238,7 +239,6 @@ describe('SelfPaymentClient', () => {
             mockDecodedWithCltv as any,
             cltvLimit,
             [],
-            false,
           ),
         ).rejects.toThrow('CLTV limit too small');
 
@@ -265,7 +265,6 @@ describe('SelfPaymentClient', () => {
           } as any,
           100,
           [],
-          false,
         ),
       ).rejects.toThrow('invoice expired');
 
@@ -287,13 +286,7 @@ describe('SelfPaymentClient', () => {
       const emitSpy = jest.spyOn(client, 'emit');
 
       await expect(
-        client.handleSelfPayment(
-          mockSwap as any,
-          mockDecoded as any,
-          100,
-          [],
-          false,
-        ),
+        client.handleSelfPayment(mockSwap as any, mockDecoded as any, 100, []),
       ).resolves.toEqual({
         isSelf: true,
         result: undefined,
@@ -334,13 +327,7 @@ describe('SelfPaymentClient', () => {
       const warnSpy = jest.spyOn(Logger.disabledLogger, 'warn');
 
       await expect(
-        client.handleSelfPayment(
-          mockSwap as any,
-          mockDecoded as any,
-          100,
-          [],
-          false,
-        ),
+        client.handleSelfPayment(mockSwap as any, mockDecoded as any, 100, []),
       ).resolves.toEqual({
         isSelf: true,
         result: undefined,
@@ -381,13 +368,7 @@ describe('SelfPaymentClient', () => {
       const emitSpy = jest.spyOn(client, 'emit');
 
       await expect(
-        client.handleSelfPayment(
-          mockSwap as any,
-          mockDecoded as any,
-          100,
-          [],
-          false,
-        ),
+        client.handleSelfPayment(mockSwap as any, mockDecoded as any, 100, []),
       ).resolves.toEqual({
         isSelf: true,
         result: undefined,
@@ -411,7 +392,6 @@ describe('SelfPaymentClient', () => {
         mockDecoded as any,
         100,
         [],
-        false,
       );
 
       expect(result).toEqual({
@@ -443,7 +423,6 @@ describe('SelfPaymentClient', () => {
           mockDecoded as any,
           100,
           [],
-          false,
         );
 
         expect(result).toEqual({
@@ -490,14 +469,12 @@ describe('SelfPaymentClient', () => {
         mockDecoded as any,
         100,
         [],
-        false,
       );
       const promise2 = client.handleSelfPayment(
         mockSwap as any,
         mockDecoded as any,
         100,
         [],
-        false,
       );
 
       // Verify only first call started

--- a/test/unit/lightning/SelfPaymentClient.spec.ts
+++ b/test/unit/lightning/SelfPaymentClient.spec.ts
@@ -202,6 +202,7 @@ describe('SelfPaymentClient', () => {
           mockDecoded as any,
           100,
           [],
+          false,
         ),
       ).rejects.toThrow('invoice mismatch');
 
@@ -237,6 +238,7 @@ describe('SelfPaymentClient', () => {
             mockDecodedWithCltv as any,
             cltvLimit,
             [],
+            false,
           ),
         ).rejects.toThrow('CLTV limit too small');
 
@@ -263,6 +265,7 @@ describe('SelfPaymentClient', () => {
           } as any,
           100,
           [],
+          false,
         ),
       ).rejects.toThrow('invoice expired');
 
@@ -284,7 +287,13 @@ describe('SelfPaymentClient', () => {
       const emitSpy = jest.spyOn(client, 'emit');
 
       await expect(
-        client.handleSelfPayment(mockSwap as any, mockDecoded as any, 100, []),
+        client.handleSelfPayment(
+          mockSwap as any,
+          mockDecoded as any,
+          100,
+          [],
+          false,
+        ),
       ).resolves.toEqual({
         isSelf: true,
         result: undefined,
@@ -325,7 +334,13 @@ describe('SelfPaymentClient', () => {
       const warnSpy = jest.spyOn(Logger.disabledLogger, 'warn');
 
       await expect(
-        client.handleSelfPayment(mockSwap as any, mockDecoded as any, 100, []),
+        client.handleSelfPayment(
+          mockSwap as any,
+          mockDecoded as any,
+          100,
+          [],
+          false,
+        ),
       ).resolves.toEqual({
         isSelf: true,
         result: undefined,
@@ -366,7 +381,13 @@ describe('SelfPaymentClient', () => {
       const emitSpy = jest.spyOn(client, 'emit');
 
       await expect(
-        client.handleSelfPayment(mockSwap as any, mockDecoded as any, 100, []),
+        client.handleSelfPayment(
+          mockSwap as any,
+          mockDecoded as any,
+          100,
+          [],
+          false,
+        ),
       ).resolves.toEqual({
         isSelf: true,
         result: undefined,
@@ -390,6 +411,7 @@ describe('SelfPaymentClient', () => {
         mockDecoded as any,
         100,
         [],
+        false,
       );
 
       expect(result).toEqual({
@@ -421,6 +443,7 @@ describe('SelfPaymentClient', () => {
           mockDecoded as any,
           100,
           [],
+          false,
         );
 
         expect(result).toEqual({
@@ -467,12 +490,14 @@ describe('SelfPaymentClient', () => {
         mockDecoded as any,
         100,
         [],
+        false,
       );
       const promise2 = client.handleSelfPayment(
         mockSwap as any,
         mockDecoded as any,
         100,
         [],
+        false,
       );
 
       // Verify only first call started

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -72,6 +72,11 @@ const mockGetPairs = jest.fn().mockResolvedValue([]);
 const mockAddPair = jest.fn().mockReturnValue(Promise.resolve());
 
 jest.mock('../../../lib/db/repositories/PairRepository');
+jest.mock('../../../lib/db/repositories/DisabledSignerRepository', () => ({
+  getDisabledSigners: jest.fn().mockResolvedValue([]),
+  addSigners: jest.fn().mockResolvedValue(undefined),
+  removeSigners: jest.fn().mockResolvedValue(undefined),
+}));
 
 let mockGetSwapResult: any = undefined;
 const mockGetSwap = jest.fn().mockImplementation(async () => {

--- a/test/unit/service/SignerControlRegistry.spec.ts
+++ b/test/unit/service/SignerControlRegistry.spec.ts
@@ -1,0 +1,118 @@
+import Logger from '../../../lib/Logger';
+import { Signer } from '../../../lib/proto/boltzrpc';
+import SignerControlRegistry from '../../../lib/service/SignerControlRegistry';
+
+const mockRepository = {
+  getDisabledSigners: jest.fn(),
+  addSigners: jest.fn(),
+  removeSigners: jest.fn(),
+};
+
+describe('SignerControlRegistry', () => {
+  let registry: SignerControlRegistry;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRepository.getDisabledSigners.mockResolvedValue([]);
+    mockRepository.addSigners.mockResolvedValue(undefined);
+    mockRepository.removeSigners.mockResolvedValue(undefined);
+
+    registry = SignerControlRegistry.getInstance();
+    registry.init(Logger.disabledLogger, mockRepository as any);
+    registry.reset();
+  });
+
+  test('should disable signers with set semantics', async () => {
+    const disabled = await registry.disableSigners([
+      Signer.SIGNER_CHAIN_LOCKUP,
+      Signer.SIGNER_CHAIN_LOCKUP,
+      Signer.SIGNER_REVERSE_LOCKUP,
+    ]);
+
+    expect(disabled).toEqual([
+      Signer.SIGNER_REVERSE_LOCKUP,
+      Signer.SIGNER_CHAIN_LOCKUP,
+    ]);
+    expect(registry.getDisabledSigners()).toEqual([
+      Signer.SIGNER_REVERSE_LOCKUP,
+      Signer.SIGNER_CHAIN_LOCKUP,
+    ]);
+  });
+
+  test('should enable signers idempotently', async () => {
+    await registry.disableSigners([
+      Signer.SIGNER_REVERSE_LOCKUP,
+      Signer.SIGNER_CHAIN_LOCKUP,
+    ]);
+
+    await expect(
+      registry.enableSigners([Signer.SIGNER_REVERSE_LOCKUP]),
+    ).resolves.toEqual([Signer.SIGNER_CHAIN_LOCKUP]);
+    await expect(
+      registry.enableSigners([Signer.SIGNER_REVERSE_LOCKUP]),
+    ).resolves.toEqual([Signer.SIGNER_CHAIN_LOCKUP]);
+  });
+
+  test('should log disable and enable operations', async () => {
+    const infoSpy = jest.spyOn(Logger.disabledLogger, 'info');
+
+    await registry.disableSigners([Signer.SIGNER_CHAIN_LOCKUP]);
+    await registry.enableSigners([Signer.SIGNER_CHAIN_LOCKUP]);
+
+    expect(infoSpy).toHaveBeenCalledTimes(2);
+    expect(infoSpy).toHaveBeenNthCalledWith(
+      1,
+      'Disabled signers: SIGNER_CHAIN_LOCKUP. Disabled signer set: SIGNER_CHAIN_LOCKUP',
+    );
+    expect(infoSpy).toHaveBeenNthCalledWith(
+      2,
+      'Enabled signers: SIGNER_CHAIN_LOCKUP. No signers are disabled',
+    );
+  });
+
+  test('should return the same singleton instance', async () => {
+    await registry.disableSigners([Signer.SIGNER_CHAIN_LOCKUP]);
+
+    expect(SignerControlRegistry.getInstance()).toBe(registry);
+  });
+
+  test('should reset state explicitly', async () => {
+    await registry.disableSigners([Signer.SIGNER_CHAIN_LOCKUP]);
+
+    registry.reset();
+    expect(registry.getDisabledSigners()).toEqual([]);
+  });
+
+  test('should load persisted disabled signers', async () => {
+    registry.init(Logger.disabledLogger, mockRepository as any);
+    mockRepository.getDisabledSigners.mockResolvedValueOnce([
+      'SIGNER_CHAIN_LOCKUP',
+      'SIGNER_REVERSE_LOCKUP',
+    ]);
+
+    await registry.load();
+
+    expect(registry.getDisabledSigners()).toEqual([
+      Signer.SIGNER_REVERSE_LOCKUP,
+      Signer.SIGNER_CHAIN_LOCKUP,
+    ]);
+  });
+
+  test('should persist mutations before changing memory', async () => {
+    registry.init(Logger.disabledLogger, mockRepository as any);
+
+    await expect(
+      registry.disableSigners([Signer.SIGNER_CHAIN_LOCKUP]),
+    ).resolves.toEqual([Signer.SIGNER_CHAIN_LOCKUP]);
+    expect(mockRepository.addSigners).toHaveBeenCalledWith([
+      'SIGNER_CHAIN_LOCKUP',
+    ]);
+
+    await expect(
+      registry.enableSigners([Signer.SIGNER_CHAIN_LOCKUP]),
+    ).resolves.toEqual([]);
+    expect(mockRepository.removeSigners).toHaveBeenCalledWith([
+      'SIGNER_CHAIN_LOCKUP',
+    ]);
+  });
+});

--- a/test/unit/service/SignerControlRegistry.spec.ts
+++ b/test/unit/service/SignerControlRegistry.spec.ts
@@ -19,7 +19,7 @@ describe('SignerControlRegistry', () => {
 
     registry = SignerControlRegistry.getInstance();
     registry.init(Logger.disabledLogger, mockRepository as any);
-    registry.reset();
+    (registry as any)['disabledSigners'].clear();
   });
 
   test('should disable signers with set semantics', async () => {
@@ -76,10 +76,10 @@ describe('SignerControlRegistry', () => {
     expect(SignerControlRegistry.getInstance()).toBe(registry);
   });
 
-  test('should reset state explicitly', async () => {
+  test('should allow tests to clear singleton state explicitly', async () => {
     await registry.disableSigners([Signer.SIGNER_CHAIN_LOCKUP]);
 
-    registry.reset();
+    (registry as any)['disabledSigners'].clear();
     expect(registry.getDisabledSigners()).toEqual([]);
   });
 
@@ -96,6 +96,23 @@ describe('SignerControlRegistry', () => {
       Signer.SIGNER_REVERSE_LOCKUP,
       Signer.SIGNER_CHAIN_LOCKUP,
     ]);
+  });
+
+  test('should skip unknown persisted disabled signers', async () => {
+    const warnSpy = jest.spyOn(Logger.disabledLogger, 'warn');
+
+    registry.init(Logger.disabledLogger, mockRepository as any);
+    mockRepository.getDisabledSigners.mockResolvedValueOnce([
+      'SIGNER_CHAIN_LOCKUP',
+      'SIGNER_UNKNOWN_TO_THIS_VERSION',
+    ]);
+
+    await registry.load();
+
+    expect(registry.getDisabledSigners()).toEqual([Signer.SIGNER_CHAIN_LOCKUP]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Ignoring unknown disabled signer: SIGNER_UNKNOWN_TO_THIS_VERSION',
+    );
   });
 
   test('should persist mutations before changing memory', async () => {

--- a/test/unit/service/cooperative/MusigSigner.spec.ts
+++ b/test/unit/service/cooperative/MusigSigner.spec.ts
@@ -1,4 +1,5 @@
 import { Transaction as ScureTransaction } from '@scure/btc-signer';
+import { crypto } from 'bitcoinjs-lib';
 import { randomBytes } from 'crypto';
 import Logger from '../../../../lib/Logger';
 import { getHexString } from '../../../../lib/Utils';
@@ -9,10 +10,14 @@ import {
   SwapUpdateEvent,
   SwapVersion,
 } from '../../../../lib/consts/Enums';
+import ReverseSwapRepository from '../../../../lib/db/repositories/ReverseSwapRepository';
 import SwapRepository from '../../../../lib/db/repositories/SwapRepository';
+import WrappedSwapRepository from '../../../../lib/db/repositories/WrappedSwapRepository';
 import type LndClient from '../../../../lib/lightning/LndClient';
 import type ClnClient from '../../../../lib/lightning/cln/ClnClient';
+import { Signer } from '../../../../lib/proto/boltzrpc';
 import Errors from '../../../../lib/service/Errors';
+import SignerControlRegistry from '../../../../lib/service/SignerControlRegistry';
 import MusigSigner, {
   RefundRejectionReason,
 } from '../../../../lib/service/cooperative/MusigSigner';
@@ -41,13 +46,103 @@ describe('MusigSigner', () => {
     ['BTC', btcCurrency as Currency],
     [ArkClient.symbol, arkCurrency as unknown as Currency],
   ]);
+  const signerControlRegistry = SignerControlRegistry.getInstance();
 
   const signer = new MusigSigner(
     Logger.disabledLogger,
     currencies,
     {} as unknown as WalletManager,
     {} as unknown as SwapNursery,
+    signerControlRegistry,
   );
+
+  beforeEach(() => {
+    signerControlRegistry.reset();
+  });
+
+  describe('signReverseSwapClaim', () => {
+    const preimage = Buffer.alloc(32, 1);
+    const reverseSwap = {
+      id: 'reverse-swap-id',
+      pair: 'BTC/BTC',
+      orderSide: OrderSide.BUY,
+      version: SwapVersion.Taproot,
+      status: SwapUpdateEvent.TransactionMempool,
+      preimageHash: getHexString(crypto.sha256(preimage)),
+    };
+
+    const createSigner = () => {
+      const nursery = {
+        lock: {
+          acquire: jest.fn(async (_lock, callback) => callback()),
+        },
+        settleReverseSwapInvoice: jest.fn().mockResolvedValue(undefined),
+      } as any as SwapNursery;
+
+      return {
+        nursery,
+        signer: new MusigSigner(
+          Logger.disabledLogger,
+          currencies,
+          {} as unknown as WalletManager,
+          nursery,
+          signerControlRegistry,
+        ),
+      };
+    };
+
+    beforeEach(() => {
+      ReverseSwapRepository.getReverseSwap = jest
+        .fn()
+        .mockResolvedValue(reverseSwap);
+      WrappedSwapRepository.setPreimage = jest
+        .fn()
+        .mockResolvedValue(reverseSwap);
+    });
+
+    test('should allow preimage-only settlement when cooperative claims are disabled', async () => {
+      const { nursery, signer } = createSigner();
+
+      await signerControlRegistry.disableSigners([
+        Signer.SIGNER_REVERSE_CLAIM_COOPERATIVE,
+      ]);
+
+      await expect(
+        signer.signReverseSwapClaim(reverseSwap.id, preimage),
+      ).resolves.toEqual(undefined);
+
+      expect(WrappedSwapRepository.setPreimage).toHaveBeenCalledWith(
+        reverseSwap,
+        preimage,
+      );
+      expect(nursery.settleReverseSwapInvoice).toHaveBeenCalledWith(
+        reverseSwap,
+        preimage,
+      );
+    });
+
+    test('should reject partial signatures when cooperative claims are disabled', async () => {
+      const { signer } = createSigner();
+
+      await signerControlRegistry.disableSigners([
+        Signer.SIGNER_REVERSE_CLAIM_COOPERATIVE,
+      ]);
+
+      await expect(
+        signer.signReverseSwapClaim(reverseSwap.id, preimage, {
+          theirNonce: Buffer.alloc(66),
+          rawTransaction: Buffer.alloc(0),
+          index: 0,
+        }),
+      ).rejects.toEqual(
+        Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_CLAIM(
+          'cooperative signatures are disabled',
+        ),
+      );
+
+      expect(WrappedSwapRepository.setPreimage).not.toHaveBeenCalled();
+    });
+  });
 
   describe('signRefundArk', () => {
     test.each([[null], [undefined]])(
@@ -86,7 +181,9 @@ describe('MusigSigner', () => {
         version: SwapVersion.Taproot,
       });
 
-      signer.setDisableCooperative(true);
+      await signerControlRegistry.disableSigners([
+        Signer.SIGNER_SUBMARINE_REFUND_COOPERATIVE,
+      ]);
 
       await expect(
         signer.signRefundArk('asdf', 'transaction', 'checkpoint'),
@@ -95,8 +192,6 @@ describe('MusigSigner', () => {
           'cooperative signatures are disabled',
         ),
       );
-
-      signer.setDisableCooperative(false);
     });
 
     test('should validate eligibility', async () => {

--- a/test/unit/service/cooperative/MusigSigner.spec.ts
+++ b/test/unit/service/cooperative/MusigSigner.spec.ts
@@ -53,11 +53,11 @@ describe('MusigSigner', () => {
     currencies,
     {} as unknown as WalletManager,
     {} as unknown as SwapNursery,
-    signerControlRegistry,
   );
 
   beforeEach(() => {
-    signerControlRegistry.reset();
+    (signerControlRegistry as any)['disabledSigners'].clear();
+    (signerControlRegistry as any)['repository'] = undefined;
   });
 
   describe('signReverseSwapClaim', () => {
@@ -86,7 +86,6 @@ describe('MusigSigner', () => {
           currencies,
           {} as unknown as WalletManager,
           nursery,
-          signerControlRegistry,
         ),
       };
     };

--- a/test/unit/swap/PaymentHandler.spec.ts
+++ b/test/unit/swap/PaymentHandler.spec.ts
@@ -5,7 +5,9 @@ import type Swap from '../../../lib/db/models/Swap';
 import LightningErrors from '../../../lib/lightning/Errors';
 import type { LightningClient } from '../../../lib/lightning/LightningClient';
 import LndClient from '../../../lib/lightning/LndClient';
+import { Signer } from '../../../lib/proto/boltzrpc';
 import { Payment_PaymentStatus } from '../../../lib/proto/lnd/rpc';
+import SignerControlRegistry from '../../../lib/service/SignerControlRegistry';
 import TimeoutDeltaProvider from '../../../lib/service/TimeoutDeltaProvider';
 import type DecodedInvoiceSidecar from '../../../lib/sidecar/DecodedInvoice';
 import { InvoiceType } from '../../../lib/sidecar/DecodedInvoice';
@@ -74,6 +76,8 @@ const sidecar = {
 
 describe('PaymentHandler', () => {
   const nodeSwitch = MockedNodeSwitch();
+  const signerControlRegistry = SignerControlRegistry.getInstance();
+  let relevantPayments: any[] = [];
 
   const mockedEmit = jest.fn();
 
@@ -86,6 +90,7 @@ describe('PaymentHandler', () => {
 
   const swap = {
     id: 'test',
+    invoice: 'lnbcrt1testinvoice',
     pair: 'BTC/BTC',
     preimageHash:
       '8bc944ac6563a0dc50c2666ffc1f6cc6295d5f093859f869c8d065fcb965443a',
@@ -119,10 +124,15 @@ describe('PaymentHandler', () => {
       getRelevantNode: jest
         .fn()
         .mockImplementation(async (_currency, _swap, node) => {
-          return { node };
+          return {
+            node,
+            paymentHash: swap.preimageHash,
+            payments: relevantPayments,
+          };
         }),
     } as any,
     { emit: mockedEmit } as any,
+    signerControlRegistry,
   );
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
@@ -133,8 +143,22 @@ describe('PaymentHandler', () => {
     }),
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
+    cltvLimit = 100;
+    sendPaymentError = undefined;
+    trackPaymentResponse = undefined;
+    signerControlRegistry.reset();
+    await signerControlRegistry.enableSigners([
+      Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+    ]);
+    relevantPayments = [];
+    (
+      handler['selfPaymentClient'].handleSelfPayment as jest.Mock
+    ).mockResolvedValue({
+      isSelf: false,
+      result: undefined,
+    });
   });
 
   test('should check payment for CLTV limits that are too small', async () => {
@@ -153,6 +177,57 @@ describe('PaymentHandler', () => {
     expect(btcLndClient.trackPayment).toHaveBeenCalledWith(
       getHexBuffer(swap.preimageHash),
     );
+  });
+
+  test('should fail fast for new payments when invoice signer is disabled', async () => {
+    await signerControlRegistry.disableSigners([
+      Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+    ]);
+
+    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
+      undefined,
+    );
+
+    expect(
+      handler['selfPaymentClient'].handleSelfPayment,
+    ).toHaveBeenCalledTimes(1);
+    expect(handler['selfPaymentClient'].handleSelfPayment).toHaveBeenCalledWith(
+      swap,
+      0,
+      cltvLimit,
+      [],
+      true,
+    );
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+    expect(swap.update).toHaveBeenCalledTimes(1);
+    expect(swap.update).toHaveBeenCalledWith({
+      failureReason: 'invoice could not be paid',
+      status: SwapUpdateEvent.InvoiceFailedToPay,
+    });
+  });
+
+  test('should allow payment retries with history when signer is disabled', async () => {
+    await signerControlRegistry.disableSigners([
+      Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+    ]);
+    relevantPayments = [{} as any];
+
+    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
+      undefined,
+    );
+
+    expect(
+      handler['selfPaymentClient'].handleSelfPayment,
+    ).toHaveBeenCalledTimes(1);
+    expect(handler['selfPaymentClient'].handleSelfPayment).toHaveBeenCalledWith(
+      swap,
+      0,
+      cltvLimit,
+      relevantPayments,
+      true,
+    );
+    expect(btcLndClient.sendPayment).toHaveBeenCalledTimes(1);
+    expect(swap.update).not.toHaveBeenCalled();
   });
 
   test.each`
@@ -341,7 +416,7 @@ describe('PaymentHandler', () => {
       ).toHaveBeenCalledTimes(1);
       expect(
         handler['selfPaymentClient'].handleSelfPayment,
-      ).toHaveBeenCalledWith(swap, 0, cltvLimit, undefined);
+      ).toHaveBeenCalledWith(swap, 0, cltvLimit, [], false);
       expect(settleInvoiceSpy).toHaveBeenCalledTimes(1);
       expect(settleInvoiceSpy).toHaveBeenCalledWith(swap, mockPaymentResponse);
       expect(btcLndClient.sendPayment).not.toHaveBeenCalled();

--- a/test/unit/swap/PaymentHandler.spec.ts
+++ b/test/unit/swap/PaymentHandler.spec.ts
@@ -132,7 +132,6 @@ describe('PaymentHandler', () => {
         }),
     } as any,
     { emit: mockedEmit } as any,
-    signerControlRegistry,
   );
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
@@ -148,10 +147,8 @@ describe('PaymentHandler', () => {
     cltvLimit = 100;
     sendPaymentError = undefined;
     trackPaymentResponse = undefined;
-    signerControlRegistry.reset();
-    await signerControlRegistry.enableSigners([
-      Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
-    ]);
+    (signerControlRegistry as any)['disabledSigners'].clear();
+    (signerControlRegistry as any)['repository'] = undefined;
     relevantPayments = [];
     (
       handler['selfPaymentClient'].handleSelfPayment as jest.Mock
@@ -196,7 +193,6 @@ describe('PaymentHandler', () => {
       0,
       cltvLimit,
       [],
-      true,
     );
     expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
     expect(swap.update).toHaveBeenCalledTimes(1);
@@ -224,7 +220,6 @@ describe('PaymentHandler', () => {
       0,
       cltvLimit,
       relevantPayments,
-      true,
     );
     expect(btcLndClient.sendPayment).toHaveBeenCalledTimes(1);
     expect(swap.update).not.toHaveBeenCalled();
@@ -416,7 +411,7 @@ describe('PaymentHandler', () => {
       ).toHaveBeenCalledTimes(1);
       expect(
         handler['selfPaymentClient'].handleSelfPayment,
-      ).toHaveBeenCalledWith(swap, 0, cltvLimit, [], false);
+      ).toHaveBeenCalledWith(swap, 0, cltvLimit, []);
       expect(settleInvoiceSpy).toHaveBeenCalledTimes(1);
       expect(settleInvoiceSpy).toHaveBeenCalledWith(swap, mockPaymentResponse);
       expect(btcLndClient.sendPayment).not.toHaveBeenCalled();

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -151,6 +151,7 @@ describe('SwapNursery', () => {
   const mockChainSwapSigner = {
     setAttemptSettle: jest.fn(),
     on: jest.fn(),
+    registerForClaim: jest.fn(),
   } as any;
 
   let swapNursery: SwapNursery;
@@ -307,11 +308,12 @@ describe('SwapNursery', () => {
         };
 
         if (method === 'lockupUtxo') {
-          await (guardedNursery as any)[method](
+          const result = await (guardedNursery as any)[method](
             chainSwap,
             mockChainClient,
             wallet,
           );
+          expect(result).toEqual(false);
         } else {
           await (guardedNursery as any)[method](chainSwap, wallet);
         }
@@ -323,6 +325,28 @@ describe('SwapNursery', () => {
         );
       },
     );
+
+    test('should not register chain swaps for claim when UTXO lockup signer is disabled', async () => {
+      const guardedNursery = await createGuardedNursery(
+        Signer.SIGNER_CHAIN_LOCKUP,
+      );
+      guardedNursery.currencies = new Map([['BTC', mockCurrency]]);
+
+      await (guardedNursery as any).handleChainSwapLockup({
+        id: 'chain-swap-id',
+        type: SwapType.Chain,
+        sendingData: {
+          expectedAmount: 100_000,
+          lockupAddress: 'bcrt1lockup',
+          symbol: 'BTC',
+        },
+      });
+
+      expect(mockChainSwapSigner.registerForClaim).not.toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'signer SIGNER_CHAIN_LOCKUP is disabled',
+      );
+    });
   });
 
   describe('settleReverseSwapInvoice', () => {

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -225,8 +225,8 @@ describe('SwapNursery', () => {
   describe('signer lockup guards', () => {
     const createGuardedNursery = async (signer: Signer) => {
       const signerControlRegistry = SignerControlRegistry.getInstance();
-      signerControlRegistry.init(mockLogger);
-      signerControlRegistry.reset();
+      (signerControlRegistry as any)['disabledSigners'].clear();
+      (signerControlRegistry as any)['repository'] = undefined;
       await signerControlRegistry.disableSigners([signer]);
 
       return new SwapNursery(
@@ -243,40 +243,8 @@ describe('SwapNursery', () => {
         mockChainSwapSigner,
         {} as any,
         {} as any,
-        undefined,
-        signerControlRegistry,
       );
     };
-
-    test('should report disabled reverse lockup signers without throwing', async () => {
-      const guardedNursery = await createGuardedNursery(
-        Signer.SIGNER_REVERSE_LOCKUP,
-      );
-
-      expect(
-        (guardedNursery as any).lockupSignerEnabled({
-          type: SwapType.ReverseSubmarine,
-        }),
-      ).toEqual(false);
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'signer SIGNER_REVERSE_LOCKUP is disabled',
-      );
-    });
-
-    test('should report disabled chain lockup signers without throwing', async () => {
-      const guardedNursery = await createGuardedNursery(
-        Signer.SIGNER_CHAIN_LOCKUP,
-      );
-
-      expect(
-        (guardedNursery as any).lockupSignerEnabled({
-          type: SwapType.Chain,
-        }),
-      ).toEqual(false);
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'signer SIGNER_CHAIN_LOCKUP is disabled',
-      );
-    });
 
     test.each`
       method
@@ -285,7 +253,7 @@ describe('SwapNursery', () => {
       ${'lockupEther'}
       ${'lockupERC20'}
     `(
-      'should skip $method without failing swap when lockup signer is disabled',
+      'should fail $method when lockup signer is disabled',
       async ({ method }) => {
         const guardedNursery = await createGuardedNursery(
           Signer.SIGNER_CHAIN_LOCKUP,
@@ -308,21 +276,26 @@ describe('SwapNursery', () => {
         };
 
         if (method === 'lockupUtxo') {
-          const result = await (guardedNursery as any)[method](
+          await (guardedNursery as any)[method](
             chainSwap,
             mockChainClient,
             wallet,
           );
-          expect(result).toEqual(false);
         } else {
           await (guardedNursery as any)[method](chainSwap, wallet);
         }
 
         expect(wallet.sendToAddress).not.toHaveBeenCalled();
-        expect(handleSwapSendFailedSpy).not.toHaveBeenCalled();
-        expect(mockLogger.info).toHaveBeenCalledWith(
-          'signer SIGNER_CHAIN_LOCKUP is disabled',
+        expect(handleSwapSendFailedSpy).toHaveBeenCalledTimes(1);
+        expect(handleSwapSendFailedSpy).toHaveBeenCalledWith(
+          chainSwap,
+          wallet.symbol,
+          expect.any(Error),
+          undefined,
         );
+        expect(
+          (handleSwapSendFailedSpy.mock.calls[0][2] as Error).message,
+        ).toEqual('signer SIGNER_CHAIN_LOCKUP is disabled');
       },
     );
 
@@ -331,6 +304,9 @@ describe('SwapNursery', () => {
         Signer.SIGNER_CHAIN_LOCKUP,
       );
       guardedNursery.currencies = new Map([['BTC', mockCurrency]]);
+      const handleSwapSendFailedSpy = jest
+        .spyOn(guardedNursery as any, 'handleSwapSendFailed')
+        .mockResolvedValue(undefined);
 
       await (guardedNursery as any).handleChainSwapLockup({
         id: 'chain-swap-id',
@@ -343,9 +319,7 @@ describe('SwapNursery', () => {
       });
 
       expect(mockChainSwapSigner.registerForClaim).not.toHaveBeenCalled();
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'signer SIGNER_CHAIN_LOCKUP is disabled',
-      );
+      expect(handleSwapSendFailedSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -295,7 +295,9 @@ describe('SwapNursery', () => {
         );
         expect(
           (handleSwapSendFailedSpy.mock.calls[0][2] as Error).message,
-        ).toEqual('signer SIGNER_CHAIN_LOCKUP is disabled');
+        ).toEqual(
+          'signer SIGNER_CHAIN_LOCKUP is disabled for Chain Swap chain-swap-id',
+        );
       },
     );
 

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -18,6 +18,8 @@ import SwapRepository from '../../../lib/db/repositories/SwapRepository';
 import WrappedSwapRepository from '../../../lib/db/repositories/WrappedSwapRepository';
 import type { LightningClient } from '../../../lib/lightning/LightningClient';
 import type NotificationClient from '../../../lib/notifications/NotificationClient';
+import { Signer } from '../../../lib/proto/boltzrpc';
+import SignerControlRegistry from '../../../lib/service/SignerControlRegistry';
 import Errors from '../../../lib/swap/Errors';
 import SwapNursery from '../../../lib/swap/SwapNursery';
 import type { Currency } from '../../../lib/wallet/WalletManager';
@@ -217,6 +219,110 @@ describe('SwapNursery', () => {
 
     mockGetSwapResult = null;
     mockGetChainSwapResult = null;
+  });
+
+  describe('signer lockup guards', () => {
+    const createGuardedNursery = async (signer: Signer) => {
+      const signerControlRegistry = SignerControlRegistry.getInstance();
+      signerControlRegistry.init(mockLogger);
+      signerControlRegistry.reset();
+      await signerControlRegistry.disableSigners([signer]);
+
+      return new SwapNursery(
+        mockLogger,
+        {} as any,
+        mockNotifications,
+        {} as any,
+        {} as any,
+        {} as any,
+        mockWalletManager,
+        {} as any,
+        0,
+        mockClaimer,
+        mockChainSwapSigner,
+        {} as any,
+        {} as any,
+        undefined,
+        signerControlRegistry,
+      );
+    };
+
+    test('should report disabled reverse lockup signers without throwing', async () => {
+      const guardedNursery = await createGuardedNursery(
+        Signer.SIGNER_REVERSE_LOCKUP,
+      );
+
+      expect(
+        (guardedNursery as any).lockupSignerEnabled({
+          type: SwapType.ReverseSubmarine,
+        }),
+      ).toEqual(false);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'signer SIGNER_REVERSE_LOCKUP is disabled',
+      );
+    });
+
+    test('should report disabled chain lockup signers without throwing', async () => {
+      const guardedNursery = await createGuardedNursery(
+        Signer.SIGNER_CHAIN_LOCKUP,
+      );
+
+      expect(
+        (guardedNursery as any).lockupSignerEnabled({
+          type: SwapType.Chain,
+        }),
+      ).toEqual(false);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'signer SIGNER_CHAIN_LOCKUP is disabled',
+      );
+    });
+
+    test.each`
+      method
+      ${'lockupUtxo'}
+      ${'lockupVtxo'}
+      ${'lockupEther'}
+      ${'lockupERC20'}
+    `(
+      'should skip $method without failing swap when lockup signer is disabled',
+      async ({ method }) => {
+        const guardedNursery = await createGuardedNursery(
+          Signer.SIGNER_CHAIN_LOCKUP,
+        );
+        const wallet = {
+          symbol: 'BTC',
+          sendToAddress: jest.fn(),
+        };
+        const handleSwapSendFailedSpy = jest
+          .spyOn(guardedNursery as any, 'handleSwapSendFailed')
+          .mockResolvedValue(undefined);
+        const chainSwap = {
+          id: 'chain-swap-id',
+          type: SwapType.Chain,
+          sendingData: {
+            expectedAmount: 100_000,
+            lockupAddress: 'bcrt1lockup',
+            symbol: 'BTC',
+          },
+        };
+
+        if (method === 'lockupUtxo') {
+          await (guardedNursery as any)[method](
+            chainSwap,
+            mockChainClient,
+            wallet,
+          );
+        } else {
+          await (guardedNursery as any)[method](chainSwap, wallet);
+        }
+
+        expect(wallet.sendToAddress).not.toHaveBeenCalled();
+        expect(handleSwapSendFailedSpy).not.toHaveBeenCalled();
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          'signer SIGNER_CHAIN_LOCKUP is disabled',
+        );
+      },
+    );
   });
 
   describe('settleReverseSwapInvoice', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added signer management CLI commands: disable, enable, and list disabled signers.
* Introduced gRPC endpoints for signer control operations.
* Signers are now persistently tracked and can be disabled/enabled at runtime.
* Swap operations now respect disabled signer configurations.

## Bug Fixes
* Removed legacy development-only cooperative disable command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-backend/pull/1302)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->