### PR TITLE
refactor: use Fulmine ListVHTLCs

### DIFF
--- a/lib/chain/ArkSubscription.ts
+++ b/lib/chain/ArkSubscription.ts
@@ -37,6 +37,38 @@ type Events = {
   'vhtlc.spent': SpentVHtlc;
 };
 
+class AddressMapper {
+  private readonly decodedAddresses: Map<string, string>;
+
+  constructor(
+    addresses: string[],
+    onInvalidAddress?: (address: string, error: unknown) => void,
+  ) {
+    this.decodedAddresses = new Map();
+
+    for (const address of addresses) {
+      try {
+        this.decodedAddresses.set(
+          getHexString(ArkClient.decodeAddress(address).tweakedPubKey),
+          address,
+        );
+      } catch (error) {
+        if (onInvalidAddress !== undefined) {
+          onInvalidAddress(address, error);
+        } else {
+          throw error;
+        }
+      }
+    }
+  }
+
+  public getAddress = (script: string) => {
+    return this.decodedAddresses.get(
+      getHexString(getHexBuffer(script).subarray(2)),
+    );
+  };
+}
+
 class ArkSubscription extends TypedEventEmitter<Events> {
   private static readonly reconnectInterval = 2_500;
   private static readonly rescanIntervalMinutes = 5;
@@ -142,50 +174,60 @@ class ArkSubscription extends TypedEventEmitter<Events> {
         `Rescanning ${this.client.serviceName()} ${this.client.symbol}`,
       );
 
-      for (const [address, vhtlcId] of this.subscribedAddresses.entries()) {
-        try {
-          const req: arkrpc.ListVHTLCRequest = {
-            vhtlcId,
-          };
+      if (this.subscribedAddresses.size === 0) {
+        return;
+      }
 
-          const res = await this.unaryCall<
-            arkrpc.ListVHTLCRequest,
-            arkrpc.ListVHTLCResponse
-          >('listVhtlc', req);
+      const req: arkrpc.ListVHTLCsRequest = {
+        vhtlcIds: Array.from(this.subscribedAddresses.values()),
+      };
+      const res = await this.unaryCall<
+        arkrpc.ListVHTLCsRequest,
+        arkrpc.ListVHTLCsResponse
+      >('listVhtlCs', req);
 
-          for (const vhtlc of res.vhtlcs) {
-            if (vhtlc.outpoint === undefined) {
-              this.logger.warn(`No outpoint for vHTLC ${vhtlc.script}`);
-              continue;
-            }
+      const addressMapper = new AddressMapper(
+        Array.from(this.subscribedAddresses.keys()),
+        this.invalidAddressHandler('subscribed'),
+      );
 
-            this.emit('vhtlc.created', {
-              address,
-              txId: vhtlc.outpoint.txid,
+      for (const vhtlc of res.vhtlcs) {
+        if (vhtlc.outpoint === undefined) {
+          this.logger.warn(`No outpoint for vHTLC ${vhtlc.script}`);
+          continue;
+        }
+
+        const address = addressMapper.getAddress(vhtlc.script);
+        if (address === undefined) {
+          this.logger.warn(`No address for vHTLC ${vhtlc.script}`);
+          continue;
+        }
+
+        this.emit('vhtlc.created', {
+          address,
+          txId: vhtlc.outpoint.txid,
+          vout: vhtlc.outpoint.vout,
+          amount: fromProtoInt(vhtlc.amount),
+        });
+
+        if (
+          vhtlc.isSpent &&
+          vhtlc.spentBy !== undefined &&
+          vhtlc.spentBy !== ''
+        ) {
+          this.emit('vhtlc.spent', {
+            outpoint: {
+              txid: vhtlc.outpoint.txid,
               vout: vhtlc.outpoint.vout,
-              amount: fromProtoInt(vhtlc.amount),
-            });
-
-            if (
-              vhtlc.isSpent &&
-              vhtlc.spentBy !== undefined &&
-              vhtlc.spentBy !== ''
-            ) {
-              this.emit('vhtlc.spent', {
-                outpoint: {
-                  txid: vhtlc.outpoint.txid,
-                  vout: vhtlc.outpoint.vout,
-                },
-                spentBy: vhtlc.spentBy,
-              });
-            }
-          }
-        } catch (error) {
-          this.logger.silly(
-            `No ${this.client.serviceName()} ${this.client.symbol} vHTLC found for address ${address}: ${formatError(error)}`,
-          );
+            },
+            spentBy: vhtlc.spentBy,
+          });
         }
       }
+    } catch (error) {
+      this.logger.error(
+        `Error rescanning ${this.client.serviceName()} ${this.client.symbol}: ${formatError(error)}`,
+      );
     } finally {
       this.isRescanning = false;
     }
@@ -208,11 +250,9 @@ class ArkSubscription extends TypedEventEmitter<Events> {
           return;
         }
 
-        const decoded = new Map<string, string>(
-          notification.addresses.map((address) => [
-            getHexString(ArkClient.decodeAddress(address).tweakedPubKey),
-            address,
-          ]),
+        const addressMapper = new AddressMapper(
+          notification.addresses,
+          this.invalidAddressHandler('notification'),
         );
 
         for (const vhtlc of notification.newVtxos) {
@@ -221,9 +261,7 @@ class ArkSubscription extends TypedEventEmitter<Events> {
             continue;
           }
 
-          const recipient = decoded.get(
-            getHexString(getHexBuffer(vhtlc.script).subarray(2)),
-          );
+          const recipient = addressMapper.getAddress(vhtlc.script);
           if (recipient === undefined) {
             continue;
           }
@@ -323,6 +361,14 @@ class ArkSubscription extends TypedEventEmitter<Events> {
     } finally {
       this.isReconnecting = false;
     }
+  };
+
+  private invalidAddressHandler = (source: string) => {
+    return (address: string, error: unknown) => {
+      this.logger.warn(
+        `Ignoring invalid ${source} ARK address ${address}: ${formatError(error)}`,
+      );
+    };
   };
 }
 

--- a/proto/ark/service.proto
+++ b/proto/ark/service.proto
@@ -108,6 +108,11 @@ service Service {
       get: "/v1/vhtlc"
     };
   };
+  rpc ListVHTLCs(ListVHTLCsRequest) returns (ListVHTLCsResponse) {
+    option (google.api.http) = {
+      get: "/v1/vhtlcs"
+    };
+  };
   rpc GetInvoice(GetInvoiceRequest) returns (GetInvoiceResponse) {
     option (google.api.http) = {
       post: "/v1/invoice"
@@ -337,6 +342,13 @@ message ListVHTLCRequest {
   string vhtlc_id = 1;
 }
 message ListVHTLCResponse {
+  repeated Vtxo vhtlcs = 1;
+}
+
+message ListVHTLCsRequest {
+  repeated string vhtlc_ids = 1;
+}
+message ListVHTLCsResponse {
   repeated Vtxo vhtlcs = 1;
 }
 

--- a/test/unit/chain/ArkSubscription.spec.ts
+++ b/test/unit/chain/ArkSubscription.spec.ts
@@ -1,0 +1,165 @@
+import { EventEmitter } from 'events';
+import type Logger from '../../../lib/Logger';
+import ArkClient from '../../../lib/chain/ArkClient';
+import ArkSubscription from '../../../lib/chain/ArkSubscription';
+
+class MockStream extends EventEmitter {
+  public destroy = jest.fn();
+  public cancel = jest.fn();
+}
+
+describe('ArkSubscription', () => {
+  const mockLogger = {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    verbose: jest.fn(),
+  };
+
+  const client = {
+    serviceName: () => 'ark',
+    symbol: 'ARK',
+  } as unknown as ArkClient;
+
+  const createSubscription = () => {
+    const stream = new MockStream();
+    const notificationClient = {
+      getVtxoNotifications: jest.fn().mockReturnValue(stream),
+    };
+    const unaryCall = jest.fn();
+    const unaryNotificationCall = jest.fn();
+
+    const subscription = new ArkSubscription(
+      mockLogger as unknown as Logger,
+      client,
+      notificationClient as any,
+      unaryCall as any,
+      unaryNotificationCall as any,
+    );
+
+    return {
+      stream,
+      unaryCall,
+      unaryNotificationCall,
+      subscription,
+    };
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test('ignores invalid notification addresses and still emits valid vHTLCs', () => {
+    const { stream, subscription } = createSubscription();
+
+    const created = jest.fn();
+    subscription.on('vhtlc.created', created);
+
+    const tweakedPubKey = Buffer.alloc(32, 1);
+    jest
+      .spyOn(ArkClient, 'decodeAddress')
+      .mockImplementation((address: string) => {
+        if (address === 'invalid-address') {
+          throw new Error('invalid address');
+        }
+
+        return {
+          serverPubKey: Buffer.alloc(32, 2),
+          tweakedPubKey,
+        };
+      });
+
+    (subscription as any).streamVhtlcs();
+
+    stream.emit('data', {
+      notification: {
+        addresses: ['invalid-address', 'valid-address'],
+        newVtxos: [
+          {
+            script: Buffer.concat([Buffer.alloc(2), tweakedPubKey]).toString(
+              'hex',
+            ),
+            outpoint: {
+              txid: 'txid',
+              vout: 1,
+            },
+            amount: '21',
+          },
+        ],
+        spentVtxos: [],
+      },
+    });
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Ignoring invalid notification ARK address invalid-address: invalid address',
+    );
+    expect(created).toHaveBeenCalledWith({
+      address: 'valid-address',
+      txId: 'txid',
+      vout: 1,
+      amount: 21,
+    });
+  });
+
+  test('ignores invalid subscribed addresses during rescan and still emits valid vHTLCs', async () => {
+    const { subscription, unaryCall } = createSubscription();
+
+    const created = jest.fn();
+    subscription.on('vhtlc.created', created);
+
+    const tweakedPubKey = Buffer.alloc(32, 1);
+    jest
+      .spyOn(ArkClient, 'decodeAddress')
+      .mockImplementation((address: string) => {
+        if (address === 'invalid-address') {
+          throw new Error('invalid address');
+        }
+
+        return {
+          serverPubKey: Buffer.alloc(32, 2),
+          tweakedPubKey,
+        };
+      });
+
+    await subscription.subscribeAddresses([
+      {
+        address: 'invalid-address',
+        vHtlcId: 'bad-vhtlc-id',
+      },
+      {
+        address: 'valid-address',
+        vHtlcId: 'good-vhtlc-id',
+      },
+    ]);
+
+    unaryCall.mockResolvedValue({
+      vhtlcs: [
+        {
+          script: Buffer.concat([Buffer.alloc(2), tweakedPubKey]).toString(
+            'hex',
+          ),
+          outpoint: {
+            txid: 'txid',
+            vout: 1,
+          },
+          amount: '21',
+          isSpent: false,
+        },
+      ],
+    });
+
+    await subscription.rescan();
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Ignoring invalid subscribed ARK address invalid-address: invalid address',
+    );
+    expect(created).toHaveBeenCalledWith({
+      address: 'valid-address',
+      txId: 'txid',
+      vout: 1,
+      amount: 21,
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/ArkLabsHQ/fulmine/pull/386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ListVHTLCs RPC (GET /v1/vhtlcs) for batch vHTLC retrieval.

* **Bug Fixes**
  * Rescan and streaming now use batched vHTLC lookups, skip unresolved recipients, and surface consolidated error logging; invalid addresses generate warnings.

* **Tests**
  * Added unit tests covering vHTLC event handling and invalid-address warnings.

* **Chores**
  * Updated regtest submodule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->