### PR TITLE
feat: CLI tool to rotate referral API keys

### DIFF
--- a/boltzr-cli/src/grpc/mod.rs
+++ b/boltzr-cli/src/grpc/mod.rs
@@ -73,6 +73,17 @@ impl BoltzClient {
         Ok(response.into_inner())
     }
 
+    pub async fn rotate_referral_keys(
+        &mut self,
+        id: String,
+    ) -> Result<boltz_rpc::RotateReferralKeysResponse> {
+        let response = self
+            .client
+            .rotate_referral_keys(boltz_rpc::RotateReferralKeysRequest { id })
+            .await?;
+        Ok(response.into_inner())
+    }
+
     pub async fn allow_refund(&mut self, id: String) -> Result<boltz_rpc::AllowRefundResponse> {
         let response = self
             .client

--- a/boltzr-cli/src/main.rs
+++ b/boltzr-cli/src/main.rs
@@ -421,6 +421,8 @@ enum ReferralCommands {
         fee_share: u32,
         routing_node: Option<String>,
     },
+    #[command(about = "Rotates the API credentials of a referral")]
+    Rotate { id: String },
     #[command(about = "Sets the configuration of a referral")]
     SetConfig {
         id: String,
@@ -885,6 +887,25 @@ async fn run_command(cli: Cli) -> Result<()> {
                 let response = get_grpc_client(&cli)
                     .await?
                     .add_referral(id.to_string(), *fee_share, routing_node.clone())
+                    .await?;
+                print_pretty(&response)?;
+            }
+            ReferralCommands::Rotate { id } => {
+                let confirmed = inquire::Confirm::new(&format!(
+                    "Rotate API credentials for referral '{}'? This will invalidate the current keys.",
+                    id
+                ))
+                .with_default(false)
+                .prompt()?;
+
+                if !confirmed {
+                    println!("Aborted");
+                    return Ok(());
+                }
+
+                let response = get_grpc_client(&cli)
+                    .await?
+                    .rotate_referral_keys(id.clone())
                     .await?;
                 print_pretty(&response)?;
             }

--- a/lib/db/repositories/ReferralRepository.ts
+++ b/lib/db/repositories/ReferralRepository.ts
@@ -176,6 +176,17 @@ class ReferralRepository {
     });
   };
 
+  public static setApiKeys = async (
+    ref: Referral,
+    apiKey: string,
+    apiSecret: string,
+  ) => {
+    return await ref.update({
+      apiKey,
+      apiSecret,
+    });
+  };
+
   private static sanityCheckConfig = (
     config: ReferralConfig | null | undefined,
   ) => {

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -32,6 +32,7 @@ class GrpcServer {
       getAddress: grpcService.getAddress,
       sendCoins: grpcService.sendCoins,
       addReferral: grpcService.addReferral,
+      rotateReferralKeys: grpcService.rotateReferralKeys,
       sweepSwaps: grpcService.sweepSwaps,
       listSwaps: grpcService.listSwaps,
       rescan: grpcService.rescan,

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -177,6 +177,22 @@ class GrpcService {
     });
   };
 
+  public rotateReferralKeys: handleUnaryCall<
+    boltzrpc.RotateReferralKeysRequest,
+    boltzrpc.RotateReferralKeysResponse
+  > = async (call, callback) => {
+    await GrpcService.handleCallback(call, callback, async () => {
+      const { apiKey, apiSecret } = await this.service.rotateReferralKeys(
+        call.request.id,
+      );
+
+      return {
+        apiKey,
+        apiSecret,
+      };
+    });
+  };
+
   public setSwapStatus: handleUnaryCall<
     boltzrpc.SetSwapStatusRequest,
     boltzrpc.SetSwapStatusResponse

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -1056,6 +1056,34 @@ class Service {
     };
   };
 
+  public rotateReferralKeys = async (
+    id: string,
+  ): Promise<{
+    apiKey: string;
+    apiSecret: string;
+  }> => {
+    if (id === '') {
+      throw new Error('referral IDs cannot be empty');
+    }
+
+    const referral = await ReferralRepository.getReferralById(id);
+    if (referral === null) {
+      throw new Error(`could not find referral with id: ${id}`);
+    }
+
+    const apiKey = createApiCredential();
+    const apiSecret = createApiCredential();
+
+    await ReferralRepository.setApiKeys(referral, apiKey, apiSecret);
+
+    this.logger.info(`Rotated API keys for referral: ${id}`);
+
+    return {
+      apiKey,
+      apiSecret,
+    };
+  };
+
   public setSwapStatus = async (id: string, status: string) => {
     if (
       ![

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -27,6 +27,8 @@ service Boltz {
 
   /* Adds a new referral ID to the database */
   rpc AddReferral (AddReferralRequest) returns (AddReferralResponse);
+  /* Rotates the API keys of a referral */
+  rpc RotateReferralKeys (RotateReferralKeysRequest) returns (RotateReferralKeysResponse);
 
   /* Modifies the status of a swap */
   rpc SetSwapStatus (SetSwapStatusRequest) returns (SetSwapStatusResponse);
@@ -203,6 +205,14 @@ message AddReferralRequest {
   optional string routing_node = 3;
 }
 message AddReferralResponse {
+  string api_key = 1;
+  string api_secret = 2;
+}
+
+message RotateReferralKeysRequest {
+  string id = 1;
+}
+message RotateReferralKeysResponse {
   string api_key = 1;
   string api_secret = 2;
 }

--- a/test/integration/db/repositories/ReferralRepository.spec.ts
+++ b/test/integration/db/repositories/ReferralRepository.spec.ts
@@ -684,19 +684,76 @@ describe('ReferralRepository', () => {
         ).toThrow('hidePair must be a boolean');
       });
     });
+  });
 
