### PR TITLE
feat: store found claim transactions ids

### DIFF
--- a/boltzr/migrations/2026-04-23-151018-0000_claim_transactions_swap_id_trigger/down.sql
+++ b/boltzr/migrations/2026-04-23-151018-0000_claim_transactions_swap_id_trigger/down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS trigger_claim_transactions_check_swap_exists ON claim_transactions;
+
+DROP FUNCTION IF EXISTS claim_transactions_check_swap_exists ();

--- a/boltzr/migrations/2026-04-23-151018-0000_claim_transactions_swap_id_trigger/up.sql
+++ b/boltzr/migrations/2026-04-23-151018-0000_claim_transactions_swap_id_trigger/up.sql
@@ -1,0 +1,27 @@
+-- Enforce that swap_id references an existing reverse or chain swap
+CREATE OR REPLACE FUNCTION claim_transactions_check_swap_exists () RETURNS TRIGGER AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM "reverseSwaps" WHERE id = NEW.swap_id
+        UNION ALL
+        SELECT 1 FROM "chainSwaps" WHERE id = NEW.swap_id
+    ) THEN
+        RAISE EXCEPTION 'swap_id % not found in "reverseSwaps" or "chainSwaps"', NEW.swap_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+    IF to_regclass('claim_transactions') IS NOT NULL THEN
+        DROP TRIGGER IF EXISTS trigger_claim_transactions_check_swap_exists ON claim_transactions;
+
+        CREATE TRIGGER trigger_claim_transactions_check_swap_exists BEFORE INSERT
+        OR
+        UPDATE OF swap_id ON claim_transactions FOR EACH ROW
+        EXECUTE FUNCTION claim_transactions_check_swap_exists ();
+    END IF;
+END;
+$$;

--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -8,6 +8,7 @@ import Migration from './Migration';
 import ChainSwap from './models/ChainSwap';
 import ChainSwapData from './models/ChainSwapData';
 import ChainTip from './models/ChainTip';
+import ClaimTransaction from './models/ClaimTransaction';
 import Commitment from './models/Commitment';
 import DatabaseVersion from './models/DatabaseVersion';
 import ExtraFee from './models/ExtraFee';
@@ -121,6 +122,7 @@ class Database {
       ReverseRoutingHint.sync(),
       PendingLockupTransaction.sync(),
       RefundTransaction.sync(),
+      ClaimTransaction.sync(),
       ScriptPubKey.sync(),
     ]);
   };
@@ -163,6 +165,7 @@ class Database {
     PendingEthereumTransaction.load(Database.sequelize);
     Rebroadcast.load(Database.sequelize);
     RefundTransaction.load(Database.sequelize);
+    ClaimTransaction.load(Database.sequelize);
     ScriptPubKey.load(Database.sequelize);
     Commitment.load(Database.sequelize);
 

--- a/lib/db/models/ClaimTransaction.ts
+++ b/lib/db/models/ClaimTransaction.ts
@@ -1,0 +1,42 @@
+import { DataTypes, Model, type Sequelize } from 'sequelize';
+
+type ClaimTransactionType = {
+  swapId: string;
+  symbol: string;
+  id: string;
+};
+
+class ClaimTransaction extends Model implements ClaimTransactionType {
+  declare swapId: string;
+  declare symbol: string;
+  declare id: string;
+
+  public static load = (sequelize: Sequelize): void => {
+    ClaimTransaction.init(
+      {
+        swapId: {
+          type: new DataTypes.STRING(255),
+          primaryKey: true,
+          allowNull: false,
+        },
+        symbol: {
+          type: new DataTypes.STRING(255),
+          allowNull: false,
+        },
+        id: {
+          type: new DataTypes.STRING(255),
+          allowNull: false,
+        },
+      },
+      {
+        sequelize,
+        timestamps: true,
+        underscored: true,
+        tableName: 'claim_transactions',
+      },
+    );
+  };
+}
+
+export default ClaimTransaction;
+export { ClaimTransactionType };

--- a/lib/db/repositories/ClaimTransactionRepository.ts
+++ b/lib/db/repositories/ClaimTransactionRepository.ts
@@ -1,4 +1,6 @@
 import { Op } from 'sequelize';
+import type Logger from '../../Logger';
+import { formatError } from '../../Utils';
 import ClaimTransaction, {
   type ClaimTransactionType,
 } from '../models/ClaimTransaction';
@@ -12,6 +14,19 @@ class ClaimTransactionRepository {
     });
 
     return tx[0];
