### PR TITLE
fix: harden swap validation and expiry handling

### DIFF
--- a/boltzr/src/api/rescue.rs
+++ b/boltzr/src/api/rescue.rs
@@ -2,7 +2,8 @@ use crate::api::ServerState;
 use crate::api::errors::AxumError;
 use crate::api::ws::status::SwapInfos;
 use crate::service::{
-    KeyVecIterator, MAX_GAP_LIMIT, Pagination, PubkeyIterator, SingleKeyIterator, XpubIterator,
+    KeyVecIterator, MAX_GAP_LIMIT, MAX_PAGINATION_LIMIT, Pagination, PubkeyIterator,
+    SingleKeyIterator, XpubIterator,
 };
 use crate::swap::manager::SwapManager;
 use crate::utils::serde::{PublicKeyDeserialize, PublicKeyVecDeserialize, XpubDeserialize};
@@ -64,13 +65,19 @@ impl TryFrom<RescueParams> for Box<dyn PubkeyIterator + Send> {
                     }
                 }
 
-                if let Some(pagination_params) = &pagination
-                    && pagination_params.limit == 0
-                {
-                    return Err(AxumError::new(
-                        StatusCode::UNPROCESSABLE_ENTITY,
-                        anyhow::anyhow!("limit must be at least 1"),
-                    ));
+                if let Some(pagination_params) = &pagination {
+                    if pagination_params.limit == 0 {
+                        return Err(AxumError::new(
+                            StatusCode::UNPROCESSABLE_ENTITY,
+                            anyhow::anyhow!("limit must be at least 1"),
+                        ));
+                    }
+                    if pagination_params.limit > MAX_PAGINATION_LIMIT {
+                        return Err(AxumError::new(
+                            StatusCode::UNPROCESSABLE_ENTITY,
+                            anyhow::anyhow!("limit must not exceed {}", MAX_PAGINATION_LIMIT),
+                        ));
+                    }
                 }
 
                 let iterator = XpubIterator::new(xpub.0, derivation_path, gap_limit)
@@ -363,5 +370,20 @@ mod test {
         let body = res.into_body().collect().await.unwrap().to_bytes();
         let error = serde_json::from_slice::<ApiError>(&body).unwrap();
         assert_eq!(error.error, "limit must be at least 1");
+    }
+
+    #[tokio::test]
+    async fn test_swap_restore_with_pagination_limit_exceeds_max() {
+        let res = make_restore_request_with_pagination(
+            "/v2/swap/restore",
+            VALID_XPUB,
+            Some(0),
+            Some(MAX_PAGINATION_LIMIT + 1),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        let error = serde_json::from_slice::<ApiError>(&body).unwrap();
+        assert!(error.error.contains("limit must not exceed"));
     }
 }

--- a/boltzr/src/db/helpers/swap.rs
+++ b/boltzr/src/db/helpers/swap.rs
@@ -14,11 +14,12 @@ pub trait SwapHelper {
     fn get_by_id(&self, id: &str) -> QueryResponse<Swap>;
     fn get_all(&self, condition: SwapCondition) -> QueryResponse<Vec<Swap>>;
     fn get_all_nullable(&self, condition: SwapNullableCondition) -> QueryResponse<Vec<Swap>>;
-    fn update_status(
+    fn update_status_if_matches(
         &self,
         id: &str,
         status: SwapUpdate,
         failure_reason: Option<String>,
+        condition: SwapCondition,
     ) -> QueryResponse<usize>;
 }
 
@@ -60,7 +61,7 @@ impl SwapHelper for SwapHelperDatabase {
     }
 
     #[instrument(
-        name = "db::SwapHelperDatabase::update_status",
+        name = "db::SwapHelperDatabase::update_status_if_matches",
         skip_all,
         fields(
             swap_id = %id,
@@ -68,15 +69,17 @@ impl SwapHelper for SwapHelperDatabase {
             has_failure_reason = failure_reason.is_some()
         )
     )]
-    fn update_status(
+    fn update_status_if_matches(
         &self,
         id: &str,
         status: SwapUpdate,
         failure_reason: Option<String>,
+        condition: SwapCondition,
     ) -> QueryResponse<usize> {
         if let Some(failure_reason) = failure_reason {
             Ok(update(swaps::dsl::swaps)
                 .filter(swaps::dsl::id.eq(id))
+                .filter(condition)
                 .set((
                     swaps::dsl::status.eq(status.to_string()),
                     swaps::dsl::failureReason.eq(failure_reason),
@@ -85,6 +88,7 @@ impl SwapHelper for SwapHelperDatabase {
         } else {
             Ok(update(swaps::dsl::swaps)
                 .filter(swaps::dsl::id.eq(id))
+                .filter(condition)
                 .set(swaps::dsl::status.eq(status.to_string()))
                 .execute(&mut self.pool.get()?)?)
         }
@@ -107,11 +111,12 @@ pub mod test {
             fn get_by_id(&self, id: &str) -> QueryResponse<Swap>;
             fn get_all(&self, condition: SwapCondition) -> QueryResponse<Vec<Swap>>;
             fn get_all_nullable(&self, condition: SwapNullableCondition) -> QueryResponse<Vec<Swap>>;
-            fn update_status(
+            fn update_status_if_matches(
                 &self,
                 id: &str,
                 status: SwapUpdate,
                 failure_reason: Option<String>,
+                condition: SwapCondition,
             ) -> QueryResponse<usize>;
         }
     );

--- a/boltzr/src/grpc/service.rs
+++ b/boltzr/src/grpc/service.rs
@@ -853,11 +853,12 @@ mod test {
             fn get_by_id(&self, id: &str) -> QueryResponse<Swap>;
             fn get_all(&self, condition: SwapCondition) -> QueryResponse<Vec<Swap>>;
             fn get_all_nullable(&self, condition: SwapNullableCondition) -> QueryResponse<Vec<Swap>>;
-            fn update_status(
+            fn update_status_if_matches(
                 &self,
                 id: &str,
                 status: SwapUpdate,
                 failure_reason: Option<String>,
+                condition: SwapCondition,
             ) -> QueryResponse<usize>;
         }
     }

--- a/boltzr/src/service/mod.rs
+++ b/boltzr/src/service/mod.rs
@@ -107,11 +107,12 @@ pub mod test {
             fn get_by_id(&self, id: &str) -> QueryResponse<Swap>;
             fn get_all(&self, condition: SwapCondition) -> QueryResponse<Vec<Swap>>;
             fn get_all_nullable(&self, condition: SwapNullableCondition) -> QueryResponse<Vec<Swap>>;
-            fn update_status(
+            fn update_status_if_matches(
                 &self,
                 id: &str,
                 status: SwapUpdate,
                 failure_reason: Option<String>,
+                condition: SwapCondition,
             ) -> QueryResponse<usize>;
         }
     }

--- a/boltzr/src/service/mod.rs
+++ b/boltzr/src/service/mod.rs
@@ -22,7 +22,8 @@ mod rescue;
 pub use country_codes::MarkingsConfig;
 pub use pair_stats::HistoricalConfig;
 pub use pubkey_iterator::{
-    KeyVecIterator, MAX_GAP_LIMIT, Pagination, PubkeyIterator, SingleKeyIterator, XpubIterator,
+    KeyVecIterator, MAX_GAP_LIMIT, MAX_PAGINATION_LIMIT, Pagination, PubkeyIterator,
+    SingleKeyIterator, XpubIterator,
 };
 
 pub struct Service {

--- a/boltzr/src/service/pubkey_iterator.rs
+++ b/boltzr/src/service/pubkey_iterator.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 pub const MAX_GAP_LIMIT: u32 = 150;
+pub const MAX_PAGINATION_LIMIT: u32 = 1000;
 
 const DEFAULT_GAP_LIMIT: u32 = 50;
 const DEFAULT_DERIVATION_PATH: &str = "m/44/0/0/0";
@@ -66,6 +67,13 @@ impl Pagination {
     }
 }
 
+fn buffered_end(start: u32, end: u32) -> Result<u32> {
+    let delta = end.checked_sub(start).ok_or_else(|| {
+        anyhow::anyhow!("derive_keys end ({}) is less than start ({})", end, start)
+    })?;
+    Ok(end.saturating_add(delta))
+}
+
 impl XpubIterator {
     pub fn new(
         xpub: Xpub,
@@ -116,7 +124,7 @@ impl PubkeyIterator for XpubIterator {
 
         // Add extra keys to the map to avoid keys not being found because of the gap limit
         // for swaps with multiple keys
-        for i in start..(end + (end - start)) {
+        for i in start..buffered_end(start, end)? {
             let key = self
                 .xpub
                 .derive_pub(
@@ -172,7 +180,8 @@ impl PubkeyIterator for KeyVecIterator {
         let mut result = Vec::new();
 
         // Add some buffer to avoid keys not being found because of the gap limit
-        let actual_end = std::cmp::min((end + (end - start)) as usize, self.keys.len());
+        let buffered_end = buffered_end(start, end)?;
+        let actual_end = std::cmp::min(buffered_end as usize, self.keys.len());
         for (i, key) in self.keys[start as usize..actual_end].iter().enumerate() {
             let key = hex::encode(key.inner.serialize());
 
@@ -241,6 +250,28 @@ mod tests {
             limit: 1,
         };
         assert!(overflow.end().is_err());
+    }
+
+    #[test]
+    fn test_buffered_end() {
+        assert_eq!(buffered_end(0, 5).unwrap(), 10);
+        assert_eq!(buffered_end(5, 5).unwrap(), 5);
+        assert_eq!(buffered_end(10, 20).unwrap(), 30);
+
+        // Saturates at u32::MAX instead of wrapping around.
+        assert_eq!(
+            buffered_end(u32::MAX - 100, u32::MAX - 1).unwrap(),
+            u32::MAX
+        );
+        assert_eq!(buffered_end(u32::MAX - 1, u32::MAX).unwrap(), u32::MAX);
+        assert_eq!(
+            buffered_end(u32::MAX - MAX_PAGINATION_LIMIT, u32::MAX).unwrap(),
+            u32::MAX
+        );
+
+        // Rejects ranges where end < start to avoid underflow.
+        assert!(buffered_end(10, 5).is_err());
+        assert!(buffered_end(u32::MAX, 0).is_err());
     }
 
     mod xpub_iterator {

--- a/boltzr/src/swap/asset_rescue.rs
+++ b/boltzr/src/swap/asset_rescue.rs
@@ -570,7 +570,7 @@ mod tests {
             fn get_by_id(&self, id: &str) -> Result<Swap>;
             fn get_all(&self, condition: SwapCondition) -> Result<Vec<Swap>>;
             fn get_all_nullable(&self, condition: SwapNullableCondition) -> Result<Vec<Swap>>;
-            fn update_status(&self, id: &str, status: SwapUpdate, failure_reason: Option<String>) -> Result<usize>;
+            fn update_status_if_matches(&self, id: &str, status: SwapUpdate, failure_reason: Option<String>, condition: SwapCondition) -> Result<usize>;
         }
     }
 

--- a/boltzr/src/swap/expiration/custom_expiry.rs
+++ b/boltzr/src/swap/expiration/custom_expiry.rs
@@ -1,6 +1,6 @@
 use crate::api::ws::types::{SwapStatus, SwapStatusNoId};
 use crate::db::helpers::referral::ReferralHelper;
-use crate::db::helpers::swap::SwapHelper;
+use crate::db::helpers::swap::{SwapCondition, SwapHelper};
 use crate::db::models::{Referral, SwapType};
 use crate::swap::expiration::ExpirationChecker;
 use crate::swap::{SwapUpdate, serialize_swap_updates};
@@ -12,6 +12,17 @@ use std::time::Duration;
 use tracing::{info, instrument, trace};
 
 const FAILURE_REASON_CUSTOM_EXPIRATION: &str = "swap expired";
+
+fn custom_expirable_swaps_condition() -> SwapCondition {
+    Box::new(
+        crate::db::schema::swaps::dsl::status
+            .eq_any(serialize_swap_updates(&[
+                SwapUpdate::SwapCreated,
+                SwapUpdate::InvoiceSet,
+            ]))
+            .and(crate::db::schema::swaps::dsl::referral.is_not_null()),
+    )
+}
 
 pub struct CustomExpirationChecker {
     update_tx: tokio::sync::broadcast::Sender<SwapStatus>,
@@ -56,14 +67,7 @@ impl ExpirationChecker for CustomExpirationChecker {
     #[instrument(name = "CustomExpirationChecker::check", skip_all)]
     fn check(&self) -> anyhow::Result<()> {
         let referrals = self.get_referrals()?;
-        let swaps = self.swap_repo.get_all(Box::new(
-            crate::db::schema::swaps::dsl::status
-                .eq_any(serialize_swap_updates(&[
-                    SwapUpdate::SwapCreated,
-                    SwapUpdate::InvoiceSet,
-                ]))
-                .and(crate::db::schema::swaps::dsl::referral.is_not_null()),
-        ))?;
+        let swaps = self.swap_repo.get_all(custom_expirable_swaps_condition())?;
 
         trace!(
             "Checking for custom expirations of {} Submarine Swaps",
@@ -90,16 +94,30 @@ impl ExpirationChecker for CustomExpirationChecker {
                 continue;
             }
 
-            info!(
-                "Failing Submarine Swap {} because of a custom expiration from the referral",
-                swap.id
-            );
-
             let status = SwapUpdate::InvoiceFailedToPay;
             let failure_reason = FAILURE_REASON_CUSTOM_EXPIRATION;
 
-            self.swap_repo
-                .update_status(&swap.id, status, Some(failure_reason.to_string()))?;
+            // Conditional update to avoid racing with a concurrent status transition
+            // (e.g. invoice pending/paid) that happens between the snapshot and here.
+            let updated = self.swap_repo.update_status_if_matches(
+                &swap.id,
+                status,
+                Some(failure_reason.to_string()),
+                custom_expirable_swaps_condition(),
+            )?;
+
+            if updated == 0 {
+                trace!(
+                    "Skipping custom expiration failure for Submarine Swap {} because its status has changed",
+                    swap.id
+                );
+                continue;
+            }
+
+            info!(
+                "Failed Submarine Swap {} because of a custom expiration from the referral",
+                swap.id
+            );
 
             self.update_tx.send(SwapStatus {
                 id: swap.id,
@@ -122,7 +140,11 @@ mod test {
     use crate::db::helpers::referral::{ReferralCondition, ReferralHelper};
     use crate::db::helpers::swap::{SwapCondition, SwapHelper, SwapNullableCondition};
     use crate::db::models::Swap;
-    use mockall::{mock, predicate};
+    use crate::db::schema::swaps::dsl::swaps;
+    use diesel::QueryDsl;
+    use diesel::debug_query;
+    use diesel::pg::Pg;
+    use mockall::mock;
 
     mock! {
         SwapHelper {}
@@ -135,11 +157,12 @@ mod test {
             fn get_by_id(&self, id: &str) -> QueryResponse<Swap>;
             fn get_all(&self, condition: SwapCondition) -> QueryResponse<Vec<Swap>>;
             fn get_all_nullable(&self, condition: SwapNullableCondition) -> QueryResponse<Vec<Swap>>;
-            fn update_status(
+            fn update_status_if_matches(
                 &self,
                 id: &str,
                 status: SwapUpdate,
                 failure_reason: Option<String>,
+                condition: SwapCondition,
             ) -> QueryResponse<usize>;
         }
     }
@@ -243,13 +266,13 @@ mod test {
             }])
         });
         swap_repo
-            .expect_update_status()
-            .with(
-                predicate::eq(swap_id),
-                predicate::eq(SwapUpdate::InvoiceFailedToPay),
-                predicate::eq(Some(FAILURE_REASON_CUSTOM_EXPIRATION.to_string())),
-            )
-            .returning(|_, _, _| Ok(1));
+            .expect_update_status_if_matches()
+            .withf(move |id, status, failure_reason, _condition| {
+                id == swap_id
+                    && *status == SwapUpdate::InvoiceFailedToPay
+                    && failure_reason.as_deref() == Some(FAILURE_REASON_CUSTOM_EXPIRATION)
+            })
+            .returning(|_, _, _, _| Ok(1));
 
         let (tx, mut rx) = tokio::sync::broadcast::channel(1);
         let checker =
@@ -269,5 +292,61 @@ mod test {
                 },
             }
         );
+    }
+
+    #[tokio::test]
+    async fn test_check_expired_skips_when_concurrently_updated() {
+        let mut referral_repo = MockReferralHelper::new();
+        referral_repo.expect_get_all().returning(|_| {
+            Ok(vec![Referral {
+                id: "pro".to_string(),
+                config: Some(serde_json::json!({ "expirations": { "0": 120 }})),
+            }])
+        });
+
+        let mut swap_repo = MockSwapHelper::new();
+
+        let swap_id = "id";
+        swap_repo.expect_get_all().returning(|_| {
+            Ok(vec![Swap {
+                id: swap_id.to_string(),
+                pair: "BTC/BTC".to_string(),
+                referral: Some("pro".to_string()),
+                status: SwapUpdate::InvoiceSet.to_string(),
+                createdAt: Local::now().naive_utc() - Duration::from_secs(212),
+                ..Default::default()
+            }])
+        });
+        swap_repo
+            .expect_update_status_if_matches()
+            .withf(move |id, status, failure_reason, _condition| {
+                id == swap_id
+                    && *status == SwapUpdate::InvoiceFailedToPay
+                    && failure_reason.as_deref() == Some(FAILURE_REASON_CUSTOM_EXPIRATION)
+            })
+            .returning(|_, _, _, _| Ok(0));
+
+        let (tx, mut rx) = tokio::sync::broadcast::channel(1);
+        let checker =
+            CustomExpirationChecker::new(tx, Arc::new(swap_repo), Arc::new(referral_repo));
+
+        checker.check().unwrap();
+
+        assert!(matches!(
+            rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn test_custom_expirable_swaps_condition_matches_expected_statuses() {
+        let query = swaps.filter(custom_expirable_swaps_condition());
+        let sql = debug_query::<Pg, _>(&query).to_string();
+
+        for status in [SwapUpdate::SwapCreated, SwapUpdate::InvoiceSet] {
+            assert!(sql.contains(&status.to_string()));
+        }
+
+        assert!(sql.contains(r#""swaps"."referral" IS NOT NULL"#));
     }
 }

--- a/boltzr/src/swap/expiration/invoice_expiry.rs
+++ b/boltzr/src/swap/expiration/invoice_expiry.rs
@@ -87,16 +87,30 @@ impl ExpirationChecker for InvoiceExpirationChecker {
                 continue;
             }
 
-            info!(
-                "Failing Submarine Swap {} because its invoice expired already",
-                swap.id
-            );
-
             let status = SwapUpdate::InvoiceFailedToPay;
             let failure_reason = FAILURE_REASON_EXPIRED_INVOICE;
 
-            self.swap_repo
-                .update_status(&swap.id, status, Some(failure_reason.to_string()))?;
+            // Conditional update to avoid racing with a concurrent invoice payment
+            // that transitions the swap to a terminal/paid state after we loaded it.
+            let updated = self.swap_repo.update_status_if_matches(
+                &swap.id,
+                status,
+                Some(failure_reason.to_string()),
+                expirable_invoice_swaps_condition(),
+            )?;
+
+            if updated == 0 {
+                trace!(
+                    "Skipping expired invoice failure for Submarine Swap {} because its status has changed",
+                    swap.id
+                );
+                continue;
+            }
+
+            info!(
+                "Failed Submarine Swap {} because its invoice expired already",
+                swap.id
+            );
 
             self.update_tx.send(SwapStatus {
                 id: swap.id,
@@ -127,7 +141,7 @@ mod test {
     use diesel::QueryDsl;
     use diesel::debug_query;
     use diesel::pg::Pg;
-    use mockall::{mock, predicate};
+    use mockall::mock;
     use std::collections::HashMap;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -143,11 +157,12 @@ mod test {
             fn get_by_id(&self, id: &str) -> QueryResponse<Swap>;
             fn get_all(&self, condition: SwapCondition) -> QueryResponse<Vec<Swap>>;
             fn get_all_nullable(&self, condition: SwapNullableCondition) -> QueryResponse<Vec<Swap>>;
-            fn update_status(
+            fn update_status_if_matches(
                 &self,
                 id: &str,
                 status: SwapUpdate,
                 failure_reason: Option<String>,
+                condition: SwapCondition,
             ) -> QueryResponse<usize>;
         }
     }
@@ -239,13 +254,13 @@ mod test {
                 }
             ])
         });
-        swap.expect_update_status()
-            .with(
-                predicate::eq(swap_id),
-                predicate::eq(SwapUpdate::InvoiceFailedToPay),
-                predicate::eq(Some(FAILURE_REASON_EXPIRED_INVOICE.to_string())),
-            )
-            .returning(|_, _, _| Ok(1));
+        swap.expect_update_status_if_matches()
+            .withf(move |id, status, failure_reason, _condition| {
+                id == swap_id
+                    && *status == SwapUpdate::InvoiceFailedToPay
+                    && failure_reason.as_deref() == Some(FAILURE_REASON_EXPIRED_INVOICE)
+            })
+            .returning(|_, _, _, _| Ok(1));
 
         let (tx, mut rx) = tokio::sync::broadcast::channel(1);
         let checker = InvoiceExpirationChecker::new(tx, get_currencies().await, Arc::new(swap));
@@ -264,5 +279,41 @@ mod test {
                 },
             }
         );
+    }
+
+    #[tokio::test]
+    async fn test_check_expired_invoice_skips_when_concurrently_updated() {
+        let swap_id = "raced";
+
+        let mut swap = MockSwapHelper::new();
+        swap.expect_get_all().returning(|_| {
+            Ok(vec![
+                Swap {
+                    id: swap_id.to_string(),
+                    pair: "L-BTC/BTC".to_string(),
+                    orderSide: 1,
+                    status: "invoice.set".to_string(),
+                    invoice: Some("lnbcrt1230p1pnwzkshsp584p434kjslfl030shwps75nvy4leq5k6psvdxn4kzsxjnptlmr3spp5nxqauehzqkx3xswjtrgx9lh5pqjxkyx0kszj0nc4m4jn7uk9gc5qdq8v9ekgesxqyjw5qcqp29qxpqysgqu6ft6p8c36khp082xng2xzmta25nlg803qjncal3fhzw8eshrsdyevhlgs970a09n95r3gtvqvvyk24vyv4506cu6cxl8ytaywrjkhcp468qnl".to_string()),
+                    ..Default::default()
+                }
+            ])
+        });
+        swap.expect_update_status_if_matches()
+            .withf(move |id, status, failure_reason, _condition| {
+                id == swap_id
+                    && *status == SwapUpdate::InvoiceFailedToPay
+                    && failure_reason.as_deref() == Some(FAILURE_REASON_EXPIRED_INVOICE)
+            })
+            .returning(|_, _, _, _| Ok(0));
+
+        let (tx, mut rx) = tokio::sync::broadcast::channel(1);
+        let checker = InvoiceExpirationChecker::new(tx, get_currencies().await, Arc::new(swap));
+
+        checker.check().unwrap();
+
+        assert!(matches!(
+            rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
     }
 }

--- a/boltzr/src/swap/expiration/invoice_expiry.rs
+++ b/boltzr/src/swap/expiration/invoice_expiry.rs
@@ -1,6 +1,6 @@
 use crate::api::ws::types::{SwapStatus, SwapStatusNoId};
 use crate::currencies::Currencies;
-use crate::db::helpers::swap::SwapHelper;
+use crate::db::helpers::swap::{SwapCondition, SwapHelper};
 use crate::db::models::LightningSwap;
 use crate::lightning::invoice;
 use crate::swap::expiration::ExpirationChecker;
@@ -17,6 +17,22 @@ pub struct InvoiceExpirationChecker {
     update_tx: tokio::sync::broadcast::Sender<SwapStatus>,
     currencies: Currencies,
     swap_repo: Arc<dyn SwapHelper + Sync + Send>,
+}
+
+fn expirable_invoice_swaps_condition() -> SwapCondition {
+    Box::new(
+        crate::db::schema::swaps::dsl::status
+            .ne_all(serialize_swap_updates(&[
+                SwapUpdate::SwapExpired,
+                SwapUpdate::InvoicePending,
+                SwapUpdate::InvoicePaid,
+                SwapUpdate::InvoiceFailedToPay,
+                SwapUpdate::TransactionClaimed,
+                SwapUpdate::TransactionLockupFailed,
+                SwapUpdate::TransactionClaimPending,
+            ]))
+            .and(crate::db::schema::swaps::dsl::invoice.is_not_null()),
+    )
 }
 
 impl InvoiceExpirationChecker {
@@ -44,18 +60,9 @@ impl ExpirationChecker for InvoiceExpirationChecker {
 
     #[instrument(name = "InvoiceExpirationChecker::check", skip_all)]
     fn check(&self) -> anyhow::Result<()> {
-        let swaps = self.swap_repo.get_all(Box::new(
-            crate::db::schema::swaps::dsl::status
-                .ne_all(serialize_swap_updates(&[
-                    SwapUpdate::SwapExpired,
-                    SwapUpdate::InvoicePending,
-                    SwapUpdate::InvoiceFailedToPay,
-                    SwapUpdate::TransactionClaimed,
-                    SwapUpdate::TransactionLockupFailed,
-                    SwapUpdate::TransactionClaimPending,
-                ]))
-                .and(crate::db::schema::swaps::dsl::invoice.is_not_null()),
-        ))?;
+        let swaps = self
+            .swap_repo
+            .get_all(expirable_invoice_swaps_condition())?;
         trace!(
             "Checking for expired invoices of {} Submarine Swaps",
             swaps.len()
@@ -113,9 +120,13 @@ mod test {
     use crate::db::helpers::QueryResponse;
     use crate::db::helpers::swap::{SwapCondition, SwapHelper, SwapNullableCondition};
     use crate::db::models::Swap;
+    use crate::db::schema::swaps::dsl::swaps;
     use crate::swap::SwapUpdate;
     use crate::wallet::{Bitcoin, Network};
     use bip39::Mnemonic;
+    use diesel::QueryDsl;
+    use diesel::debug_query;
+    use diesel::pg::Pg;
     use mockall::{mock, predicate};
     use std::collections::HashMap;
     use std::str::FromStr;
@@ -189,6 +200,26 @@ mod test {
         let checker = InvoiceExpirationChecker::new(tx, get_currencies().await, Arc::new(swap));
 
         checker.check().unwrap();
+    }
+
+    #[test]
+    fn test_expirable_invoice_swaps_condition_excludes_all_filtered_statuses() {
+        let query = swaps.filter(expirable_invoice_swaps_condition());
+        let sql = debug_query::<Pg, _>(&query).to_string();
+
+        for status in [
+            SwapUpdate::SwapExpired,
+            SwapUpdate::InvoicePending,
+            SwapUpdate::InvoicePaid,
+            SwapUpdate::InvoiceFailedToPay,
+            SwapUpdate::TransactionClaimed,
+            SwapUpdate::TransactionLockupFailed,
+            SwapUpdate::TransactionClaimPending,
+        ] {
+            assert!(sql.contains(&status.to_string()));
+        }
+
+        assert!(sql.contains(r#""swaps"."invoice" IS NOT NULL"#));
     }
 
     #[tokio::test]

--- a/boltzr/src/swap/filters.rs
+++ b/boltzr/src/swap/filters.rs
@@ -254,11 +254,12 @@ mod test {
             fn get_by_id(&self, id: &str) -> QueryResponse<Swap>;
             fn get_all(&self, condition: SwapCondition) -> QueryResponse<Vec<Swap>>;
             fn get_all_nullable(&self, condition: SwapNullableCondition) -> QueryResponse<Vec<Swap>>;
-            fn update_status(
+            fn update_status_if_matches(
                 &self,
                 id: &str,
                 status: SwapUpdate,
                 failure_reason: Option<String>,
+                condition: SwapCondition,
             ) -> QueryResponse<usize>;
         }
     }

--- a/boltzr/src/swap/status.rs
+++ b/boltzr/src/swap/status.rs
@@ -35,6 +35,8 @@ pub enum SwapUpdate {
     InvoiceSet,
     #[strum(serialize = "invoice.pending")]
     InvoicePending,
+    #[strum(serialize = "invoice.paid")]
+    InvoicePaid,
     #[strum(serialize = "invoice.failedToPay")]
     InvoiceFailedToPay,
 

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -2019,8 +2019,9 @@ class SwapRouter extends RouterBase {
      *                   minimum: 0
      *                 limit:
      *                   type: number
-     *                   description: Number of keys to scan from startIndex. Must be provided together with startIndex. Must be at least 1
+     *                   description: Number of keys to scan from startIndex. Must be provided together with startIndex. Must be between 1 and 1000
      *                   minimum: 1
+     *                   maximum: 1000
      *         - type: object
      *           required: ["publicKey"]
      *           properties:

--- a/lib/db/repositories/ChainSwapRepository.ts
+++ b/lib/db/repositories/ChainSwapRepository.ts
@@ -333,15 +333,24 @@ class ChainSwapRepository {
     fee: number,
     userLockAmount: number,
     serverLockAmount: number,
+    acceptZeroConf?: boolean,
   ): Promise<ChainSwapInfo> =>
     Database.sequelize.transaction(async (transaction) => {
-      swap.chainSwap = await swap.chainSwap.update(
-        {
-          fee,
-          failureReason: null,
-        },
-        { transaction },
-      );
+      const chainSwapUpdate: {
+        fee: number;
+        failureReason: null;
+        acceptZeroConf?: boolean;
+      } = {
+        fee,
+        failureReason: null,
+      };
+      if (acceptZeroConf !== undefined) {
+        chainSwapUpdate.acceptZeroConf = acceptZeroConf;
+      }
+
+      swap.chainSwap = await swap.chainSwap.update(chainSwapUpdate, {
+        transaction,
+      });
       swap.receivingData = await swap.receivingData.update(
         {
           expectedAmount: userLockAmount,

--- a/lib/service/Renegotiator.ts
+++ b/lib/service/Renegotiator.ts
@@ -69,6 +69,16 @@ class Renegotiator {
           throw Errors.INVALID_QUOTE();
         }
 
+        // Only re-evaluate the zero-conf acceptance when the swap already
+        // accepts zero-conf; renegotiation must never upgrade a swap from
+        // non-zero-conf to zero-conf, only (potentially) downgrade it
+        const acceptZeroConf =
+          swap.acceptZeroConf &&
+          this.rateProvider.acceptZeroConf(
+            receivingCurrency.symbol,
+            swap.receivingData.amount!,
+          );
+
         await this.balanceCheck.checkBalance(
           swap.sendingData.symbol,
           serverLockAmount,
@@ -94,6 +104,7 @@ class Renegotiator {
               percentageFee,
               swap.receivingData.amount!,
               serverLockAmount,
+              acceptZeroConf,
             ),
             receivingCurrency.chainClient,
             this.walletManager.wallets.get(receivingCurrency.symbol)!,
@@ -149,6 +160,7 @@ class Renegotiator {
             percentageFee,
             swap.receivingData.amount!,
             serverLockAmount,
+            acceptZeroConf,
           );
 
           if (isEther) {
@@ -182,6 +194,7 @@ class Renegotiator {
             percentageFee,
             swap.receivingData.amount!,
             serverLockAmount,
+            acceptZeroConf,
           );
           await this.swapNursery.arkNursery.checkChainSwapLockup(
             receivingCurrency.arkNode,

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -4909,8 +4909,9 @@
                   },
                   "limit": {
                     "type": "number",
-                    "description": "Number of keys to scan from startIndex. Must be provided together with startIndex. Must be at least 1",
-                    "minimum": 1
+                    "description": "Number of keys to scan from startIndex. Must be provided together with startIndex. Must be between 1 and 1000",
+                    "minimum": 1,
+                    "maximum": 1000
                   }
                 }
               }

--- a/test/integration/service/Renegotiator.spec.ts
+++ b/test/integration/service/Renegotiator.spec.ts
@@ -136,6 +136,7 @@ describe('Renegotiator', () => {
         server: 123,
       }),
     },
+    acceptZeroConf: jest.fn().mockReturnValue(true),
   } as any as RateProvider;
 
   const balanceCheck = {
@@ -262,12 +263,20 @@ describe('Renegotiator', () => {
 
     describe('UTXO based chain', () => {
       test.each`
-        confirmed
-        ${true}
-        ${false}
+        confirmed | swapAcceptZeroConf | rateProviderAcceptZeroConf | expectedAcceptZeroConf | expectedRateProviderCalls
+        ${true}   | ${true}            | ${true}                    | ${true}                | ${1}
+        ${false}  | ${true}            | ${true}                    | ${true}                | ${1}
+        ${false}  | ${true}            | ${false}                   | ${false}               | ${1}
+        ${false}  | ${false}           | ${true}                    | ${false}               | ${0}
       `(
-        'should check chain swap lockups of confirmed ($confirmed) transactions',
-        async ({ confirmed }) => {
+        'should check chain swap lockups (confirmed=$confirmed, swapAcceptZeroConf=$swapAcceptZeroConf, rateProviderAcceptZeroConf=$rateProviderAcceptZeroConf)',
+        async ({
+          confirmed,
+          swapAcceptZeroConf,
+          rateProviderAcceptZeroConf,
+          expectedAcceptZeroConf,
+          expectedRateProviderCalls,
+        }) => {
           const transactionId = await bitcoinClient.sendToAddress(
             await bitcoinClient.getNewAddress(''),
             100_000,
@@ -282,6 +291,7 @@ describe('Renegotiator', () => {
 
           ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
             chainSwap: {},
+            acceptZeroConf: swapAcceptZeroConf,
             receivingData: {
               transactionId,
               symbol: 'BTC',
@@ -295,12 +305,26 @@ describe('Renegotiator', () => {
             .fn()
             .mockImplementation(async (swap) => swap);
 
+          (rateProvider.acceptZeroConf as jest.Mock).mockReturnValueOnce(
+            rateProviderAcceptZeroConf,
+          );
+
           negotiator['validateEligibility'] = jest
             .fn()
             .mockImplementation(async () => {});
 
           const quote = 94_877;
           await negotiator.acceptQuote('someId', quote);
+
+          expect(rateProvider.acceptZeroConf).toHaveBeenCalledTimes(
+            expectedRateProviderCalls,
+          );
+          if (expectedRateProviderCalls > 0) {
+            expect(rateProvider.acceptZeroConf).toHaveBeenCalledWith(
+              'BTC',
+              100_000,
+            );
+          }
 
           expect(ChainSwapRepository.setExpectedAmounts).toHaveBeenCalledTimes(
             1,
@@ -310,6 +334,7 @@ describe('Renegotiator', () => {
             5_000,
             100_000,
             quote,
+            expectedAcceptZeroConf,
           );
 
           expect(
@@ -465,6 +490,7 @@ describe('Renegotiator', () => {
 
         ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
           chainSwap: {},
+          acceptZeroConf: true,
           receivingData: {
             symbol: 'RBTC',
             amount: 100_000,
@@ -486,12 +512,19 @@ describe('Renegotiator', () => {
         const quote = 94_877;
         await negotiator.acceptQuote(swapId, quote);
 
+        expect(rateProvider.acceptZeroConf).toHaveBeenCalledTimes(1);
+        expect(rateProvider.acceptZeroConf).toHaveBeenCalledWith(
+          'RBTC',
+          100_000,
+        );
+
         expect(ChainSwapRepository.setExpectedAmounts).toHaveBeenCalledTimes(1);
         expect(ChainSwapRepository.setExpectedAmounts).toHaveBeenCalledWith(
           expect.anything(),
           5_000,
           100_000,
           quote,
+          true,
         );
 
         expect(
@@ -542,6 +575,7 @@ describe('Renegotiator', () => {
 
         ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
           chainSwap: {},
+          acceptZeroConf: true,
           receivingData: {
             symbol: 'TBTC',
             amount: 100_000,
@@ -563,12 +597,19 @@ describe('Renegotiator', () => {
         const quote = 94_877;
         await negotiator.acceptQuote(swapId, quote);
 
+        expect(rateProvider.acceptZeroConf).toHaveBeenCalledTimes(1);
+        expect(rateProvider.acceptZeroConf).toHaveBeenCalledWith(
+          'TBTC',
+          100_000,
+        );
+
         expect(ChainSwapRepository.setExpectedAmounts).toHaveBeenCalledTimes(1);
         expect(ChainSwapRepository.setExpectedAmounts).toHaveBeenCalledWith(
           expect.anything(),
           5_000,
           100_000,
           quote,
+          true,
         );
 
         expect(
@@ -620,6 +661,7 @@ describe('Renegotiator', () => {
         ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
           id: swapId,
           chainSwap: {},
+          acceptZeroConf: true,
           receivingData: {
             symbol: 'ARK',
             amount: 100_000,
@@ -645,12 +687,19 @@ describe('Renegotiator', () => {
 
         await negotiator.acceptQuote(swapId, 94_877);
 
+        expect(rateProvider.acceptZeroConf).toHaveBeenCalledTimes(1);
+        expect(rateProvider.acceptZeroConf).toHaveBeenCalledWith(
+          'ARK',
+          100_000,
+        );
+
         expect(ChainSwapRepository.setExpectedAmounts).toHaveBeenCalledTimes(1);
         expect(ChainSwapRepository.setExpectedAmounts).toHaveBeenCalledWith(
           expect.anything(),
           5_000,
           100_000,
           94_877,
+          true,
         );
 
         expect(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced pagination limit (1–1000) for rescue requests.
  * Zero-confirmation handling added to swap renegotiation (acceptZeroConf propagated).

* **Bug Fixes**
  * Added "invoice.paid" swap status for improved tracking.

* **Documentation**
  * API/OpenAPI docs updated to reflect pagination limit (maximum 1000).

* **Refactor**
  * Consolidated and optimized swap filtering logic for invoice expiration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->