-    describe('lookups', () => {
-      test('should return null when referral does not exist', async () => {
-        await expect(
-          ReferralRepository.getReferralById('missing'),
-        ).resolves.toBe(null);
-        await expect(
-          ReferralRepository.getReferralByApiKey('missing-key'),
-        ).resolves.toBe(null);
-        await expect(
-          ReferralRepository.getReferralByRoutingNode('missing-node'),
-        ).resolves.toBe(null);
+  describe('setApiKeys', () => {
+    test('should rotate api credentials', async () => {
+      const ref = await ReferralRepository.addReferral({
+        ...fixture,
+        apiKey: 'oldKey',
+        apiSecret: 'oldSecret',
+        config: {
+          maxRoutingFee: 0.001,
+        },
       });
+
+      await ReferralRepository.setApiKeys(ref, 'newKey', 'newSecret');
+
+      await expect(
+        ReferralRepository.getReferralByApiKey('oldKey'),
+      ).resolves.toBeNull();
+
+      const rotated = await ReferralRepository.getReferralByApiKey('newKey');
+      expect(rotated?.id).toEqual(fixture.id);
+      expect(rotated?.apiSecret).toEqual('newSecret');
+      expect(rotated?.feeShare).toEqual(fixture.feeShare);
+      expect(rotated?.config).toEqual({
+        maxRoutingFee: 0.001,
+      });
+    });
+
+    test('should preserve config merge after rotating api credentials', async () => {
+      ReferralRepository.setConfiguredReferrals({
+        test: {
+          pairs: {
+            'BTC/BTC': {
+              showHidden: true,
+            },
+          },
+        },
+      });
+
+      const ref = await ReferralRepository.addReferral({
+        ...fixture,
+        apiKey: 'oldKey',
+        apiSecret: 'oldSecret',
+        config: undefined,
+      });
+
+      await ReferralRepository.setApiKeys(ref, 'newKey', 'newSecret');
+
+      const rotated = await ReferralRepository.getReferralByApiKey('newKey');
+      expect(rotated?.config).toEqual({
+        pairs: {
+          'BTC/BTC': {
+            showHidden: true,
+          },
+        },
+      });
+    });
+  });
+
+  describe('lookups', () => {
+    test('should return null when referral does not exist', async () => {
+      await expect(ReferralRepository.getReferralById('missing')).resolves.toBe(
+        null,
+      );
+      await expect(
+        ReferralRepository.getReferralByApiKey('missing-key'),
+      ).resolves.toBe(null);
+      await expect(
+        ReferralRepository.getReferralByRoutingNode('missing-node'),
+      ).resolves.toBe(null);
     });
   });
 });

--- a/test/unit/grpc/GrpcService.spec.ts
+++ b/test/unit/grpc/GrpcService.spec.ts
@@ -55,6 +55,14 @@ const mockAddReferral = jest
   .fn()
   .mockImplementation(() => mockAddReferralResponse);
 
+const mockRotateReferralKeysResponse = {
+  apiKey: 'rotated-key',
+  apiSecret: 'rotated-secret',
+};
+const mockRotateReferralKeys = jest
+  .fn()
+  .mockImplementation(() => mockRotateReferralKeysResponse);
+
 const mockDeriveBlindingKeysResponse = {
   publicKey: getHexBuffer('aa'),
   privateKey: getHexBuffer('bb'),
@@ -131,6 +139,7 @@ jest.mock('../../../lib/service/Service', () => {
       getAddress: mockGetAddress,
       sendCoins: mockSendCoins,
       addReferral: mockAddReferral,
+      rotateReferralKeys: mockRotateReferralKeys,
       rescan: jest.fn().mockResolvedValue(831106),
       checkTransaction: jest.fn().mockResolvedValue(undefined),
     };
@@ -163,6 +172,23 @@ const createCallback = (
     callback(error, response);
   };
 };
+
+const callUnaryAsPromise = <T>(
+  method: (
+    call: any,
+    callback: (error: any, response?: T | null) => void,
+  ) => void,
+  call: any,
+): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    method(call, (error, response) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(response!);
+      }
+    });
+  });
 
 TransactionLabelRepository.getLabel = jest.fn().mockResolvedValue(null);
 