+  };
+
+  public static persistTransaction = async (
+    logger: Logger,
+    claimTransaction: ClaimTransactionType,
+  ) => {
+    try {
+      await ClaimTransactionRepository.addTransaction(claimTransaction);
+    } catch (err) {
+      logger.error(
+        `Could not persist claim transaction for swap ${claimTransaction.swapId}: ${formatError(err)}`,
+      );
+    }
   };
 
   public static getTransactionForSwap = async (swapId: string) => {

--- a/lib/db/repositories/ClaimTransactionRepository.ts
+++ b/lib/db/repositories/ClaimTransactionRepository.ts
@@ -1,0 +1,32 @@
+import { Op } from 'sequelize';
+import ClaimTransaction, {
+  type ClaimTransactionType,
+} from '../models/ClaimTransaction';
+
+class ClaimTransactionRepository {
+  public static addTransaction = async (
+    claimTransaction: ClaimTransactionType,
+  ) => {
+    const tx = await ClaimTransaction.upsert(claimTransaction, {
+      returning: true,
+    });
+
+    return tx[0];
+  };
+
+  public static getTransactionForSwap = async (swapId: string) => {
+    return await ClaimTransaction.findOne({ where: { swapId } });
+  };
+
+  public static getTransactionsForSwaps = async (swapIds: string[]) => {
+    if (swapIds.length === 0) {
+      return [];
+    }
+
+    return await ClaimTransaction.findAll({
+      where: { swapId: { [Op.in]: swapIds } },
+    });
+  };
+}
+
+export default ClaimTransactionRepository;

--- a/lib/notifications/CommandHandler.ts
+++ b/lib/notifications/CommandHandler.ts
@@ -28,6 +28,7 @@ import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
 import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../db/repositories/ChainSwapRepository';
+import ClaimTransactionRepository from '../db/repositories/ClaimTransactionRepository';
 import FeeRepository from '../db/repositories/FeeRepository';
 import ReverseRoutingHintRepository from '../db/repositories/ReverseRoutingHintRepository';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
@@ -381,13 +382,18 @@ class CommandHandler {
     reverseSwaps: ReverseSwap[],
     chainSwaps: ChainSwapInfo[],
   ) => {
-    const reverseRoutingHints = new Map<string, ReverseRoutingHint>(
-      (
-        await ReverseRoutingHintRepository.getHints(
-          reverseSwaps.map((s) => s.id),
-        )
-      ).map((h) => [h.swapId, h]),
-    );
+    const [reverseRoutingHints, claimTransactions] = await Promise.all([
+      ReverseRoutingHintRepository.getHints(reverseSwaps.map((s) => s.id)).then(
+        (hints) =>
+          new Map<string, ReverseRoutingHint>(hints.map((h) => [h.swapId, h])),
+      ),
+      ClaimTransactionRepository.getTransactionsForSwaps([
+        ...reverseSwaps.map((s) => s.id),
+        ...chainSwaps.map((s) => s.id),
+      ]).then(
+        (txs) => new Map<string, string>(txs.map((t) => [t.swapId, t.id])),
+      ),
+    ]);
 
     for (const swap of swaps) {
       await this.sendSwapInfo(swap);
@@ -430,10 +436,23 @@ class CommandHandler {
           }
         }
       }
+
+      const claimTransactionId = claimTransactions.get(reverseSwap.id);
+      if (claimTransactionId !== undefined) {
+        reverseSwap.dataValues.claimTransactionId = claimTransactionId;
+      }
+
       await this.sendSwapInfo(reverseSwap);
     }
 
-    for (const chainSwap of chainSwaps) {
+    for (const chainSwap of chainSwaps as (ChainSwapInfo & {
+      claimTransactionId?: string;
+    })[]) {
+      const claimTransactionId = claimTransactions.get(chainSwap.id);
+      if (claimTransactionId !== undefined) {
+        chainSwap.claimTransactionId = claimTransactionId;
+      }
+
       await this.sendSwapInfo(chainSwap);
     }
 

--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -476,17 +476,17 @@ class EthereumNursery extends TypedEventEmitter<{
             `Found claim in ${this.ethereumManager.networkDetails.name} EtherSwap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
           );
 
-          await ClaimTransactionRepository.addTransaction({
-            swapId: swap.id,
-            symbol: this.ethereumManager.networkDetails.symbol,
-            id: transactionHash,
-          });
-
           this.emit('claim', {
             swap,
             preimage,
             isEtherSwap: true,
             transactionHash,
+          });
+
+          await ClaimTransactionRepository.persistTransaction(this.logger, {
+            swapId: swap.id,
+            symbol: this.ethereumManager.networkDetails.symbol,
+            id: transactionHash,
           });
         }
       },
@@ -550,17 +550,17 @@ class EthereumNursery extends TypedEventEmitter<{
             `Found claim in ${this.ethereumManager.networkDetails.name} ERC20Swap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
           );
 
-          await ClaimTransactionRepository.addTransaction({
-            swapId: swap.id,
-            symbol: this.getUserClaimChainSymbol(swap),
-            id: transactionHash,
-          });
-
           this.emit('claim', {
             swap,
             preimage,
             isEtherSwap: false,
             transactionHash,
+          });
+
+          await ClaimTransactionRepository.persistTransaction(this.logger, {
+            swapId: swap.id,
+            symbol: this.getUserClaimChainSymbol(swap),
+            id: transactionHash,
           });
         }
       },

--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -23,6 +23,7 @@ import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
 import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../db/repositories/ChainSwapRepository';
+import ClaimTransactionRepository from '../db/repositories/ClaimTransactionRepository';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
 import SwapRepository from '../db/repositories/SwapRepository';
 import type Wallet from '../wallet/Wallet';
