### PR TITLE
fix: ignore undefined min token balance

### DIFF
--- a/lib/notifications/BalanceChecker.ts
+++ b/lib/notifications/BalanceChecker.ts
@@ -25,10 +25,6 @@ type CurrencyThresholds = {
   minRemoteBalance?: number;
 };
 
-type ConfigWithMinWalletBalance = BaseCurrencyConfig & {
-  minWalletBalance: number;
-};
-
 class BalanceChecker {
   private currencies: CurrencyThresholds[] = [];
 
@@ -37,6 +33,10 @@ class BalanceChecker {
 
   private localBalanceAlerts = new Set<string>();
   private remoteBalanceAlerts = new Set<string>();
+
+  private static isValidMinWalletBalance(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
 
   constructor(
     private logger: Logger,
@@ -47,18 +47,34 @@ class BalanceChecker {
   ) {
     currencyConfigs
       .filter((config): config is BaseCurrencyConfig => config !== undefined)
-      .filter(
-        (config): config is ConfigWithMinWalletBalance =>
-          config.minWalletBalance !== undefined &&
-          !isNaN(config.minWalletBalance),
-      )
-      .forEach((config) =>
+      .forEach((config) => {
+        if (!BalanceChecker.isValidMinWalletBalance(config.minWalletBalance)) {
+          this.logger.warn(
+            `Ignoring ${config.symbol || liquidSymbol} balance checker config because minWalletBalance is invalid`,
+          );
+          return;
+        }
+
         this.currencies.push({
           ...config,
           symbol: config.symbol || liquidSymbol,
-        }),
-      );
-    tokenConfigs.forEach((config) => this.currencies.push(config));
+          minWalletBalance: config.minWalletBalance,
+        });
+      });
+
+    tokenConfigs.forEach((config) => {
+      if (!BalanceChecker.isValidMinWalletBalance(config.minWalletBalance)) {
+        this.logger.warn(
+          `Ignoring ${config.symbol} balance checker config because minWalletBalance is invalid`,
+        );
+        return;
+      }
+
+      this.currencies.push({
+        ...config,
+        minWalletBalance: config.minWalletBalance,
+      });
+    });
   }
 
   public check = async (): Promise<void> => {

--- a/test/unit/notifications/BalanceChecker.spec.ts
+++ b/test/unit/notifications/BalanceChecker.spec.ts
@@ -115,6 +115,7 @@ describe('BalanceChecker', () => {
         {},
         { minWalletBalance: undefined } as any,
         { minWalletBalance: Number.NaN } as any,
+        { minWalletBalance: Infinity } as any,
       ],
       [],
     );
@@ -132,6 +133,24 @@ describe('BalanceChecker', () => {
     );
     expect(check['currencies'].length).toEqual(1);
     expect(check['currencies'][0]).toEqual(btcCurrency);
+  });
+
+  test('should ignore token configs with invalid min wallet balance', () => {
+    const check = new BalanceChecker(
+      Logger.disabledLogger,
+      new MockedService(),
+      new MockedNotificationClient(),
+      [btcCurrency],
+      [
+        usdtCurrency,
+        { symbol: 'TBTC', minWalletBalance: Number.NaN } as any,
+        { symbol: 'RBTC' } as any,
+        { symbol: 'WBTC', minWalletBalance: Infinity } as any,
+      ],
+    );
+    expect(check['currencies'].length).toEqual(2);
+    expect(check['currencies'][0]).toEqual(btcCurrency);
+    expect(check['currencies'][1]).toEqual(usdtCurrency);
   });
 
   test('should check all currencies', async () => {


### PR DESCRIPTION
Follow up for https://github.com/BoltzExchange/boltz-backend/pull/1299

Also includes tokens now and logs if a config is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid wallet balance configurations; invalid values are now logged as warnings and safely excluded rather than causing errors.

* **Tests**
  * Added validation tests for configuration sanitization, ensuring invalid wallet balance values (NaN, Infinity) are properly excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->