@@ -396,6 +422,49 @@ describe('GrpcService', () => {
       ...callData,
       routingNode: undefined,
     });
+  });
+
+  test('should handle RotateReferralKeys', async () => {
+    const id = 'someId';
+
+    const response =
+      await callUnaryAsPromise<boltzrpc.RotateReferralKeysResponse>(
+        grpcService.rotateReferralKeys,
+        createCall({ id }),
+      );
+
+    expect(response.apiKey).toEqual(mockRotateReferralKeysResponse.apiKey);
+    expect(response.apiSecret).toEqual(
+      mockRotateReferralKeysResponse.apiSecret,
+    );
+    expect(mockRotateReferralKeys).toHaveBeenCalledTimes(1);
+    expect(mockRotateReferralKeys).toHaveBeenCalledWith(id);
+  });
+
+  test('should propagate empty id errors from RotateReferralKeys', async () => {
+    mockRotateReferralKeys.mockRejectedValueOnce(
+      new Error('referral IDs cannot be empty'),
+    );
+
+    await expect(
+      callUnaryAsPromise<boltzrpc.RotateReferralKeysResponse>(
+        grpcService.rotateReferralKeys,
+        createCall({ id: '' }),
+      ),
+    ).rejects.toEqual(new Error('referral IDs cannot be empty'));
+  });
+
+  test('should propagate not found errors from RotateReferralKeys', async () => {
+    mockRotateReferralKeys.mockRejectedValueOnce(
+      'could not find referral with id: ref',
+    );
+
+    await expect(
+      callUnaryAsPromise<boltzrpc.RotateReferralKeysResponse>(
+        grpcService.rotateReferralKeys,
+        createCall({ id: 'ref' }),
+      ),
+    ).rejects.toEqual({ message: 'could not find referral with id: ref' });
   });
 
   test('should sweep swaps of one currency', async () => {

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -98,13 +98,21 @@ jest.mock('../../../lib/db/repositories/ReverseSwapRepository', () => {
 
 const mockAddReferral = jest.fn().mockImplementation(async () => {});
 
+let referralById: any = undefined;
+const mockGetReferralById = jest.fn().mockImplementation(async () => {
+  return referralById;
+});
+const mockSetApiKeys = jest.fn().mockImplementation(async () => {});
+
 let referralByRoutingNode: any = undefined;
 const mockGetReferralByRoutingNode = jest.fn().mockImplementation(async () => {
   return referralByRoutingNode;
 });
 
 ReferralRepository.addReferral = mockAddReferral;
+ReferralRepository.getReferralById = mockGetReferralById;
 ReferralRepository.getReferralByRoutingNode = mockGetReferralByRoutingNode;
+ReferralRepository.setApiKeys = mockSetApiKeys;
 
 const mockedSwap = {
   id: 'swapId',
@@ -841,6 +849,9 @@ describe('Service', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    referralById = undefined;
+    referralByRoutingNode = undefined;
 
     PairRepository.addPair = mockAddPair;
     PairRepository.getPairs = mockGetPairs;
@@ -1917,6 +1928,51 @@ describe('Service', () => {
 
     await expect(service.addReferral(referral)).rejects.toEqual(
       new Error('referral IDs cannot be empty'),
+    );
+  });
+
+  test('should rotate referral credentials', async () => {
+    const oldApiKey = 'oldkey000';
+    const oldApiSecret = 'oldsecret000';
+
+    const referral = {
+      id: 'adsf',
+      feeShare: 25,
+      routingNode: '03',
+      apiKey: oldApiKey,
+      apiSecret: oldApiSecret,
+      config: {
+        maxRoutingFee: 0.001,
+      },
+    };
+
+    referralById = referral;
+
+    const response = await service.rotateReferralKeys(referral.id);
+
+    expect(response.apiKey).toBeDefined();
+    expect(response.apiSecret).toBeDefined();
+    expect(response.apiKey).not.toEqual(oldApiKey);
+    expect(response.apiSecret).not.toEqual(oldApiSecret);
+
+    expect(mockGetReferralById).toHaveBeenCalledTimes(1);
+    expect(mockGetReferralById).toHaveBeenCalledWith(referral.id);
+
+    expect(mockSetApiKeys).toHaveBeenCalledTimes(1);
+    expect(mockSetApiKeys).toHaveBeenCalledWith(
+      referral,
+      response.apiKey,
+      response.apiSecret,
+    );
+
+    await expect(service.rotateReferralKeys('')).rejects.toEqual(
+      new Error('referral IDs cannot be empty'),
+    );
+
+    referralById = null;
+
+    await expect(service.rotateReferralKeys('missing')).rejects.toEqual(
+      new Error('could not find referral with id: missing'),
     );
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI command to rotate referral API credentials with confirmation prompt before proceeding.
  * System now generates and persists new API keys and secrets upon rotation.

* **Tests**
  * Added integration and unit test coverage for referral credential rotation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->