### PR TITLE
fix: tolerate positive slippage

### DIFF
--- a/docs/commitment-swaps.md
+++ b/docs/commitment-swaps.md
@@ -147,12 +147,13 @@ POST /v2/commitment/{currency}
 }
 ```
 
-| Field             | Required | Description                                            |
-| ----------------- | -------- | ------------------------------------------------------ |
-| `swapId`          | Yes      | ID of the swap this commitment is for                  |
-| `signature`       | Yes      | EIP-712 commitment signature (hex encoded)             |
-| `transactionHash` | Yes      | Transaction hash containing the lockup                 |
-| `logIndex`        | No       | Log index if multiple lockups exist in the transaction |
+| Field                      | Required | Description                                              |
+| -------------------------- | -------- | -------------------------------------------------------- |
+| `swapId`                   | Yes      | ID of the swap this commitment is for                    |
+| `signature`                | Yes      | EIP-712 commitment signature (hex encoded)               |
+| `transactionHash`          | Yes      | Transaction hash containing the lockup                   |
+| `logIndex`                 | No       | Log index if multiple lockups exist in the transaction   |
+| `maxOverpaymentPercentage` | No       | Override for the configured positive-slippage percentage |
 
 **Response:** `201 Created` with empty object `{}`
 
@@ -189,7 +190,8 @@ For Submarine Swaps where you send EVM assets to receive Lightning:
    your tokens.
 
 4. **Create the commitment signature** using EIP-712 with the actual locked
-   amount
+   amount. The committed amount must not be below the swap amount and may only
+   exceed it within the configured positive-slippage tolerance.
 
 5. **Submit the commitment**:
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -196,8 +196,9 @@ A Chain Swap is eligible for renegotiation only if:
 - The swap status is `transaction.lockupFailed`
 - The status was set because of over- or underpayment
 - No refund signature has been created yet for the swap
-- The actual amount locked by the client still falls within the pair's minimal
-  and maximal limits
+- The actual amount locked by the client respects the pair's minimal limit and
+  does not exceed the maximal limit beyond the configured positive-slippage
+  tolerance
 - There is at least 60 minutes remaining until the swap expires
 
 Requesting and accepting a new quote is optional; swap clients may revert to

--- a/docs/renegotiating.md
+++ b/docs/renegotiating.md
@@ -59,10 +59,11 @@ be refunded instead.
 
 ### Amount Within Pair Limits
 
-The actual locked amount must fall within the pair's minimum and maximum limits.
-Boltz also validates liquidity availability before accepting renegotiation. If
-the new amount exceeds pair limits or liquidity is insufficient, renegotiation
-is not possible.
+The actual locked amount must respect the pair's minimum limit. Positive
+slippage above the maximum limit is accepted only within the configured
+overpayment tolerance. Boltz also validates liquidity availability before
+accepting renegotiation. If the new amount exceeds the allowed limit or
+liquidity is insufficient, renegotiation is not possible.
 
 ## API
 

--- a/lib/Boltz.ts
+++ b/lib/Boltz.ts
@@ -34,6 +34,7 @@ import NotificationProvider from './notifications/NotificationProvider';
 import Service from './service/Service';
 import Sidecar from './sidecar/Sidecar';
 import NodeSwitch from './swap/NodeSwitch';
+import OverpaymentProtector from './swap/OverpaymentProtector';
 import type { Currency } from './wallet/WalletManager';
 import WalletManager from './wallet/WalletManager';
 import EthereumManager from './wallet/ethereum/EthereumManager';
@@ -133,6 +134,11 @@ class Boltz {
       );
     });
 
+    const overpaymentProtector = new OverpaymentProtector(
+      this.logger,
+      this.config.swap.overpayment,
+    );
+
     this.ethereumManagers = [
       { network: networks.Ethereum, config: this.config.ethereum },
       { network: networks.Rootstock, config: this.config.rsk },
@@ -144,7 +150,7 @@ class Boltz {
             this.logger,
             network,
             config!,
-            this.config.swap.overpayment,
+            overpaymentProtector,
           );
         } catch (error) {
           this.logger.warn(
@@ -192,6 +198,7 @@ class Boltz {
         this.sidecar,
         this.config.swap,
         this.routingFee,
+        overpaymentProtector,
       );
 
       if (notificationClient !== undefined) {

--- a/lib/service/Renegotiator.ts
+++ b/lib/service/Renegotiator.ts
@@ -1,3 +1,4 @@
+import type { OverPaymentConfig } from '../Config';
 import { parseTransaction } from '../Core';
 import type Logger from '../Logger';
 import { isTxConfirmed } from '../Utils';
@@ -20,6 +21,7 @@ import FeeProvider from '../rates/FeeProvider';
 import type RateProvider from '../rates/RateProvider';
 import { TransactionStatus } from '../sidecar/Sidecar';
 import ErrorsSwap from '../swap/Errors';
+import { getAllowedPositiveSlippageFromConfig } from '../swap/OverpaymentProtector';
 import type SwapNursery from '../swap/SwapNursery';
 import type { Currency } from '../wallet/WalletManager';
 import type WalletManager from '../wallet/WalletManager';
@@ -46,6 +48,7 @@ class Renegotiator {
     private readonly eipSigner: EipSigner,
     private readonly rateProvider: RateProvider,
     private readonly balanceCheck: BalanceCheck,
+    private readonly overPaymentConfig?: OverPaymentConfig,
   ) {}
 
   public getQuote = async (swapId: string): Promise<number> => {
@@ -268,7 +271,14 @@ class Renegotiator {
       throw Errors.PAIR_NOT_FOUND(swap.pair);
     }
 
-    if (swap.receivingData.amount! > pair.limits.maximal) {
+    if (
+      swap.receivingData.amount! >
+      pair.limits.maximal +
+        getAllowedPositiveSlippageFromConfig(
+          pair.limits.maximal,
+          this.overPaymentConfig,
+        )
+    ) {
       throw Errors.EXCEED_MAXIMAL_AMOUNT(
         swap.receivingData.amount!,
         pair.limits.maximal,

--- a/lib/service/Renegotiator.ts
+++ b/lib/service/Renegotiator.ts
@@ -1,4 +1,3 @@
-import type { OverPaymentConfig } from '../Config';
 import { parseTransaction } from '../Core';
 import type Logger from '../Logger';
 import { isTxConfirmed } from '../Utils';
@@ -21,7 +20,7 @@ import FeeProvider from '../rates/FeeProvider';
 import type RateProvider from '../rates/RateProvider';
 import { TransactionStatus } from '../sidecar/Sidecar';
 import ErrorsSwap from '../swap/Errors';
-import { getAllowedPositiveSlippageFromConfig } from '../swap/OverpaymentProtector';
+import type OverpaymentProtector from '../swap/OverpaymentProtector';
 import type SwapNursery from '../swap/SwapNursery';
 import type { Currency } from '../wallet/WalletManager';
 import type WalletManager from '../wallet/WalletManager';
@@ -48,7 +47,7 @@ class Renegotiator {
     private readonly eipSigner: EipSigner,
     private readonly rateProvider: RateProvider,
     private readonly balanceCheck: BalanceCheck,
-    private readonly overPaymentConfig?: OverPaymentConfig,
+    private readonly overpaymentProtector: OverpaymentProtector,
   ) {}
 
   public getQuote = async (swapId: string): Promise<number> => {
@@ -274,9 +273,8 @@ class Renegotiator {
     if (
       swap.receivingData.amount! >
       pair.limits.maximal +
-        getAllowedPositiveSlippageFromConfig(
+        this.overpaymentProtector.getAllowedPositiveSlippage(
           pair.limits.maximal,
-          this.overPaymentConfig,
         )
     ) {
       throw Errors.EXCEED_MAXIMAL_AMOUNT(

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -92,6 +92,7 @@ import { InvoiceType } from '../sidecar/DecodedInvoice';
 import type Sidecar from '../sidecar/Sidecar';
 import SwapErrors from '../swap/Errors';
 import NodeSwitch from '../swap/NodeSwitch';
+import type OverpaymentProtector from '../swap/OverpaymentProtector';
 import type { SwapNurseryEvents } from '../swap/PaymentHandler';
 import SwapManager from '../swap/SwapManager';
 import SwapOutputType from '../swap/SwapOutputType';
@@ -188,6 +189,7 @@ class Service {
     public readonly sidecar: Sidecar,
     public readonly swapConfig: Pick<SwapConfig, 'cltvDelta'>,
     public readonly routingFee: RoutingFee,
+    overpaymentProtector: OverpaymentProtector,
   ) {
     this.prepayMinerFee = config.prepayminerfee;
     this.logger.debug(
@@ -250,6 +252,7 @@ class Service {
       this.lockupTransactionTracker,
       this.sidecar,
       this.balanceCheck,
+      overpaymentProtector,
     );
     this.walletManager.ethereumManagers.forEach((manager) => {
       manager.commitments.setRefundSignatureLock(

--- a/lib/swap/OverpaymentProtector.ts
+++ b/lib/swap/OverpaymentProtector.ts
@@ -2,64 +2,37 @@ import type { OverPaymentConfig } from '../Config';
 import type Logger from '../Logger';
 import { SwapType } from '../consts/Enums';
 
-export type PositiveSlippageTolerance = {
-  exemptAmount: number;
-  maxPercentage: number;
-};
-
-export const overpaymentDefaultConfig: Required<OverPaymentConfig> = {
-  exemptAmount: 10_000,
-  maxPercentage: 2,
-};
-
-export const resolvePositiveSlippageTolerance = (
-  config?: OverPaymentConfig,
-  maxPercentageOverride?: number,
-): PositiveSlippageTolerance => ({
-  exemptAmount: config?.exemptAmount ?? overpaymentDefaultConfig.exemptAmount,
-  maxPercentage:
-    (maxPercentageOverride ??
-      config?.maxPercentage ??
-      overpaymentDefaultConfig.maxPercentage) / 100,
-});
-
-export const getAllowedPositiveSlippage = (
-  amount: number,
-  tolerance: PositiveSlippageTolerance,
-): number => Math.max(tolerance.exemptAmount, amount * tolerance.maxPercentage);
-
-export const getAllowedPositiveSlippageFromConfig = (
-  amount: number,
-  config?: OverPaymentConfig,
-  maxPercentageOverride?: number,
-): number =>
-  getAllowedPositiveSlippage(
-    amount,
-    resolvePositiveSlippageTolerance(config, maxPercentageOverride),
-  );
-
 class OverpaymentProtector {
-  private static readonly defaultConfig = overpaymentDefaultConfig;
+  private static readonly defaultConfig: Required<OverPaymentConfig> = {
+    exemptAmount: 10_000,
+    maxPercentage: 2,
+  };
 
-  private readonly overPaymentExemptAmount: number;
-  private readonly overPaymentMaxPercentage: number;
+  private readonly exemptAmount: number;
+  private readonly maxPercentage: number;
 
   constructor(logger: Logger, config?: OverPaymentConfig) {
-    const tolerance = resolvePositiveSlippageTolerance({
-      ...OverpaymentProtector.defaultConfig,
-      ...config,
-    });
+    this.exemptAmount =
+      config?.exemptAmount ?? OverpaymentProtector.defaultConfig.exemptAmount;
+    this.maxPercentage =
+      config?.maxPercentage ?? OverpaymentProtector.defaultConfig.maxPercentage;
 
-    this.overPaymentExemptAmount = tolerance.exemptAmount;
     logger.debug(
-      `Onchain payment overpayment exempt amount: ${this.overPaymentExemptAmount}`,
+      `Onchain payment overpayment exempt amount: ${this.exemptAmount}`,
     );
-
-    this.overPaymentMaxPercentage = tolerance.maxPercentage;
     logger.debug(
-      `Maximal accepted onchain overpayment: ${this.overPaymentMaxPercentage * 100}%`,
+      `Maximal accepted onchain overpayment: ${this.maxPercentage}%`,
     );
   }
+
+  public getAllowedPositiveSlippage = (
+    amount: number,
+    maxPercentageOverride?: number,
+  ): number =>
+    Math.max(
+      this.exemptAmount,
+      Math.ceil((amount * (maxPercentageOverride ?? this.maxPercentage)) / 100),
+    );
 
   public isUnacceptableOverpay = (
     type: SwapType,
@@ -69,15 +42,12 @@ class OverpaymentProtector {
     // For chain swaps we renegotiate overpayments
     if (type === SwapType.Chain) {
       return actual > expected;
-    } else {
-      return (
-        actual - expected >
-          getAllowedPositiveSlippage(expected, {
-            exemptAmount: this.overPaymentExemptAmount,
-            maxPercentage: this.overPaymentMaxPercentage,
-          }) || actual > expected * 2
-      );
     }
+
+    return (
+      actual - expected > this.getAllowedPositiveSlippage(expected) ||
+      actual > expected * 2
+    );
   };
 }
 

--- a/lib/swap/OverpaymentProtector.ts
+++ b/lib/swap/OverpaymentProtector.ts
@@ -2,10 +2,41 @@ import type { OverPaymentConfig } from '../Config';
 import type Logger from '../Logger';
 import { SwapType } from '../consts/Enums';
 
+export type PositiveSlippageTolerance = {
+  exemptAmount: number;
+  maxPercentage: number;
+};
+
 export const overpaymentDefaultConfig: Required<OverPaymentConfig> = {
   exemptAmount: 10_000,
   maxPercentage: 2,
 };
+
+export const resolvePositiveSlippageTolerance = (
+  config?: OverPaymentConfig,
+  maxPercentageOverride?: number,
+): PositiveSlippageTolerance => ({
+  exemptAmount: config?.exemptAmount ?? overpaymentDefaultConfig.exemptAmount,
+  maxPercentage:
+    (maxPercentageOverride ??
+      config?.maxPercentage ??
+      overpaymentDefaultConfig.maxPercentage) / 100,
+});
+
+export const getAllowedPositiveSlippage = (
+  amount: number,
+  tolerance: PositiveSlippageTolerance,
+): number => Math.max(tolerance.exemptAmount, amount * tolerance.maxPercentage);
+
+export const getAllowedPositiveSlippageFromConfig = (
+  amount: number,
+  config?: OverPaymentConfig,
+  maxPercentageOverride?: number,
+): number =>
+  getAllowedPositiveSlippage(
+    amount,
+    resolvePositiveSlippageTolerance(config, maxPercentageOverride),
+  );
 
 class OverpaymentProtector {
   private static readonly defaultConfig = overpaymentDefaultConfig;
@@ -14,15 +45,17 @@ class OverpaymentProtector {
   private readonly overPaymentMaxPercentage: number;
 
   constructor(logger: Logger, config?: OverPaymentConfig) {
-    this.overPaymentExemptAmount =
-      config?.exemptAmount ?? OverpaymentProtector.defaultConfig.exemptAmount;
+    const tolerance = resolvePositiveSlippageTolerance({
+      ...OverpaymentProtector.defaultConfig,
+      ...config,
+    });
+
+    this.overPaymentExemptAmount = tolerance.exemptAmount;
     logger.debug(
       `Onchain payment overpayment exempt amount: ${this.overPaymentExemptAmount}`,
     );
 
-    this.overPaymentMaxPercentage =
-      (config?.maxPercentage ??
-        OverpaymentProtector.defaultConfig.maxPercentage) / 100;
+    this.overPaymentMaxPercentage = tolerance.maxPercentage;
     logger.debug(
       `Maximal accepted onchain overpayment: ${this.overPaymentMaxPercentage * 100}%`,
     );
@@ -39,10 +72,10 @@ class OverpaymentProtector {
     } else {
       return (
         actual - expected >
-          Math.max(
-            this.overPaymentExemptAmount,
-            expected * this.overPaymentMaxPercentage,
-          ) || actual > expected * 2
+          getAllowedPositiveSlippage(expected, {
+            exemptAmount: this.overPaymentExemptAmount,
+            maxPercentage: this.overPaymentMaxPercentage,
+          }) || actual > expected * 2
       );
     }
   };

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -90,6 +90,7 @@ import type WalletManager from '../wallet/WalletManager';
 import Errors from './Errors';
 import NodeFallback from './NodeFallback';
 import NodeSwitch, { ReverseSwapNodeResolutionStatus } from './NodeSwitch';
+import type OverpaymentProtector from './OverpaymentProtector';
 import ReverseRoutingHints from './ReverseRoutingHints';
 import SwapNursery from './SwapNursery';
 import type SwapOutputType from './SwapOutputType';
@@ -213,6 +214,7 @@ class SwapManager {
     lockupTransactionTracker: LockupTransactionTracker,
     private readonly sidecar: Sidecar,
     balanceCheck: BalanceCheck,
+    overpaymentProtector: OverpaymentProtector,
   ) {
     this.deferredClaimer = new DeferredClaimer(
       this.logger,
@@ -250,7 +252,7 @@ class SwapManager {
       this.deferredClaimer,
       this.chainSwapSigner,
       lockupTransactionTracker,
-      swapConfig.overpayment,
+      overpaymentProtector,
       swapConfig.paymentTimeoutMinutes,
     );
 
@@ -263,7 +265,7 @@ class SwapManager {
       this.eipSigner,
       rateProvider,
       balanceCheck,
-      swapConfig.overpayment,
+      overpaymentProtector,
     );
 
     this.reverseRoutingHints = new ReverseRoutingHints(

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -263,6 +263,7 @@ class SwapManager {
       this.eipSigner,
       rateProvider,
       balanceCheck,
+      swapConfig.overpayment,
     );
 
     this.reverseRoutingHints = new ReverseRoutingHints(

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -4,7 +4,6 @@ import { OutputType, SwapTreeSerializer } from 'boltz-core';
 import type { ContractTransactionResponse } from 'ethers';
 import type { Transaction as LiquidTransaction } from 'liquidjs-lib';
 import { Op } from 'sequelize';
-import type { OverPaymentConfig } from '../Config';
 import type {
   ClaimDetails,
   LiquidClaimDetails,
@@ -88,7 +87,7 @@ import EthereumNursery from './EthereumNursery';
 import InvoiceNursery from './InvoiceNursery';
 import LightningNursery from './LightningNursery';
 import NodeSwitch, { ReverseSwapNodeResolutionStatus } from './NodeSwitch';
-import OverpaymentProtector from './OverpaymentProtector';
+import type OverpaymentProtector from './OverpaymentProtector';
 import type { SwapNurseryEvents } from './PaymentHandler';
 import PaymentHandler from './PaymentHandler';
 import RefundWatcher from './RefundWatcher';
@@ -145,7 +144,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     private readonly claimer: DeferredClaimer,
     private readonly chainSwapSigner: ChainSwapSigner,
     lockupTransactionTracker: LockupTransactionTracker,
-    overPaymentConfig?: OverPaymentConfig,
+    overpaymentProtector: OverpaymentProtector,
     paymentTimeoutMinutes?: number,
   ) {
     super();
@@ -154,10 +153,6 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
     this.transactionHook = new TransactionHook(this.logger, notifications);
 
-    const overpaymentProtector = new OverpaymentProtector(
-      this.logger,
-      overPaymentConfig,
-    );
     this.arkNursery = new ArkNursery(this.logger, overpaymentProtector);
     this.utxoNursery = new UtxoNursery(
       this.logger,

--- a/lib/wallet/ethereum/EthereumManager.ts
+++ b/lib/wallet/ethereum/EthereumManager.ts
@@ -8,15 +8,12 @@ import {
   Transaction,
   getAddress,
 } from 'ethers';
-import type {
-  ArbitrumConfig,
-  EthereumConfig,
-  OverPaymentConfig,
-} from '../../Config';
+import type { ArbitrumConfig, EthereumConfig } from '../../Config';
 import type Logger from '../../Logger';
 import { formatError, stringify } from '../../Utils';
 import { CurrencyType } from '../../consts/Enums';
 import ChainTipRepository from '../../db/repositories/ChainTipRepository';
+import type OverpaymentProtector from '../../swap/OverpaymentProtector';
 import Errors from '../Errors';
 import Wallet from '../Wallet';
 import ERC20WalletProvider from '../providers/ERC20WalletProvider';
@@ -63,7 +60,7 @@ class EthereumManager {
     private readonly logger: Logger,
     public readonly networkDetails: NetworkDetails,
     private readonly config: EthereumConfig | ArbitrumConfig,
-    private readonly overPaymentConfig?: OverPaymentConfig,
+    private readonly overpaymentProtector: OverpaymentProtector,
   ) {
     if (
       config === null ||
@@ -109,7 +106,7 @@ class EthereumManager {
       this.networkDetails,
       this.contractEventHandler,
       this.config.commitmentTimelock,
-      this.overPaymentConfig,
+      this.overpaymentProtector,
     );
   }
 

--- a/lib/wallet/ethereum/contracts/Commitments.ts
+++ b/lib/wallet/ethereum/contracts/Commitments.ts
@@ -1,7 +1,6 @@
 import type { ERC20Swap } from 'boltz-core/typechain/ERC20Swap';
 import type { EtherSwap } from 'boltz-core/typechain/EtherSwap';
 import { Signature, type Signer } from 'ethers';
-import type { OverPaymentConfig } from '../../../Config';
 import type Logger from '../../../Logger';
 import { formatError, getHexBuffer } from '../../../Utils';
 import { etherDecimals } from '../../../consts/Consts';
@@ -18,7 +17,7 @@ import CommitmentRepository from '../../../db/repositories/CommitmentRepository'
 import SwapRepository from '../../../db/repositories/SwapRepository';
 import TimeoutDeltaProvider from '../../../service/TimeoutDeltaProvider';
 import type { RefundSignatureLock } from '../../../service/cooperative/EipSigner';
-import { getAllowedPositiveSlippageFromConfig } from '../../../swap/OverpaymentProtector';
+import type OverpaymentProtector from '../../../swap/OverpaymentProtector';
 import type Wallet from '../../Wallet';
 import type ERC20WalletProvider from '../../providers/ERC20WalletProvider';
 import type ConsolidatedEventHandler from '../ConsolidatedEventHandler';
@@ -57,8 +56,8 @@ class Commitments {
     private readonly logger: Logger,
     private readonly network: NetworkDetails,
     private readonly eventHandler: ConsolidatedEventHandler,
-    commitmentTimelockMinutes?: number,
-    private readonly overPaymentConfig?: OverPaymentConfig,
+    commitmentTimelockMinutes: number | undefined,
+    private readonly overpaymentProtector: OverpaymentProtector,
   ) {
     this.commitmentTimelockMinutes =
       commitmentTimelockMinutes ?? Commitments.defaultCommitmentTimelockMinutes;
@@ -325,9 +324,8 @@ class Commitments {
     const overpayment = actualAmount - expectedAmount;
     if (
       overpayment >
-      getAllowedPositiveSlippageFromConfig(
+      this.overpaymentProtector.getAllowedPositiveSlippage(
         expectedAmount,
-        this.overPaymentConfig,
         maxOverpaymentPercentage,
       )
     ) {

--- a/lib/wallet/ethereum/contracts/Commitments.ts
+++ b/lib/wallet/ethereum/contracts/Commitments.ts
@@ -18,7 +18,7 @@ import CommitmentRepository from '../../../db/repositories/CommitmentRepository'
 import SwapRepository from '../../../db/repositories/SwapRepository';
 import TimeoutDeltaProvider from '../../../service/TimeoutDeltaProvider';
 import type { RefundSignatureLock } from '../../../service/cooperative/EipSigner';
-import { overpaymentDefaultConfig } from '../../../swap/OverpaymentProtector';
+import { getAllowedPositiveSlippageFromConfig } from '../../../swap/OverpaymentProtector';
 import type Wallet from '../../Wallet';
 import type ERC20WalletProvider from '../../providers/ERC20WalletProvider';
 import type ConsolidatedEventHandler from '../ConsolidatedEventHandler';
@@ -43,8 +43,6 @@ class Commitments {
   // Two weeks
   private static readonly defaultCommitmentTimelockMinutes = 14 * 24 * 60;
 
-  private static readonly alwaysAllowedOverpayment = 121;
-
   private provider!: InjectedProvider;
   private signer!: Signer;
   private wallets!: Map<string, Wallet>;
@@ -54,20 +52,16 @@ class Commitments {
     throw new Error('refund signature lock not set');
   };
   private readonly commitmentTimelockMinutes: number;
-  private readonly maxOverpaymentPercentage: number;
 
   constructor(
     private readonly logger: Logger,
     private readonly network: NetworkDetails,
     private readonly eventHandler: ConsolidatedEventHandler,
     commitmentTimelockMinutes?: number,
-    overPaymentConfig?: OverPaymentConfig,
+    private readonly overPaymentConfig?: OverPaymentConfig,
   ) {
     this.commitmentTimelockMinutes =
       commitmentTimelockMinutes ?? Commitments.defaultCommitmentTimelockMinutes;
-    this.maxOverpaymentPercentage =
-      (overPaymentConfig?.maxPercentage ??
-        overpaymentDefaultConfig.maxPercentage) / 100;
 
     if (this.commitmentTimelockMinutes <= 0) {
       throw new Error('commitment timelock must be greater than 0');
@@ -217,16 +211,11 @@ class Commitments {
         throw new Error('invalid maxOverpaymentPercentage');
       }
 
-      const allowedOverpaymentPercentage =
-        maxOverpaymentPercentage === undefined
-          ? this.maxOverpaymentPercentage
-          : maxOverpaymentPercentage / 100;
-
       if (currency === this.network.symbol) {
         this.checkAcceptedAmount(
           swapAmount,
           Math.floor(Number(event.amount / etherDecimals)),
-          allowedOverpaymentPercentage,
+          maxOverpaymentPercentage,
         );
 
         signatureValid = await (contract as EtherSwap).checkCommitmentSignature(
@@ -257,7 +246,7 @@ class Commitments {
         this.checkAcceptedAmount(
           swapAmount,
           erc20Wallet.normalizeTokenAmount(event.amount),
-          allowedOverpaymentPercentage,
+          maxOverpaymentPercentage,
         );
 
         signatureValid = await (contract as ERC20Swap).checkCommitmentSignature(
@@ -325,7 +314,7 @@ class Commitments {
   private checkAcceptedAmount = (
     expectedAmount: number,
     actualAmount: number,
-    allowedOverpaymentPercentage: number,
+    maxOverpaymentPercentage?: number,
   ) => {
     if (actualAmount < expectedAmount) {
       throw new Error(
@@ -335,8 +324,12 @@ class Commitments {
 
     const overpayment = actualAmount - expectedAmount;
     if (
-      overpayment > Commitments.alwaysAllowedOverpayment &&
-      overpayment > expectedAmount * allowedOverpaymentPercentage
+      overpayment >
+      getAllowedPositiveSlippageFromConfig(
+        expectedAmount,
+        this.overPaymentConfig,
+        maxOverpaymentPercentage,
+      )
     ) {
       throw new Error(`overpaid amount: ${actualAmount} > ${expectedAmount}`);
     }

--- a/test/integration/service/Renegotiator.spec.ts
+++ b/test/integration/service/Renegotiator.spec.ts
@@ -1,5 +1,6 @@
 import { Transaction } from 'bitcoinjs-lib';
 import { randomBytes } from 'crypto';
+import type { OverPaymentConfig } from '../../../lib/Config';
 import Logger from '../../../lib/Logger';
 import { getHexString } from '../../../lib/Utils';
 import {
@@ -145,6 +146,19 @@ describe('Renegotiator', () => {
 
   let negotiator: Renegotiator;
 
+  const createNegotiator = (overPaymentConfig?: OverPaymentConfig) =>
+    new Renegotiator(
+      Logger.disabledLogger,
+      currencies,
+      walletManager,
+      swapNursery,
+      chainSwapSigner,
+      eipSigner,
+      rateProvider,
+      balanceCheck,
+      overPaymentConfig,
+    );
+
   beforeAll(async () => {
     const { provider, signer } = await getSigner();
     currencies.set('RBTC', {
@@ -168,16 +182,7 @@ describe('Renegotiator', () => {
   });
 
   beforeEach(() => {
-    negotiator = new Renegotiator(
-      Logger.disabledLogger,
-      currencies,
-      walletManager,
-      swapNursery,
-      chainSwapSigner,
-      eipSigner,
-      rateProvider,
-      balanceCheck,
-    );
+    negotiator = createNegotiator();
 
     ExtraFeeRepository.get = jest.fn().mockResolvedValue(null);
 
@@ -966,20 +971,71 @@ describe('Renegotiator', () => {
       ).rejects.toEqual(Errors.PAIR_NOT_FOUND('not/found'));
     });
 
-    test('should throw when limit is more than maxima', async () => {
+    test('should allow positive slippage above maxima within tolerance', async () => {
       await expect(
         negotiator['calculateNewQuote']({
           pair: 'BTC/BTC',
           chainSwap: {},
           receivingData: {
             symbol: 'BTC',
-            amount: 100_001,
+            amount: 110_000,
           },
           sendingData: {
             symbol: 'BTC',
           },
         } as any),
-      ).rejects.toEqual(Errors.EXCEED_MAXIMAL_AMOUNT(100_001, 100_000));
+      ).resolves.toEqual({ percentageFee: 5_500, serverLockAmount: 104_377 });
+    });
+
+    test('should throw when limit is more than maxima tolerance', async () => {
+      await expect(
+        negotiator['calculateNewQuote']({
+          pair: 'BTC/BTC',
+          chainSwap: {},
+          receivingData: {
+            symbol: 'BTC',
+            amount: 110_001,
+          },
+          sendingData: {
+            symbol: 'BTC',
+          },
+        } as any),
+      ).rejects.toEqual(Errors.EXCEED_MAXIMAL_AMOUNT(110_001, 100_000));
+    });
+
+    test('should use configured positive slippage tolerance above maxima', async () => {
+      negotiator = createNegotiator({
+        exemptAmount: 0,
+        maxPercentage: 1,
+      });
+
+      await expect(
+        negotiator['calculateNewQuote']({
+          pair: 'BTC/BTC',
+          chainSwap: {},
+          receivingData: {
+            symbol: 'BTC',
+            amount: 101_000,
+          },
+          sendingData: {
+            symbol: 'BTC',
+          },
+        } as any),
+      ).resolves.toEqual({ percentageFee: 5_050, serverLockAmount: 95_827 });
+
+      await expect(
+        negotiator['calculateNewQuote']({
+          pair: 'BTC/BTC',
+          chainSwap: {},
+          receivingData: {
+            symbol: 'BTC',
+            amount: 101_001,
+          },
+          sendingData: {
+            symbol: 'BTC',
+          },
+        } as any),
+      ).rejects.toEqual(Errors.EXCEED_MAXIMAL_AMOUNT(101_001, 100_000));
     });
 
     test('should throw when limit is less than minima', async () => {

--- a/test/integration/service/Renegotiator.spec.ts
+++ b/test/integration/service/Renegotiator.spec.ts
@@ -23,6 +23,7 @@ import type EipSigner from '../../../lib/service/cooperative/EipSigner';
 import { TransactionStatus } from '../../../lib/sidecar/Sidecar';
 import ErrorsSwap from '../../../lib/swap/Errors';
 import type EthereumNursery from '../../../lib/swap/EthereumNursery';
+import OverpaymentProtector from '../../../lib/swap/OverpaymentProtector';
 import type SwapNursery from '../../../lib/swap/SwapNursery';
 import type UtxoNursery from '../../../lib/swap/UtxoNursery';
 import type WalletManager from '../../../lib/wallet/WalletManager';
@@ -156,7 +157,7 @@ describe('Renegotiator', () => {
       eipSigner,
       rateProvider,
       balanceCheck,
-      overPaymentConfig,
+      new OverpaymentProtector(Logger.disabledLogger, overPaymentConfig),
     );
 
   beforeAll(async () => {

--- a/test/integration/service/Service.spec.ts
+++ b/test/integration/service/Service.spec.ts
@@ -3,6 +3,7 @@ import { CurrencyType } from '../../../lib/consts/Enums';
 import RoutingFee from '../../../lib/lightning/RoutingFee';
 import Errors from '../../../lib/service/Errors';
 import Service from '../../../lib/service/Service';
+import OverpaymentProtector from '../../../lib/swap/OverpaymentProtector';
 import type { Currency } from '../../../lib/wallet/WalletManager';
 import { bitcoinClient, elementsClient } from '../Nodes';
 
@@ -101,6 +102,7 @@ describe('Service', () => {
       cltvDelta: 20,
     },
     new RoutingFee(Logger.disabledLogger),
+    new OverpaymentProtector(Logger.disabledLogger),
   );
 
   beforeAll(async () => {

--- a/test/integration/swap/UtxoNursery.spec.ts
+++ b/test/integration/swap/UtxoNursery.spec.ts
@@ -156,6 +156,7 @@ describe('UtxoNursery', () => {
     lockupTracker,
     sidecar,
     {} as any,
+    new OverpaymentProtector(Logger.disabledLogger),
   );
 
   beforeAll(async () => {

--- a/test/integration/wallet/ethereum/EthereumManager.spec.ts
+++ b/test/integration/wallet/ethereum/EthereumManager.spec.ts
@@ -1,6 +1,7 @@
 import { MaxUint256 } from 'ethers';
 import Logger from '../../../../lib/Logger';
 import Database from '../../../../lib/db/Database';
+import OverpaymentProtector from '../../../../lib/swap/OverpaymentProtector';
 import Errors from '../../../../lib/wallet/Errors';
 import type Wallet from '../../../../lib/wallet/Wallet';
 import EthereumManager from '../../../../lib/wallet/ethereum/EthereumManager';
@@ -36,6 +37,8 @@ describe('EthereumManager', () => {
   let manager: EthereumManager;
   let wallets: Map<string, Wallet>;
 
+  const overpaymentProtector = new OverpaymentProtector(Logger.disabledLogger);
+
   const oldContracts = {
     version: 1,
     features: new Set(),
@@ -59,28 +62,33 @@ describe('EthereumManager', () => {
     await fundSignerWallet(setup.signer, setup.etherBase);
     const contracts = await getContracts(setup.signer);
 
-    manager = new EthereumManager(Logger.disabledLogger, networks.Ethereum, {
-      providerEndpoint,
-      networkName: 'Anvil',
-      contracts: [
-        {
-          etherSwap: await contracts.etherSwap.getAddress(),
-          erc20Swap: await contracts.erc20Swap.getAddress(),
-        },
-      ],
-      tokens: [
-        {
-          symbol: networks.Ethereum.symbol,
-          minWalletBalance: 100_000,
-        },
-        {
-          symbol: 'USDT',
-          decimals: 18,
-          minWalletBalance: 100_000,
-          contractAddress: await contracts.token.getAddress(),
-        },
-      ],
-    } as any);
+    manager = new EthereumManager(
+      Logger.disabledLogger,
+      networks.Ethereum,
+      {
+        providerEndpoint,
+        networkName: 'Anvil',
+        contracts: [
+          {
+            etherSwap: await contracts.etherSwap.getAddress(),
+            erc20Swap: await contracts.erc20Swap.getAddress(),
+          },
+        ],
+        tokens: [
+          {
+            symbol: networks.Ethereum.symbol,
+            minWalletBalance: 100_000,
+          },
+          {
+            symbol: 'USDT',
+            decimals: 18,
+            minWalletBalance: 100_000,
+            contractAddress: await contracts.token.getAddress(),
+          },
+        ],
+      } as any,
+      overpaymentProtector,
+    );
     manager['contracts'].push(oldContracts);
 
     wallets = await manager.init(setup.mnemonic);
@@ -103,7 +111,12 @@ describe('EthereumManager', () => {
   `('constructor should throw with invalid config $config', ({ config }) => {
     expect(
       () =>
-        new EthereumManager(Logger.disabledLogger, networks.Ethereum, config),
+        new EthereumManager(
+          Logger.disabledLogger,
+          networks.Ethereum,
+          config,
+          overpaymentProtector,
+        ),
     ).toThrow(Errors.MISSING_SWAP_CONTRACTS().message);
   });
 