@@ -64,6 +65,7 @@ class EthereumNursery extends TypedEventEmitter<{
     swap: ReverseSwap | ChainSwapInfo;
     preimage: Buffer;
     isEtherSwap: boolean;
+    transactionHash: string;
   };
 }> {
   private readonly contractTransactionTracker: EthereumTransactionConfirmationTracker;
@@ -474,7 +476,18 @@ class EthereumNursery extends TypedEventEmitter<{
             `Found claim in ${this.ethereumManager.networkDetails.name} EtherSwap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
           );
 
-          this.emit('claim', { swap, preimage, isEtherSwap: true });
+          await ClaimTransactionRepository.addTransaction({
+            swapId: swap.id,
+            symbol: this.ethereumManager.networkDetails.symbol,
+            id: transactionHash,
+          });
+
+          this.emit('claim', {
+            swap,
+            preimage,
+            isEtherSwap: true,
+            transactionHash,
+          });
         }
       },
     );
@@ -537,7 +550,18 @@ class EthereumNursery extends TypedEventEmitter<{
             `Found claim in ${this.ethereumManager.networkDetails.name} ERC20Swap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
           );
 
-          this.emit('claim', { swap, preimage, isEtherSwap: false });
+          await ClaimTransactionRepository.addTransaction({
+            swapId: swap.id,
+            symbol: this.getUserClaimChainSymbol(swap),
+            id: transactionHash,
+          });
+
+          this.emit('claim', {
+            swap,
+            preimage,
+            isEtherSwap: false,
+            transactionHash,
+          });
         }
       },
     );
@@ -649,6 +673,17 @@ class EthereumNursery extends TypedEventEmitter<{
     }
 
     return (swap as ChainSwapInfo).receivingData.symbol;
+  };
+
+  private getUserClaimChainSymbol = (
+    swap: ReverseSwap | ChainSwapInfo,
+  ): string => {
+    if (swap.type === SwapType.ReverseSubmarine) {
+      const { base, quote } = splitPairId(swap.pair);
+      return getChainCurrency(base, quote, swap.orderSide, true);
+    }
+
+    return (swap as ChainSwapInfo).sendingData.symbol;
   };
 
   private getSwapExpectedReceivingAmount = (swap: Swap | ChainSwapInfo) =>

--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -32,6 +32,7 @@ import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
 import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../db/repositories/ChainSwapRepository';
+import ClaimTransactionRepository from '../db/repositories/ClaimTransactionRepository';
 import RefundTransactionRepository from '../db/repositories/RefundTransactionRepository';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
 import SwapRepository from '../db/repositories/SwapRepository';
@@ -391,6 +392,12 @@ class UtxoNursery extends TypedEventEmitter<{
       }: ${transaction.getId()}`,
     );
 
+    await ClaimTransactionRepository.addTransaction({
+      swapId: reverseSwap.id,
+      symbol: chainClient.symbol,
+      id: transaction.getId(),
+    });
+
     this.emit('reverseSwap.claimed', {
       reverseSwap,
       preimage: reverseSwap.preimage
@@ -422,6 +429,20 @@ class UtxoNursery extends TypedEventEmitter<{
     );
     if (swap === null) {
       return;
+    }
+
+    // Only persist user claims: the user claims by spending the server's lockup (sendingData).
+    // Spends of the user's lockup (receivingData) are Boltz's own claims. This runs before
+    // the witness-length filter so cooperative user claims (witness length 1) are persisted too.
+    if (
+      transactionHashToId(input.hash) === swap.sendingData.transactionId &&
+      input.index === swap.sendingData.transactionVout
+    ) {
+      await ClaimTransactionRepository.addTransaction({
+        swapId: swap.id,
+        symbol: chainClient.symbol,
+        id: transaction.getId(),
+      });
     }
 
     if (transaction.ins[inputIndex].witness.length !== 4) {

--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -392,17 +392,17 @@ class UtxoNursery extends TypedEventEmitter<{
       }: ${transaction.getId()}`,
     );
 
-    await ClaimTransactionRepository.addTransaction({
-      swapId: reverseSwap.id,
-      symbol: chainClient.symbol,
-      id: transaction.getId(),
-    });
-
     this.emit('reverseSwap.claimed', {
       reverseSwap,
       preimage: reverseSwap.preimage
         ? getHexBuffer(reverseSwap.preimage)
         : detectPreimage(inputIndex, transaction),
+    });
+
+    await ClaimTransactionRepository.persistTransaction(this.logger, {
+      swapId: reverseSwap.id,
+      symbol: chainClient.symbol,
+      id: transaction.getId(),
     });
   };
 
