### PR TITLE
docs: add llms.txt and expose raw .md on all docs urls

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,6 +1,38 @@
+import { copyFile, mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { defineConfig } from 'vitepress';
 
 const docsRoot = 'https://docs.boltz.exchange';
+const siteUrl = 'https://api.docs.boltz.exchange';
+
+const sidebarItems: {
+  text: string;
+  link: string;
+  target?: string;
+}[] = [
+  { text: '👋 Introduction', link: '/index' },
+  { text: '📙 Clients, SDKs & Libraries', link: '/libraries' },
+  { text: '🤖 REST API v2', link: '/api-v2' },
+  { text: '🔁 Swap Types & States', link: '/lifecycle' },
+  { text: '💰 Swap Limits & Fees', link: '/swap-limits-and-fees' },
+  { text: '♻️ Renegotiating Swaps', link: '/renegotiating' },
+  { text: '🙋‍♂️ Claims & Refunds', link: '/claiming-swaps' },
+  { text: '🔐 Commitment Swaps', link: '/commitment-swaps' },
+  { text: '🛟 Swap Restore', link: '/swap-restore' },
+  { text: '⛑️ Asset Rescue', link: '/asset-rescue' },
+  { text: '⚠️ Common Mistakes', link: '/common-mistakes' },
+  { text: "🚫 Don't trust. Verify!", link: '/dont-trust-verify' },
+  { text: '🪄 Magic Routing Hints', link: '/magic-routing-hints' },
+  { text: '⏩ 0-conf', link: '/0-conf' },
+  { text: '🪝 Webhooks', link: '/webhooks' },
+  { text: '✨ BOLT12', link: '/bolt12' },
+  { text: '🏅 Pro', link: '/pro' },
+  { text: '📜 Claim Covenants', link: '/claim-covenants' },
+  { text: '🤝 Partner Program', link: '/partner-program' },
+  { text: '🐳 Backend Development', link: '/backend-development' },
+  { text: '🤖 REST API v1 (deprecated)', link: '/api-v1' },
+  { text: '🏠 Docs Home', link: docsRoot, target: '_self' },
+];
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -16,34 +48,7 @@ export default defineConfig({
       },
     },
     nav: [{ text: '🏠 Docs Home', link: docsRoot, target: '_self' }],
-    sidebar: [
-      {
-        items: [
-          { text: '👋 Introduction', link: '/index' },
-          { text: '📙 Clients, SDKs & Libraries', link: '/libraries' },
-          { text: '🤖 REST API v2', link: '/api-v2' },
-          { text: '🔁 Swap Types & States', link: '/lifecycle' },
-          { text: '💰 Swap Limits & Fees', link: '/swap-limits-and-fees' },
-          { text: '♻️ Renegotiating Swaps', link: '/renegotiating' },
-          { text: '🙋‍♂️ Claims & Refunds', link: '/claiming-swaps' },
-          { text: '🔐 Commitment Swaps', link: '/commitment-swaps' },
-          { text: '🛟 Swap Restore', link: '/swap-restore' },
-          { text: '⛑️ Asset Rescue', link: '/asset-rescue' },
-          { text: '⚠️ Common Mistakes', link: '/common-mistakes' },
-          { text: "🚫 Don't trust. Verify!", link: '/dont-trust-verify' },
-          { text: '🪄 Magic Routing Hints', link: '/magic-routing-hints' },
-          { text: '⏩ 0-conf', link: '/0-conf' },
-          { text: '🪝 Webhooks', link: '/webhooks' },
-          { text: '✨ BOLT12', link: '/bolt12' },
-          { text: '🏅 Pro', link: '/pro' },
-          { text: '📜 Claim Covenants', link: '/claim-covenants' },
-          { text: '🤝 Partner Program', link: '/partner-program' },
-          { text: '🐳 Backend Development', link: '/backend-development' },
-          { text: '🤖 REST API v1 (deprecated)', link: '/api-v1' },
-          { text: '🏠 Docs Home', link: docsRoot, target: '_self' },
-        ],
-      },
-    ],
+    sidebar: [{ items: sidebarItems }],
     socialLinks: [
       {
         icon: 'github',
@@ -53,4 +58,27 @@ export default defineConfig({
   },
   // Ignore dead links to localhost
   ignoreDeadLinks: [/https?:\/\/localhost/],
+
+  async buildEnd(siteConfig) {
+    // Copy raw markdown sources into the build output so each page is also
+    // reachable as `/<page>.md` next to `/<page>.html` (for LLM crawlers,
+    // `curl`, etc.).
+    await Promise.all(
+      siteConfig.pages.map(async (page) => {
+        const src = join(siteConfig.srcDir, page);
+        const dest = join(siteConfig.outDir, page);
+        await mkdir(dirname(dest), { recursive: true });
+        await copyFile(src, dest);
+      }),
+    );
+
+    // Emit an `llms.txt` index following https://llmstxt.org/ so LLM crawlers
+    // can discover the markdown sources.
+    const links = sidebarItems
+      .filter((item) => item.link.startsWith('/'))
+      .map((item) => `- [${item.text}](${siteUrl}${item.link}.md)`)
+      .join('\n');
+    const llmsTxt = `# ${siteConfig.site.title}\n\n> ${siteConfig.site.description}\n\n## Docs\n\n${links}\n`;
+    await writeFile(join(siteConfig.outDir, 'llms.txt'), llmsTxt);
+  },
 });


### PR DESCRIPTION
VitePress's `buildEnd` now copies each source page into the build output as `<page>.md` next to `<page>.html`, and writes an `llms.txt` index at the docs root, so LLM crawlers, agents and coding tools can easily fetch the raw markdown directly via e.g. https://api.docs.boltz.exchange/lifecycle.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown source files are now directly accessible at `/<page>.md`
  * Added `llms.txt` index file containing sidebar routes

* **Chores**
  * Refactored sidebar configuration for improved maintainability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->