--- a/test/integration/wallet/ethereum/contracts/Commitments.spec.ts
+++ b/test/integration/wallet/ethereum/contracts/Commitments.spec.ts
@@ -4,6 +4,7 @@ import type { ERC20Swap } from 'boltz-core/typechain/ERC20Swap';
 import type { EtherSwap } from 'boltz-core/typechain/EtherSwap';
 import { randomBytes } from 'crypto';
 import { Wallet as EthersWallet } from 'ethers';
+import type { OverPaymentConfig } from '../../../../../lib/Config';
 import Logger from '../../../../../lib/Logger';
 import { generateSwapId, getHexString } from '../../../../../lib/Utils';
 import { etherDecimals } from '../../../../../lib/consts/Consts';
@@ -767,11 +768,14 @@ describe('Commitments', () => {
 
     const createInitializedCommitments = (
       wallets: Map<string, Wallet> = new Map(),
+      overPaymentConfig?: OverPaymentConfig,
     ) => {
       const commitments = new Commitments(
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overPaymentConfig,
       );
 
       const contract = {
@@ -1126,7 +1130,7 @@ describe('Commitments', () => {
         timelock - 100,
       );
 
-      const overpaidAmount = BigInt(expectedAmount * 3) * etherDecimals;
+      const overpaidAmount = BigInt(expectedAmount + 10_001) * etherDecimals;
 
       const tx = await etherSwap['lock(bytes32,address,uint256)'](
         zeroPreimageHash,
@@ -1153,7 +1157,7 @@ describe('Commitments', () => {
       ).rejects.toThrow('overpaid amount:');
     });
 
-    test('should accept overpay at always-allowed boundary', async () => {
+    test('should accept overpay at configured exempt boundary', async () => {
       const commitments = createInitializedCommitments();
       const etherSwapAddress = await etherSwap.getAddress();
 
@@ -1166,7 +1170,7 @@ describe('Commitments', () => {
         timelock - 100,
       );
 
-      const overpaidAmount = BigInt(expectedAmount + 121) * etherDecimals;
+      const overpaidAmount = BigInt(expectedAmount + 10_000) * etherDecimals;
 
       const tx = await etherSwap['lock(bytes32,address,uint256)'](
         zeroPreimageHash,
@@ -1193,6 +1197,58 @@ describe('Commitments', () => {
         id,
         signature,
         tx.hash,
+      );
+
+      const commitment = await CommitmentRepository.getBySwapId(id);
+      expect(commitment).not.toBeNull();
+      expect(commitment!.swapId).toEqual(id);
+    });
+
+    test('should accept overpay with custom percentage override', async () => {
+      const commitments = createInitializedCommitments(new Map(), {
+        exemptAmount: 0,
+        maxPercentage: 1,
+      });
+      const etherSwapAddress = await etherSwap.getAddress();
+
+      const expectedAmount = 10_000;
+      const timelock = (await setup.provider.getBlockNumber()) + 1000;
+
+      const { id, preimageHash } = await createSwap(
+        etherSwapAddress,
+        expectedAmount,
+        timelock - 100,
+      );
+
+      const overpaidAmount = BigInt(expectedAmount + 350) * etherDecimals;
+
+      const tx = await etherSwap['lock(bytes32,address,uint256)'](
+        zeroPreimageHash,
+        await setup.signer.getAddress(),
+        timelock,
+        { value: overpaidAmount, nonce: await getSignerNonce() },
+      );
+      await tx.wait(1);
+
+      const signature = await setup.signer.signTypedData(
+        await getEtherSwapDomain(setup.provider, etherSwap),
+        etherSwapCommitTypes,
+        {
+          preimageHash,
+          amount: overpaidAmount,
+          claimAddress: await setup.signer.getAddress(),
+          refundAddress: await setup.signer.getAddress(),
+          timelock,
+        },
+      );
+
+      await commitments.commit(
+        networks.Ethereum.symbol,
+        id,
+        signature,
+        tx.hash,
+        undefined,
+        3.5,
       );
 
       const commitment = await CommitmentRepository.getBySwapId(id);

--- a/test/integration/wallet/ethereum/contracts/Commitments.spec.ts
+++ b/test/integration/wallet/ethereum/contracts/Commitments.spec.ts
@@ -22,6 +22,7 @@ import CommitmentRepository from '../../../../../lib/db/repositories/CommitmentR
 import PairRepository from '../../../../../lib/db/repositories/PairRepository';
 import SwapRepository from '../../../../../lib/db/repositories/SwapRepository';
 import TimeoutDeltaProvider from '../../../../../lib/service/TimeoutDeltaProvider';
+import OverpaymentProtector from '../../../../../lib/swap/OverpaymentProtector';
 import Wallet from '../../../../../lib/wallet/Wallet';
 import type ConsolidatedEventHandler from '../../../../../lib/wallet/ethereum/ConsolidatedEventHandler';
 import { networks } from '../../../../../lib/wallet/ethereum/EvmNetworks';
@@ -52,6 +53,8 @@ describe('Commitments', () => {
   const eventHandler = {
     handleEvent: jest.fn(),
   } as unknown as ConsolidatedEventHandler;
+
+  const overpaymentProtector = new OverpaymentProtector(Logger.disabledLogger);
 
   const fetchSignerNonce = async () => {
     const address = await setup.signer.getAddress();
@@ -133,6 +136,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       expect(commitments['commitmentTimelockMinutes']).toEqual(14 * 24 * 60);
@@ -145,6 +150,7 @@ describe('Commitments', () => {
         networks.Ethereum,
         eventHandler,
         customTimelock,
+        overpaymentProtector,
       );
 
       expect(commitments['commitmentTimelockMinutes']).toEqual(customTimelock);
@@ -157,6 +163,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const wallets = new Map();
@@ -175,6 +183,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const wallets = new Map();
@@ -222,6 +232,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const wallets = new Map();
@@ -262,6 +274,7 @@ describe('Commitments', () => {
         networks.Ethereum,
         eventHandler,
         commitmentTimelockMinutes,
+        overpaymentProtector,
       );
 
       const contract = {
@@ -342,6 +355,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const contractV5 = {
@@ -382,6 +397,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const contract = {
@@ -408,6 +425,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       commitments.init(setup.provider as any, setup.signer, [], new Map());
@@ -424,6 +443,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const contract = {
@@ -453,6 +474,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const contract = {
@@ -482,6 +505,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const contractV5 = {
@@ -525,6 +550,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const contract = {
@@ -553,6 +580,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       commitments.init(setup.provider as any, setup.signer, [], new Map());
@@ -569,6 +598,8 @@ describe('Commitments', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         eventHandler,
+        undefined,
+        overpaymentProtector,
       );
 
       const contract = {
@@ -775,7 +806,7 @@ describe('Commitments', () => {
         networks.Ethereum,
         eventHandler,
         undefined,
-        overPaymentConfig,
+        new OverpaymentProtector(Logger.disabledLogger, overPaymentConfig),
       );
 
       const contract = {

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -58,6 +58,7 @@ import Service, {
 import { InvoiceType } from '../../../lib/sidecar/DecodedInvoice';
 import type Sidecar from '../../../lib/sidecar/Sidecar';
 import NodeSwitch from '../../../lib/swap/NodeSwitch';
+import OverpaymentProtector from '../../../lib/swap/OverpaymentProtector';
 import SwapManager from '../../../lib/swap/SwapManager';
 import type Wallet from '../../../lib/wallet/Wallet';
 import type { Currency } from '../../../lib/wallet/WalletManager';
@@ -840,6 +841,7 @@ describe('Service', () => {
         cltvDelta: 20,
       },
       new RoutingFee(Logger.disabledLogger),
+      new OverpaymentProtector(Logger.disabledLogger),
     );
 
   const service = createService();

--- a/test/unit/swap/OverpaymentProtector.spec.ts
+++ b/test/unit/swap/OverpaymentProtector.spec.ts
@@ -1,9 +1,91 @@
 import type { OverPaymentConfig } from '../../../lib/Config';
 import Logger from '../../../lib/Logger';
 import { SwapType } from '../../../lib/consts/Enums';
-import OverpaymentProtector from '../../../lib/swap/OverpaymentProtector';
+import OverpaymentProtector, {
+  getAllowedPositiveSlippage,
+  getAllowedPositiveSlippageFromConfig,
+  overpaymentDefaultConfig,
+  resolvePositiveSlippageTolerance,
+} from '../../../lib/swap/OverpaymentProtector';
 
 describe('OverpaymentProtector', () => {
+  describe('resolvePositiveSlippageTolerance', () => {
+    test('should resolve undefined config to defaults', () => {
+      expect(resolvePositiveSlippageTolerance()).toEqual({
+        exemptAmount: overpaymentDefaultConfig.exemptAmount,
+        maxPercentage: overpaymentDefaultConfig.maxPercentage / 100,
+      });
+    });
+
+    test('should resolve partial config to defaults', () => {
+      expect(resolvePositiveSlippageTolerance({ exemptAmount: 123 })).toEqual({
+        exemptAmount: 123,
+        maxPercentage: overpaymentDefaultConfig.maxPercentage / 100,
+      });
+      expect(resolvePositiveSlippageTolerance({ maxPercentage: 4 })).toEqual({
+        exemptAmount: overpaymentDefaultConfig.exemptAmount,
+        maxPercentage: 0.04,
+      });
+    });
+
+    test('should preserve zero config values', () => {
+      expect(
+        resolvePositiveSlippageTolerance({
+          exemptAmount: 0,
+          maxPercentage: 0,
+        }),
+      ).toEqual({
+        exemptAmount: 0,
+        maxPercentage: 0,
+      });
+    });
+
+    test('should prefer percentage override over config and defaults', () => {
+      expect(
+        resolvePositiveSlippageTolerance(
+          {
+            exemptAmount: 123,
+            maxPercentage: 4,
+          },
+          6,
+        ),
+      ).toEqual({
+        exemptAmount: 123,
+        maxPercentage: 0.06,
+      });
+    });
+  });
+
+  describe('getAllowedPositiveSlippage', () => {
+    test.each`
+      amount       | config                                   | maxPercentageOverride | expected
+      ${100}       | ${undefined}                             | ${undefined}          | ${10_000}
+      ${1_000_000} | ${undefined}                             | ${undefined}          | ${20_000}
+      ${100}       | ${{ exemptAmount: 123 }}                 | ${undefined}          | ${123}
+      ${10_000}    | ${{ exemptAmount: 0, maxPercentage: 1 }} | ${3.5}                | ${350}
+    `(
+      'should calculate allowed slippage from resolved config',
+      ({ amount, config, maxPercentageOverride, expected }) => {
+        expect(
+          getAllowedPositiveSlippageFromConfig(
+            amount,
+            config,
+            maxPercentageOverride,
+          ),
+        ).toBeCloseTo(expected);
+      },
+    );
+
+    test('should use the larger configured tolerance', () => {
+      expect(
+        getAllowedPositiveSlippage(10_000, {
+          exemptAmount: 123,
+          maxPercentage: 0.02,
+        }),
+      ).toEqual(200);
+    });
+  });
+
   describe('constructor', () => {
     test('should use config when given as parameter', () => {
       const config: OverPaymentConfig = {

--- a/test/unit/swap/OverpaymentProtector.spec.ts
+++ b/test/unit/swap/OverpaymentProtector.spec.ts
@@ -1,58 +1,64 @@
 import type { OverPaymentConfig } from '../../../lib/Config';
 import Logger from '../../../lib/Logger';
 import { SwapType } from '../../../lib/consts/Enums';
-import OverpaymentProtector, {
-  getAllowedPositiveSlippage,
-  getAllowedPositiveSlippageFromConfig,
-  overpaymentDefaultConfig,
-  resolvePositiveSlippageTolerance,
-} from '../../../lib/swap/OverpaymentProtector';
+import OverpaymentProtector from '../../../lib/swap/OverpaymentProtector';
 
 describe('OverpaymentProtector', () => {
-  describe('resolvePositiveSlippageTolerance', () => {
-    test('should resolve undefined config to defaults', () => {
-      expect(resolvePositiveSlippageTolerance()).toEqual({
-        exemptAmount: overpaymentDefaultConfig.exemptAmount,
-        maxPercentage: overpaymentDefaultConfig.maxPercentage / 100,
-      });
+  describe('constructor', () => {
+    test('should use config when given as parameter', () => {
+      const config: OverPaymentConfig = {
+        exemptAmount: 123,
+        maxPercentage: 432,
+      };
+      const protector = new OverpaymentProtector(Logger.disabledLogger, config);
+
+      expect(protector['exemptAmount']).toEqual(config.exemptAmount);
+      expect(protector['maxPercentage']).toEqual(config.maxPercentage);
     });
 
-    test('should resolve partial config to defaults', () => {
-      expect(resolvePositiveSlippageTolerance({ exemptAmount: 123 })).toEqual({
+    test('should coalesce exempt amount', () => {
+      const config: OverPaymentConfig = {
+        maxPercentage: 432,
+      };
+      const protector = new OverpaymentProtector(Logger.disabledLogger, config);
+
+      expect(protector['exemptAmount']).toEqual(
+        OverpaymentProtector['defaultConfig'].exemptAmount,
+      );
+      expect(protector['maxPercentage']).toEqual(config.maxPercentage);
+    });
+
+    test('should coalesce max fee percentage', () => {
+      const config: OverPaymentConfig = {
         exemptAmount: 123,
-        maxPercentage: overpaymentDefaultConfig.maxPercentage / 100,
-      });
-      expect(resolvePositiveSlippageTolerance({ maxPercentage: 4 })).toEqual({
-        exemptAmount: overpaymentDefaultConfig.exemptAmount,
-        maxPercentage: 0.04,
-      });
+      };
+      const protector = new OverpaymentProtector(Logger.disabledLogger, config);
+
+      expect(protector['exemptAmount']).toEqual(config.exemptAmount);
+      expect(protector['maxPercentage']).toEqual(
+        OverpaymentProtector['defaultConfig'].maxPercentage,
+      );
+    });
+
+    test('should handle undefined config', () => {
+      const protector = new OverpaymentProtector(Logger.disabledLogger);
+
+      expect(protector['exemptAmount']).toEqual(
+        OverpaymentProtector['defaultConfig'].exemptAmount,
+      );
+      expect(protector['maxPercentage']).toEqual(
+        OverpaymentProtector['defaultConfig'].maxPercentage,
+      );
     });
 
     test('should preserve zero config values', () => {
-      expect(
-        resolvePositiveSlippageTolerance({
-          exemptAmount: 0,
-          maxPercentage: 0,
-        }),
-      ).toEqual({
+      const protector = new OverpaymentProtector(Logger.disabledLogger, {
         exemptAmount: 0,
         maxPercentage: 0,
       });
-    });
 
-    test('should prefer percentage override over config and defaults', () => {
-      expect(
-        resolvePositiveSlippageTolerance(
-          {
-            exemptAmount: 123,
-            maxPercentage: 4,
-          },
-          6,
-        ),
-      ).toEqual({
-        exemptAmount: 123,
-        maxPercentage: 0.06,
-      });
+      expect(protector['exemptAmount']).toEqual(0);
+      expect(protector['maxPercentage']).toEqual(0);
     });
   });
 
@@ -64,78 +70,67 @@ describe('OverpaymentProtector', () => {
       ${100}       | ${{ exemptAmount: 123 }}                 | ${undefined}          | ${123}
       ${10_000}    | ${{ exemptAmount: 0, maxPercentage: 1 }} | ${3.5}                | ${350}
     `(
-      'should calculate allowed slippage from resolved config',
+      'should calculate allowed slippage from configured tolerance',
       ({ amount, config, maxPercentageOverride, expected }) => {
         expect(
-          getAllowedPositiveSlippageFromConfig(
-            amount,
+          new OverpaymentProtector(
+            Logger.disabledLogger,
             config,
-            maxPercentageOverride,
-          ),
+          ).getAllowedPositiveSlippage(amount, maxPercentageOverride),
         ).toBeCloseTo(expected);
       },
     );
 
     test('should use the larger configured tolerance', () => {
       expect(
-        getAllowedPositiveSlippage(10_000, {
+        new OverpaymentProtector(Logger.disabledLogger, {
           exemptAmount: 123,
-          maxPercentage: 0.02,
-        }),
+          maxPercentage: 2,
+        }).getAllowedPositiveSlippage(10_000),
       ).toEqual(200);
     });
-  });
 
-  describe('constructor', () => {
-    test('should use config when given as parameter', () => {
-      const config: OverPaymentConfig = {
-        exemptAmount: 123,
-        maxPercentage: 432,
-      };
-      const protector = new OverpaymentProtector(Logger.disabledLogger, config);
+    test.each`
+      amount  | config                                      | maxPercentageOverride | expected
+      ${101}  | ${{ exemptAmount: 0, maxPercentage: 1 }}    | ${undefined}          | ${2}
+      ${333}  | ${{ exemptAmount: 0, maxPercentage: 1 }}    | ${undefined}          | ${4}
+      ${999}  | ${{ exemptAmount: 0, maxPercentage: 0.05 }} | ${undefined}          | ${1}
+      ${1}    | ${{ exemptAmount: 0, maxPercentage: 1 }}    | ${undefined}          | ${1}
+      ${1000} | ${{ exemptAmount: 0, maxPercentage: 1 }}    | ${0.05}               | ${1}
+    `(
+      'should round non-integer slippage up to the next integer',
+      ({ amount, config, maxPercentageOverride, expected }) => {
+        expect(
+          new OverpaymentProtector(
+            Logger.disabledLogger,
+            config,
+          ).getAllowedPositiveSlippage(amount, maxPercentageOverride),
+        ).toEqual(expected);
+      },
+    );
 
-      expect(protector['overPaymentExemptAmount']).toEqual(config.exemptAmount);
-      expect(protector['overPaymentMaxPercentage']).toEqual(
-        config.maxPercentage! / 100,
-      );
-    });
+    test.each`
+      amount    | config                                   | maxPercentageOverride
+      ${10_000} | ${{ exemptAmount: 0, maxPercentage: 2 }} | ${undefined}
+      ${5_000}  | ${{ exemptAmount: 0, maxPercentage: 1 }} | ${4}
+    `(
+      'should leave already-integer slippage unchanged',
+      ({ amount, config, maxPercentageOverride }) => {
+        const protector = new OverpaymentProtector(
+          Logger.disabledLogger,
+          config,
+        );
+        const result = protector.getAllowedPositiveSlippage(
+          amount,
+          maxPercentageOverride,
+        );
 
-    test('should coalesce exempt amount', () => {
-      const config: OverPaymentConfig = {
-        maxPercentage: 432,
-      };
-      const protector = new OverpaymentProtector(Logger.disabledLogger, config);
-
-      expect(protector['overPaymentExemptAmount']).toEqual(
-        OverpaymentProtector['defaultConfig'].exemptAmount,
-      );
-      expect(protector['overPaymentMaxPercentage']).toEqual(
-        config.maxPercentage! / 100,
-      );
-    });
-
-    test('should coalesce max fee percentage', () => {
-      const config: OverPaymentConfig = {
-        exemptAmount: 123,
-      };
-      const protector = new OverpaymentProtector(Logger.disabledLogger, config);
-
-      expect(protector['overPaymentExemptAmount']).toEqual(config.exemptAmount);
-      expect(protector['overPaymentMaxPercentage']).toEqual(
-        OverpaymentProtector['defaultConfig'].maxPercentage / 100,
-      );
-    });
-
-    test('should handle undefined config', () => {
-      const protector = new OverpaymentProtector(Logger.disabledLogger);
-
-      expect(protector['overPaymentExemptAmount']).toEqual(
-        OverpaymentProtector['defaultConfig'].exemptAmount,
-      );
-      expect(protector['overPaymentMaxPercentage']).toEqual(
-        OverpaymentProtector['defaultConfig'].maxPercentage / 100,
-      );
-    });
+        expect(Number.isInteger(result)).toBe(true);
+        expect(result).toEqual(
+          amount * ((maxPercentageOverride ?? config.maxPercentage) / 100),
+        );
+      },
+    );
   });
 
   describe('isUnacceptableOverpay', () => {

--- a/test/unit/swap/SwapManager.spec.ts
+++ b/test/unit/swap/SwapManager.spec.ts
@@ -38,6 +38,7 @@ import { InvoiceType } from '../../../lib/sidecar/DecodedInvoice';
 import type Sidecar from '../../../lib/sidecar/Sidecar';
 import Errors from '../../../lib/swap/Errors';
 import NodeSwitch from '../../../lib/swap/NodeSwitch';
+import OverpaymentProtector from '../../../lib/swap/OverpaymentProtector';
 import SwapManager from '../../../lib/swap/SwapManager';
 import SwapOutputType from '../../../lib/swap/SwapOutputType';
 import Wallet from '../../../lib/wallet/Wallet';
@@ -468,6 +469,7 @@ describe('SwapManager', () => {
       {} as any,
       sidecar,
       {} as any,
+      new OverpaymentProtector(Logger.disabledLogger),
     );
 
     manager['currencies'].set(btcCurrency.symbol, btcCurrency);

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -197,6 +197,7 @@ describe('SwapNursery', () => {
       mockClaimer,
       mockChainSwapSigner,
       {} as any,
+      {} as any,
     );
 
     // Set up private/public properties using property access notation
@@ -438,6 +439,7 @@ describe('SwapNursery', () => {
         0,
         mockClaimer,
         mockChainSwapSigner,
+        {} as any,
         {} as any,
       );
 

--- a/test/unit/wallet/ethereum/EthereumManager.spec.ts
+++ b/test/unit/wallet/ethereum/EthereumManager.spec.ts
@@ -1,6 +1,7 @@
 import { Wallet as EthersWallet, HDNodeWallet } from 'ethers';
 import type { EthereumConfig } from '../../../../lib/Config';
 import Logger from '../../../../lib/Logger';
+import OverpaymentProtector from '../../../../lib/swap/OverpaymentProtector';
 import EthereumManager from '../../../../lib/wallet/ethereum/EthereumManager';
 import { networks } from '../../../../lib/wallet/ethereum/EvmNetworks';
 import { createDeferred } from '../../../Utils';
@@ -8,6 +9,8 @@ import { createDeferred } from '../../../Utils';
 describe('EthereumManager derivation path', () => {
   const mnemonic =
     'test test test test test test test test test test test junk';
+
+  const overpaymentProtector = new OverpaymentProtector(Logger.disabledLogger);
 
   const createConfig = (
     overrides: Partial<EthereumConfig> = {},
@@ -35,6 +38,7 @@ describe('EthereumManager derivation path', () => {
       Logger.disabledLogger,
       networks.Ethereum,
       createConfig({ derivationPath }),
+      overpaymentProtector,
     );
     const signer = manager['getSigner'](mnemonic);
 
@@ -52,6 +56,7 @@ describe('EthereumManager derivation path', () => {
         Logger.disabledLogger,
         networks.Ethereum,
         createConfig({ derivationPath }),
+        overpaymentProtector,
       );
 
       expect(() => manager['getSigner'](mnemonic)).toThrow(
@@ -67,6 +72,7 @@ describe('EthereumManager derivation path', () => {
       Logger.disabledLogger,
       networks.Ethereum,
       createConfig(),
+      overpaymentProtector,
     );
     const signer = manager['getSigner'](mnemonic);
 
@@ -80,6 +86,7 @@ describe('EthereumManager derivation path', () => {
       Logger.disabledLogger,
       networks.Ethereum,
       createConfig(),
+      overpaymentProtector,
     );
     const firstCheckStarted = createDeferred();
     const releaseFirstCheck = createDeferred();


### PR DESCRIPTION
Closes https://github.com/BoltzExchange/boltz-backend/issues/1370

Allow commitment swaps and chain swap renegotiation to accept positive slippage up to the configured overpayment tolerance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added optional maxOverpaymentPercentage to commitment submission docs and clarified signature/amount constraints
  * Updated renegotiation guidance to reflect allowed overpayment within tolerance

* **New Features**
  * Introduced configurable positive-slippage tolerance for accepting overpayments
  * Locked amounts may now exceed previous maximal limits when within the configured tolerance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->