@@ -434,21 +434,27 @@ class UtxoNursery extends TypedEventEmitter<{
     // Only persist user claims: the user claims by spending the server's lockup (sendingData).
     // Spends of the user's lockup (receivingData) are Boltz's own claims. This runs before
     // the witness-length filter so cooperative user claims (witness length 1) are persisted too.
-    if (
+    const isUserClaim =
       transactionHashToId(input.hash) === swap.sendingData.transactionId &&
-      input.index === swap.sendingData.transactionVout
-    ) {
-      await ClaimTransactionRepository.addTransaction({
+      input.index === swap.sendingData.transactionVout;
+
+    const persistUserClaim = async () => {
+      if (!isUserClaim) {
+        return;
+      }
+      await ClaimTransactionRepository.persistTransaction(this.logger, {
         swapId: swap.id,
         symbol: chainClient.symbol,
         id: transaction.getId(),
       });
-    }
+    };
 
     if (transaction.ins[inputIndex].witness.length !== 4) {
       this.logger.debug(
         `Not scanning ${chainClient.symbol} transaction ${transaction.getId()} for claims because it is a cooperative claim or refund transaction`,
       );
+
+      await persistUserClaim();
       return;
     }
 
@@ -464,6 +470,8 @@ class UtxoNursery extends TypedEventEmitter<{
         ? getHexBuffer(swap.preimage)
         : detectPreimage(inputIndex, transaction),
     });
+
+    await persistUserClaim();
   };
 
   private listenBlocks = (chainClient: IChainClient, wallet: Wallet) => {

--- a/test/integration/db/repositories/ClaimTransactionRepository.spec.ts
+++ b/test/integration/db/repositories/ClaimTransactionRepository.spec.ts
@@ -55,6 +55,45 @@ describe('ClaimTransactionRepository', () => {
     expect(fetched!.id).toEqual('test2');
   });
 
+  describe('persistTransaction', () => {
+    test('should persist transaction', async () => {
+      await ClaimTransactionRepository.persistTransaction(
+        Logger.disabledLogger,
+        { swapId: 'swapId', symbol: 'RBTC', id: 'persistTest' },
+      );
+
+      const fetched =
+        await ClaimTransactionRepository.getTransactionForSwap('swapId');
+      expect(fetched).not.toBeNull();
+      expect(fetched!.id).toEqual('persistTest');
+    });
+
+    test('should swallow and log errors from addTransaction', async () => {
+      const addSpy = jest
+        .spyOn(ClaimTransactionRepository, 'addTransaction')
+        .mockRejectedValueOnce(new Error('db down'));
+      const errorSpy = jest.fn();
+      const logger = {
+        ...Logger.disabledLogger,
+        error: errorSpy,
+      } as unknown as Logger;
+
+      await expect(
+        ClaimTransactionRepository.persistTransaction(logger, {
+          swapId: 'swapId',
+          symbol: 'RBTC',
+          id: 'persistFail',
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain('swapId');
+      expect(errorSpy.mock.calls[0][0]).toContain('db down');
+
+      addSpy.mockRestore();
+    });
+  });
+
   describe('getTransactionForSwap', () => {
     test('should get transaction for swap', async () => {
       const swapId = 'swapId';

--- a/test/integration/db/repositories/ClaimTransactionRepository.spec.ts
+++ b/test/integration/db/repositories/ClaimTransactionRepository.spec.ts
@@ -1,0 +1,118 @@
+import Logger from '../../../../lib/Logger';
+import Database from '../../../../lib/db/Database';
+import ClaimTransaction from '../../../../lib/db/models/ClaimTransaction';
+import ClaimTransactionRepository from '../../../../lib/db/repositories/ClaimTransactionRepository';
+
+describe('ClaimTransactionRepository', () => {
+  const db = new Database(Logger.disabledLogger, Database.memoryDatabase);
+
+  beforeAll(async () => {
+    await db.init();
+  });
+
+  beforeEach(async () => {
+    await ClaimTransaction.truncate();
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  test('should add claim transaction', async () => {
+    const tx = await ClaimTransactionRepository.addTransaction({
+      swapId: 'swapId',
+      symbol: 'RBTC',
+      id: 'test',
+    });
+
+    expect(tx).not.toBeNull();
+    expect(tx.swapId).toEqual('swapId');
+    expect(tx.symbol).toEqual('RBTC');
+    expect(tx.id).toEqual('test');
+  });
+
+  test('should upsert claim transaction', async () => {
+    const swapId = 'swapId';
+
+    await ClaimTransactionRepository.addTransaction({
+      swapId,
+      symbol: 'RBTC',
+      id: 'test',
+    });
+
+    const upsert = await ClaimTransactionRepository.addTransaction({
+      swapId,
+      symbol: 'RBTC',
+      id: 'test2',
+    });
+
+    expect(upsert).not.toBeNull();
+    expect(upsert.id).toEqual('test2');
+
+    const fetched =
+      await ClaimTransactionRepository.getTransactionForSwap(swapId);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toEqual('test2');
+  });
+
+  describe('getTransactionForSwap', () => {
+    test('should get transaction for swap', async () => {
+      const swapId = 'swapId';
+      const transactionId = 'txId';
+
+      await ClaimTransactionRepository.addTransaction({
+        swapId,
+        id: transactionId,
+        symbol: 'RBTC',
+      });
+
+      const tx = await ClaimTransactionRepository.getTransactionForSwap(swapId);
+
+      expect(tx).not.toBeNull();
+      expect(tx!.swapId).toEqual(swapId);
+      expect(tx!.id).toEqual(transactionId);
+      expect(tx!.symbol).toEqual('RBTC');
+    });
+
+    test('should return null when no transaction exists for swap', async () => {
+      await expect(
+        ClaimTransactionRepository.getTransactionForSwap('not found'),
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe('getTransactionsForSwaps', () => {
+    test('should return an empty array when given no swap ids', async () => {
+      await expect(
+        ClaimTransactionRepository.getTransactionsForSwaps([]),
+      ).resolves.toEqual([]);
+    });
+
+    test('should return transactions for matching swap ids only', async () => {
+      await ClaimTransactionRepository.addTransaction({
+        swapId: 'swapA',
+        symbol: 'RBTC',
+        id: 'txA',
+      });
+      await ClaimTransactionRepository.addTransaction({
+        swapId: 'swapB',
+        symbol: 'USDT',
+        id: 'txB',
+      });
+      await ClaimTransactionRepository.addTransaction({
+        swapId: 'swapC',
+        symbol: 'BTC',
+        id: 'txC',
+      });
+
+      const txs = await ClaimTransactionRepository.getTransactionsForSwaps([
+        'swapA',
+        'swapC',
+        'notFound',
+      ]);
+
+      expect(txs).toHaveLength(2);
+      expect(txs.map((t) => t.swapId).sort()).toEqual(['swapA', 'swapC']);
+    });
+  });
+});

--- a/test/unit/notifications/CommandHandler.spec.ts
+++ b/test/unit/notifications/CommandHandler.spec.ts
@@ -19,6 +19,7 @@ import Stats from '../../../lib/data/Stats';
 import Database from '../../../lib/db/Database';
 import ReverseRoutingHint from '../../../lib/db/models/ReverseRoutingHint';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
+import ClaimTransactionRepository from '../../../lib/db/repositories/ClaimTransactionRepository';
 import FeeRepository from '../../../lib/db/repositories/FeeRepository';
 import PairRepository from '../../../lib/db/repositories/PairRepository';
 import ReverseRoutingHintRepository from '../../../lib/db/repositories/ReverseRoutingHintRepository';
@@ -236,6 +237,12 @@ describe('CommandHandler', () => {
     await ReverseSwapRepository.addReverseSwap(reverseSwapExample);
     await ReverseSwapRepository.addReverseSwap(pendingReverseSwapExample);
     await ReverseRoutingHintRepository.addHint(reverseRoutingHintExample);
+
+    await ClaimTransactionRepository.addTransaction({
+      swapId: reverseSwapExample.id,
+      symbol: 'RBTC',
+      id: 'reverseClaimTxHash',
+    });
   });
 
   beforeEach(() => {
@@ -346,6 +353,7 @@ describe('CommandHandler', () => {
         scriptPubkey: reverseRoutingHint!.scriptPubkey.toString('hex'),
         signature: reverseRoutingHint!.signature.toString('hex'),
       };
+      reverseSwapWithHint!.dataValues.claimTransactionId = 'reverseClaimTxHash';
 
       expect(mockSendMessage).toHaveBeenCalledTimes(2);
       expect(mockSendMessage).toHaveBeenCalledWith(
@@ -370,6 +378,53 @@ describe('CommandHandler', () => {
 
       expect(mockSendMessage).toHaveBeenCalledTimes(4);
       expect(mockSendMessage).toHaveBeenCalledWith(`${errorMessage}${id}`);
+    });
+
+    test('should attach claim transaction id to chain swaps', async () => {
+      const chainSwapId = 'chainClaimed';
+      const mockChainSwap = {
+        id: chainSwapId,
+        type: SwapType.Chain,
+        chainSwap: { dataValues: {} },
+        sendingData: {},
+        receivingData: {},
+      } as any;
+
+      const getSwapsSpy = jest
+        .spyOn(SwapRepository, 'getSwaps')
+        .mockResolvedValue([]);
+      const getReverseSwapsSpy = jest
+        .spyOn(ReverseSwapRepository, 'getReverseSwaps')
+        .mockResolvedValue([]);
+      const getChainSwapsByDataSpy = jest
+        .spyOn(ChainSwapRepository, 'getChainSwapsByData')
+        .mockResolvedValue([mockChainSwap]);
+      const getClaimsSpy = jest
+        .spyOn(ClaimTransactionRepository, 'getTransactionsForSwaps')
+        .mockResolvedValue([
+          { swapId: chainSwapId, id: 'chainClaimTxHash' } as any,
+        ]);
+
+      try {
+        sendMessage(`swapinfo ${chainSwapId}`);
+        await wait(commandWaitMs);
+
+        expect(
+          ClaimTransactionRepository.getTransactionsForSwaps,
+        ).toHaveBeenCalledWith([chainSwapId]);
+
+        expect(mockSendMessage).toHaveBeenCalledWith(
+          `Chain Swap \`${chainSwapId}\`:\n\`\`\`${stringify({
+            ...mockChainSwap,
+            claimTransactionId: 'chainClaimTxHash',
+          })}\`\`\``,
+        );
+      } finally {
+        getSwapsSpy.mockRestore();
+        getReverseSwapsSpy.mockRestore();
+        getChainSwapsByDataSpy.mockRestore();
+        getClaimsSpy.mockRestore();
+      }
     });
 
     test.each`

--- a/test/unit/swap/EthereumNursery.spec.ts
+++ b/test/unit/swap/EthereumNursery.spec.ts
@@ -750,6 +750,33 @@ describe('EthereumNursery', () => {
     expect(emittedEvents).toEqual(1);
   });
 
+  test('should still emit EtherSwap claim when persistence fails', async () => {
+    mockGetReverseSwapResult = {
+      id: 'reverseEthResilience',
+      type: SwapType.ReverseSubmarine,
+    };
+
+    ClaimTransactionRepository.addTransaction = jest
+      .fn()
+      .mockRejectedValue(new Error('db down'));
+
+    let emittedEvents = 0;
+    nursery.on('claim', () => {
+      emittedEvents += 1;
+    });
+
+    await expect(
+      emitEthClaim({
+        preimage: examplePreimage,
+        preimageHash: examplePreimageHash,
+        transactionHash: exampleTransaction.hash!,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(emittedEvents).toEqual(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(1);
+  });
+
   test('should only emit EtherSwap chain claims for the sending side', async () => {
     mockGetReverseSwapResult = null;
     const getChainSwap = jest.fn();
@@ -1210,6 +1237,35 @@ describe('EthereumNursery', () => {
     expect(mockGetReverseSwap).toHaveBeenCalledTimes(2);
 
     expect(emittedEvents).toEqual(1);
+  });
+
+  test('should still emit ERC20Swap claim when persistence fails', async () => {
+    mockGetReverseSwapResult = {
+      id: 'reverseErc20Resilience',
+      pair: 'USDT/BTC',
+      orderSide: OrderSide.BUY,
+      type: SwapType.ReverseSubmarine,
+    };
+
+    ClaimTransactionRepository.addTransaction = jest
+      .fn()
+      .mockRejectedValue(new Error('db down'));
+
+    let emittedEvents = 0;
+    nursery.on('claim', () => {
+      emittedEvents += 1;
+    });
+
+    await expect(
+      emitErc20Claim({
+        preimage: examplePreimage,
+        preimageHash: examplePreimageHash,
+        transactionHash: exampleTransaction.hash!,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(emittedEvents).toEqual(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(1);
   });
 
   test('should only emit ERC20Swap chain claims for the sending side', async () => {

--- a/test/unit/swap/EthereumNursery.spec.ts
+++ b/test/unit/swap/EthereumNursery.spec.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../../lib/consts/Types';
 import type Swap from '../../../lib/db/models/Swap';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
+import ClaimTransactionRepository from '../../../lib/db/repositories/ClaimTransactionRepository';
 import ReverseSwapRepository from '../../../lib/db/repositories/ReverseSwapRepository';
 import SwapRepository from '../../../lib/db/repositories/SwapRepository';
 import WrappedSwapRepository from '../../../lib/db/repositories/WrappedSwapRepository';
@@ -250,6 +251,8 @@ describe('EthereumNursery', () => {
     ChainSwapRepository.getChainSwapsExpirable = jest
       .fn()
       .mockResolvedValue([]);
+
+    ClaimTransactionRepository.addTransaction = jest.fn().mockResolvedValue({});
 
     WrappedSwapRepository.setStatus = mockSetReverseSwapStatus;
 
@@ -700,7 +703,7 @@ describe('EthereumNursery', () => {
     let emittedEvents = 0;
 
     mockGetReverseSwapResult = {
-      some: 'data',
+      id: 'reverseEth',
       type: SwapType.ReverseSubmarine,
     };
 
@@ -726,6 +729,12 @@ describe('EthereumNursery', () => {
     });
 
     expect(emittedEvents).toEqual(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+      swapId: mockGetReverseSwapResult.id,
+      symbol: networks.Ethereum.symbol,
+      id: exampleTransaction.hash!,
+    });
 
     // No suitable Swap in database
     mockGetReverseSwapResult = null;
@@ -793,8 +802,15 @@ describe('EthereumNursery', () => {
         isEtherSwap: true,
         preimage: examplePreimage,
         swap: sendingSideSwap,
+        transactionHash: exampleTransaction.hash!,
       },
     ]);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+      swapId: sendingSideSwap.id,
+      symbol: networks.Ethereum.symbol,
+      id: exampleTransaction.hash!,
+    });
   });
 
   test('should listen for ERC20Swap lockup events', async () => {
@@ -1147,7 +1163,10 @@ describe('EthereumNursery', () => {
     let emittedEvents = 0;
 
     mockGetReverseSwapResult = {
-      some: 'data',
+      id: 'reverseErc20',
+      pair: 'USDT/BTC',
+      orderSide: OrderSide.BUY,
+      type: SwapType.ReverseSubmarine,
     };
 
     nursery.on('claim', ({ swap, preimage }) => {
@@ -1172,6 +1191,12 @@ describe('EthereumNursery', () => {
     });
 
     expect(emittedEvents).toEqual(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+      swapId: mockGetReverseSwapResult.id,
+      symbol: 'USDT',
+      id: exampleTransaction.hash!,
+    });
 
     // No suitable Swap in database
     mockGetReverseSwapResult = null;
@@ -1239,8 +1264,15 @@ describe('EthereumNursery', () => {
         isEtherSwap: false,
         preimage: examplePreimage,
         swap: sendingSideSwap,
+        transactionHash: exampleTransaction.hash!,
       },
     ]);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+      swapId: sendingSideSwap.id,
+      symbol: sendingSideSwap.sendingData.symbol,
+      id: exampleTransaction.hash!,
+    });
   });
 
   test('should handle expired Swaps', async () => {

--- a/test/unit/swap/UtxoNursery.spec.ts
+++ b/test/unit/swap/UtxoNursery.spec.ts
@@ -826,6 +826,38 @@ describe('UtxoNursery', () => {
     expect(mockGetReverseSwap).not.toHaveBeenCalled();
   });
 
+  test('should still emit reverseSwap.claimed when persistence fails', async () => {
+    RefundTransactionRepository.getTransaction = jest
+      .fn()
+      .mockResolvedValue(null);
+
+    const transaction = Transaction.fromHex(sampleTransactions.claim);
+
+    mockGetReverseSwapResult = { id: 'reverseClaimResilience' };
+
+    ClaimTransactionRepository.addTransaction = jest
+      .fn()
+      .mockRejectedValue(new Error('db down'));
+
+    let eventEmitted = false;
+    nursery.once('reverseSwap.claimed', () => {
+      eventEmitted = true;
+    });
+
+    try {
+      await expect(
+        nursery['checkSwapClaims'](btcChainClient, transaction),
+      ).resolves.toBeUndefined();
+
+      expect(eventEmitted).toEqual(true);
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(
+        1,
+      );
+    } finally {
+      mockGetReverseSwapResult = null;
+    }
+  });
+
   describe('chain swap claim persistence', () => {
     const spentHash = Buffer.alloc(32, 7);
     const spentVout = 3;
@@ -919,6 +951,47 @@ describe('UtxoNursery', () => {
 
       expect(eventEmitted).toEqual(true);
       expect(ClaimTransactionRepository.addTransaction).not.toHaveBeenCalled();
+    });
+
+    test('should still emit when persistence fails (sendingData)', async () => {
+      RefundTransactionRepository.getTransaction = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      const mockChainSwap = {
+        id: 'chainSwapId',
+        preimage: getHexString(Buffer.alloc(32, 1)),
+        chainSwap: { id: 'chainSwapId' },
+        sendingData: {
+          transactionId: transactionHashToId(spentHash),
+          transactionVout: spentVout,
+        },
+        receivingData: {
+          transactionId: 'other',
+          transactionVout: 0,
+        },
+      };
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(mockChainSwap);
+
+      ClaimTransactionRepository.addTransaction = jest
+        .fn()
+        .mockRejectedValue(new Error('db down'));
+
+      let eventEmitted = false;
+      nursery.once('chainSwap.claimed', () => {
+        eventEmitted = true;
+      });
+
+      await expect(
+        nursery['checkSwapClaims'](btcChainClient, fakeTransaction),
+      ).resolves.toBeUndefined();
+
+      expect(eventEmitted).toEqual(true);
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     test('should persist cooperative user claims (witness length 1)', async () => {

--- a/test/unit/swap/UtxoNursery.spec.ts
+++ b/test/unit/swap/UtxoNursery.spec.ts
@@ -7,7 +7,11 @@ import { createMusig, setup, tweakMusig } from '../../../lib/Core';
 import * as Core from '../../../lib/Core';
 import { ECPair } from '../../../lib/ECPairHelper';
 import Logger from '../../../lib/Logger';
-import { getHexBuffer, transactionHashToId } from '../../../lib/Utils';
+import {
+  getHexBuffer,
+  getHexString,
+  transactionHashToId,
+} from '../../../lib/Utils';
 import ChainClient from '../../../lib/chain/ChainClient';
 import {
   CurrencyType,
@@ -17,6 +21,7 @@ import {
   SwapVersion,
 } from '../../../lib/consts/Enums';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
+import ClaimTransactionRepository from '../../../lib/db/repositories/ClaimTransactionRepository';
 import RefundTransactionRepository from '../../../lib/db/repositories/RefundTransactionRepository';
 import ReverseSwapRepository from '../../../lib/db/repositories/ReverseSwapRepository';
 import SwapRepository from '../../../lib/db/repositories/SwapRepository';
@@ -217,6 +222,8 @@ describe('UtxoNursery', () => {
     ChainSwapRepository.getChainSwapsExpirable = jest
       .fn()
       .mockResolvedValue([]);
+
+    ClaimTransactionRepository.addTransaction = jest.fn().mockResolvedValue({});
 
     WrappedSwapRepository.setStatus = mockSetStatus;
 
@@ -791,6 +798,13 @@ describe('UtxoNursery', () => {
       transactionId: transactionHashToId(transaction.ins[0].hash),
     });
 
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(1);
+    expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+      swapId: mockGetReverseSwapResult.id,
+      symbol: btcChainClient.symbol,
+      id: transaction.getId(),
+    });
+
     jest.clearAllMocks();
 
     // Should ignore transactions that are refunds of a Reverse Swap
@@ -810,6 +824,155 @@ describe('UtxoNursery', () => {
     await checkReverseSwapsClaims(btcChainClient, transaction);
 
     expect(mockGetReverseSwap).not.toHaveBeenCalled();
+  });
+
+  describe('chain swap claim persistence', () => {
+    const spentHash = Buffer.alloc(32, 7);
+    const spentVout = 3;
+    const transactionId = 'chainClaimTxId';
+    const fakeTransaction = {
+      getId: () => transactionId,
+      ins: [
+        {
+          hash: spentHash,
+          index: spentVout,
+          // Non-cooperative chain swap claim has 4 witness elements
+          witness: [
+            Buffer.alloc(0),
+            Buffer.alloc(0),
+            Buffer.alloc(0),
+            Buffer.alloc(0),
+          ],
+        },
+      ],
+    } as any;
+
+    test('should persist when spend matches sendingData (user claim)', async () => {
+      RefundTransactionRepository.getTransaction = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      const mockChainSwap = {
+        id: 'chainSwapId',
+        preimage: getHexString(Buffer.alloc(32, 1)),
+        chainSwap: { id: 'chainSwapId' },
+        sendingData: {
+          transactionId: transactionHashToId(spentHash),
+          transactionVout: spentVout,
+        },
+        receivingData: {
+          transactionId: 'other',
+          transactionVout: 0,
+        },
+      };
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(mockChainSwap);
+
+      let eventEmitted = false;
+      nursery.once('chainSwap.claimed', ({ swap }) => {
+        expect(swap).toEqual(mockChainSwap);
+        eventEmitted = true;
+      });
+
+      await nursery['checkSwapClaims'](btcChainClient, fakeTransaction);
+
+      expect(eventEmitted).toEqual(true);
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+        swapId: mockChainSwap.id,
+        symbol: btcChainClient.symbol,
+        id: transactionId,
+      });
+    });
+
+    test('should not persist when spend matches receivingData (server claim)', async () => {
+      RefundTransactionRepository.getTransaction = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      const mockChainSwap = {
+        id: 'chainSwapId',
+        preimage: getHexString(Buffer.alloc(32, 1)),
+        chainSwap: { id: 'chainSwapId' },
+        sendingData: {
+          transactionId: 'other',
+          transactionVout: 0,
+        },
+        receivingData: {
+          transactionId: transactionHashToId(spentHash),
+          transactionVout: spentVout,
+        },
+      };
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(mockChainSwap);
+
+      let eventEmitted = false;
+      nursery.once('chainSwap.claimed', () => {
+        eventEmitted = true;
+      });
+
+      await nursery['checkSwapClaims'](btcChainClient, fakeTransaction);
+
+      expect(eventEmitted).toEqual(true);
+      expect(ClaimTransactionRepository.addTransaction).not.toHaveBeenCalled();
+    });
+
+    test('should persist cooperative user claims (witness length 1)', async () => {
+      RefundTransactionRepository.getTransaction = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      const mockChainSwap = {
+        id: 'chainSwapId',
+        preimage: getHexString(Buffer.alloc(32, 1)),
+        chainSwap: { id: 'chainSwapId' },
+        sendingData: {
+          transactionId: transactionHashToId(spentHash),
+          transactionVout: spentVout,
+        },
+        receivingData: {
+          transactionId: 'other',
+          transactionVout: 0,
+        },
+      };
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(mockChainSwap);
+
+      const coopTransaction = {
+        getId: () => transactionId,
+        ins: [
+          {
+            hash: spentHash,
+            index: spentVout,
+            // Cooperative musig aggregated signature has one witness element
+            witness: [Buffer.alloc(0)],
+          },
+        ],
+      } as any;
+
+      let eventEmitted = false;
+      nursery.once('chainSwap.claimed', () => {
+        eventEmitted = true;
+      });
+
+      await nursery['checkSwapClaims'](btcChainClient, coopTransaction);
+
+      // Cooperative claims are filtered from the emit, but still persisted
+      expect(eventEmitted).toEqual(false);
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+        swapId: mockChainSwap.id,
+        symbol: btcChainClient.symbol,
+        id: transactionId,
+      });
+    });
   });
 
   test('should handle confirmed Reverse Swap lockups via block events', async () => {


### PR DESCRIPTION
Closes https://github.com/BoltzExchange/boltz-backend/issues/1368

Important limitation is that we do not scan for cooperative claim transactions on UTXO based chains because we already get the preimage from the cooperative signing flow. So, those will not be saved in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track and persist claim transaction details (transaction IDs and chain symbols) when claims occur.
  * Include claimTransactionId and transactionHash in swap notification payloads and claim events.
  * Add validation to ensure claim transactions reference existing swaps.

* **Tests**
  * Added extensive tests covering claim transaction persistence, retrieval, notification integration, and resilience when persistence fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->