### PR TITLE
fix: racy renegotiation

### DIFF
--- a/lib/db/repositories/ChainSwapRepository.ts
+++ b/lib/db/repositories/ChainSwapRepository.ts
@@ -23,6 +23,10 @@ type ChainSwapDataTypeInsert = ChainSwapDataType & {
   scriptPubKey?: Buffer;
 };
 
+type UserLockupTransactionOptions = {
+  allowLockupFailedUpdate?: boolean;
+};
+
 class ChainSwapInfo {
   constructor(
     public chainSwap: ChainSwap,
@@ -120,6 +124,33 @@ class ChainSwapInfo {
 }
 
 class ChainSwapRepository {
+  private static readonly defaultUserLockupTransactionStatuses = [
+    SwapUpdateEvent.SwapCreated,
+    SwapUpdateEvent.TransactionMempool,
+    SwapUpdateEvent.TransactionZeroConfRejected,
+    SwapUpdateEvent.TransactionConfirmed,
+  ];
+
+  public static getUserLockupTransactionStatuses = (
+    options?: UserLockupTransactionOptions,
+  ) => {
+    const statuses = [
+      ...ChainSwapRepository.defaultUserLockupTransactionStatuses,
+    ];
+    if (options?.allowLockupFailedUpdate) {
+      statuses.push(SwapUpdateEvent.TransactionLockupFailed);
+    }
+
+    return statuses;
+  };
+
+  public static canActOnUserLockup = (
+    swap: ChainSwapInfo,
+    options?: UserLockupTransactionOptions,
+  ): boolean =>
+    swap.status !== SwapUpdateEvent.TransactionLockupFailed ||
+    options?.allowLockupFailedUpdate === true;
+
   public static getChainSwap = async (
     options: WhereOptions,
   ): Promise<ChainSwapInfo | null> => {
@@ -306,27 +337,52 @@ class ChainSwapRepository {
     onchainAmount: number,
     confirmed: boolean,
     lockupTransactionVout?: number,
-  ): Promise<ChainSwapInfo> =>
-    Database.sequelize.transaction(async (transaction) => {
-      swap.chainSwap = await swap.chainSwap.update(
-        {
-          status: confirmed
-            ? SwapUpdateEvent.TransactionConfirmed
-            : SwapUpdateEvent.TransactionMempool,
-        },
-        { transaction },
-      );
-      swap.receivingData = await swap.receivingData.update(
-        {
-          amount: onchainAmount,
-          transactionId: lockupTransactionId,
-          transactionVout: lockupTransactionVout,
-        },
-        { transaction },
-      );
+    options?: UserLockupTransactionOptions,
+  ): Promise<ChainSwapInfo> => {
+    const update = async () =>
+      Database.sequelize.transaction(async (transaction) => {
+        const [updatedRows] = await ChainSwap.update(
+          {
+            status: confirmed
+              ? SwapUpdateEvent.TransactionConfirmed
+              : SwapUpdateEvent.TransactionMempool,
+          },
+          {
+            transaction,
+            where: {
+              id: swap.id,
+              status: {
+                [Op.in]:
+                  ChainSwapRepository.getUserLockupTransactionStatuses(options),
+              },
+            },
+          },
+        );
 
-      return swap;
-    });
+        if (updatedRows === 0) {
+          return;
+        }
+
+        await ChainSwapData.update(
+          {
+            amount: onchainAmount,
+            transactionId: lockupTransactionId,
+            transactionVout: lockupTransactionVout,
+          },
+          {
+            transaction,
+            where: {
+              swapId: swap.id,
+              symbol: swap.receivingData.symbol,
+            },
+          },
+        );
+      });
+
+    return update().then(
+      async () => (await ChainSwapRepository.getChainSwap({ id: swap.id }))!,
+    );
+  };
 
   public static setExpectedAmounts = (
     swap: ChainSwapInfo,
@@ -423,4 +479,4 @@ class ChainSwapRepository {
 }
 
 export default ChainSwapRepository;
-export { ChainSwapInfo, ChainSwapDataTypeInsert };
+export { ChainSwapInfo, ChainSwapDataTypeInsert, UserLockupTransactionOptions };

--- a/lib/service/Renegotiator.ts
+++ b/lib/service/Renegotiator.ts
@@ -114,6 +114,7 @@ class Renegotiator {
             isTxConfirmed(txInfo)
               ? TransactionStatus.Confirmed
               : TransactionStatus.ZeroConfSafe,
+            { allowLockupFailedUpdate: true },
           );
         } else if (receivingCurrency.provider !== undefined) {
           const nursery = this.swapNursery.ethereumNurseries.find((nursery) =>
@@ -176,6 +177,7 @@ class Renegotiator {
               updatedSwap,
               transaction,
               formatEtherSwapValues(values),
+              { allowLockupFailedUpdate: true },
             );
           } else {
             const values = contracts.erc20Swap.interface.decodeEventLog(
@@ -188,6 +190,7 @@ class Renegotiator {
               updatedSwap,
               transaction,
               formatERC20SwapValues(values),
+              { allowLockupFailedUpdate: true },
             );
           }
         } else if (receivingCurrency.arkNode !== undefined) {
@@ -206,6 +209,7 @@ class Renegotiator {
               amount: swap.receivingData.amount!,
               address: swap.receivingData.lockupAddress,
             },
+            { allowLockupFailedUpdate: true },
           );
         } else {
           throw Errors.CURRENCY_NOT_FOUND(swap.pair);

--- a/lib/swap/ArkNursery.ts
+++ b/lib/swap/ArkNursery.ts
@@ -18,7 +18,10 @@ import {
 import TypedEventEmitter from '../consts/TypedEventEmitter';
 import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
-import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
+import type {
+  ChainSwapInfo,
+  UserLockupTransactionOptions,
+} from '../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../db/repositories/ChainSwapRepository';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
 import SwapRepository from '../db/repositories/SwapRepository';
@@ -122,7 +125,9 @@ class ArkNursery extends TypedEventEmitter<{
       await this.lock.acquire(`vhtlc.created:${vHtlc.address}`, async () => {
         await Promise.all([
           this.checkSubmarineLockup(arkNode, vHtlc, collectUnsubscribe),
-          this.checkChainSwapLockup(arkNode, vHtlc, collectUnsubscribe),
+          this.checkChainSwapLockup(arkNode, vHtlc, {
+            onUnsubscribe: collectUnsubscribe,
+          }),
         ]);
       });
     }
@@ -137,7 +142,9 @@ class ArkNursery extends TypedEventEmitter<{
   public checkChainSwapLockup = async (
     arkNode: ArkClient,
     vHtlc: CreatedVHtlc,
-    onUnsubscribe?: UnsubscribeHandler,
+    options?: UserLockupTransactionOptions & {
+      onUnsubscribe?: UnsubscribeHandler;
+    },
   ) => {
     let swap = await ChainSwapRepository.getChainSwapByData(
       {
@@ -145,13 +152,8 @@ class ArkNursery extends TypedEventEmitter<{
       },
       {
         status: {
-          [Op.in]: [
-            SwapUpdateEvent.SwapCreated,
-            SwapUpdateEvent.TransactionMempool,
-            SwapUpdateEvent.TransactionLockupFailed,
-            SwapUpdateEvent.TransactionZeroConfRejected,
-            SwapUpdateEvent.TransactionConfirmed,
-          ],
+          [Op.in]:
+            ChainSwapRepository.getUserLockupTransactionStatuses(options),
         },
       },
     );
@@ -164,7 +166,11 @@ class ArkNursery extends TypedEventEmitter<{
       return;
     }
 
-    await this.handleUnsubscribe(arkNode, vHtlc.address, onUnsubscribe);
+    await this.handleUnsubscribe(
+      arkNode,
+      vHtlc.address,
+      options?.onUnsubscribe,
+    );
 
     this.logger.info(
       `Found ${ArkClient.symbol} lockup vHTLC for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${vHtlc.txId}:${vHtlc.vout}`,
@@ -175,7 +181,15 @@ class ArkNursery extends TypedEventEmitter<{
       vHtlc.amount,
       true,
       vHtlc.vout,
+      options,
     );
+
+    if (!ChainSwapRepository.canActOnUserLockup(swap, options)) {
+      this.logger.debug(
+        `Not acting on lockup vHTLC of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
+      );
+      return;
+    }
 
     if (swap.receivingData.expectedAmount! > vHtlc.amount) {
       this.emit('chainSwap.lockup.failed', {

--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -21,7 +21,10 @@ import TypedEventEmitter from '../consts/TypedEventEmitter';
 import type { ERC20SwapValues, EtherSwapValues } from '../consts/Types';
 import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
-import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
+import type {
+  ChainSwapInfo,
+  UserLockupTransactionOptions,
+} from '../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../db/repositories/ChainSwapRepository';
 import ClaimTransactionRepository from '../db/repositories/ClaimTransactionRepository';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
@@ -156,6 +159,7 @@ class EthereumNursery extends TypedEventEmitter<{
     swap: Swap | ChainSwapInfo,
     transaction: Transaction | TransactionResponse,
     etherSwapValues: EtherSwapValues,
+    options?: UserLockupTransactionOptions,
   ) => {
     if (
       this.getSwapReceivingCurrency(swap) !==
@@ -182,7 +186,19 @@ class EthereumNursery extends TypedEventEmitter<{
             transaction.hash!,
             lockupAmount,
             true,
+            undefined,
+            options,
           );
+
+    if (
+      swap.type === SwapType.Chain &&
+      !ChainSwapRepository.canActOnUserLockup(swap as ChainSwapInfo, options)
+    ) {
+      this.logger.debug(
+        `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
+      );
+      return;
+    }
 
     if (etherSwapValues.claimAddress !== this.ethereumManager.address) {
       this.emit('lockup.failed', {
@@ -283,6 +299,7 @@ class EthereumNursery extends TypedEventEmitter<{
     swap: Swap | ChainSwapInfo,
     transaction: Transaction | TransactionResponse,
     erc20SwapValues: ERC20SwapValues,
+    options?: UserLockupTransactionOptions,
   ) => {
     const wallet = this.walletManager.wallets.get(
       this.getSwapReceivingCurrency(swap),
@@ -313,7 +330,19 @@ class EthereumNursery extends TypedEventEmitter<{
             transaction.hash!,
             lockupAmount,
             true,
+            undefined,
+            options,
           );
+
+    if (
+      swap.type === SwapType.Chain &&
+      !ChainSwapRepository.canActOnUserLockup(swap as ChainSwapInfo, options)
+    ) {
+      this.logger.debug(
+        `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
+      );
+      return;
+    }
 
     if (erc20SwapValues.claimAddress !== this.ethereumManager.address) {
       this.emit('lockup.failed', {

--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -30,7 +30,10 @@ import {
 import TypedEventEmitter from '../consts/TypedEventEmitter';
 import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
-import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
+import type {
+  ChainSwapInfo,
+  UserLockupTransactionOptions,
+} from '../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../db/repositories/ChainSwapRepository';
 import ClaimTransactionRepository from '../db/repositories/ClaimTransactionRepository';
 import RefundTransactionRepository from '../db/repositories/RefundTransactionRepository';
@@ -127,6 +130,7 @@ class UtxoNursery extends TypedEventEmitter<{
     wallet: Wallet,
     transaction: Transaction | LiquidTransaction,
     status: TransactionStatus,
+    options?: UserLockupTransactionOptions,
   ) => {
     const tweakedKey = tweakMusig(
       wallet.type,
@@ -153,7 +157,15 @@ class UtxoNursery extends TypedEventEmitter<{
       outputValue,
       status === TransactionStatus.Confirmed,
       swapOutput.vout,
+      options,
     );
+
+    if (!ChainSwapRepository.canActOnUserLockup(swap, options)) {
+      this.logger.debug(
+        `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
+      );
+      return;
+    }
 
     if (swap.receivingData.expectedAmount > outputValue || outputValue === 0) {
       let reason: string;
@@ -304,13 +316,7 @@ class UtxoNursery extends TypedEventEmitter<{
         },
         {
           status: {
-            [Op.or]: [
-              SwapUpdateEvent.SwapCreated,
-              SwapUpdateEvent.TransactionMempool,
-              SwapUpdateEvent.TransactionLockupFailed,
-              SwapUpdateEvent.TransactionZeroConfRejected,
-              SwapUpdateEvent.TransactionConfirmed,
-            ],
+            [Op.in]: ChainSwapRepository.getUserLockupTransactionStatuses(),
           },
         },
       );

--- a/test/integration/db/repositories/ChainSwapRepository.spec.ts
+++ b/test/integration/db/repositories/ChainSwapRepository.spec.ts
@@ -463,6 +463,48 @@ describe('ChainSwapRepository', () => {
     },
   );
 
+  test('should not overwrite failed user lockup transactions by default', async () => {
+    const swap = await createChainSwap(SwapUpdateEvent.TransactionLockupFailed);
+    const queried = (await ChainSwapRepository.getChainSwap({
+      id: swap.chainSwap.id,
+    }))!;
+
+    const updated = await ChainSwapRepository.setUserLockupTransaction(
+      queried,
+      'tx',
+      queried.receivingData.expectedAmount! + 1,
+      true,
+      1,
+    );
+
+    expect(updated.status).toEqual(SwapUpdateEvent.TransactionLockupFailed);
+    expect(updated.receivingData.transactionId).toBeNull();
+    expect(updated.receivingData.transactionVout).toBeNull();
+    expect(updated.receivingData.amount).toBeNull();
+  });
+
+  test('should update failed user lockup transactions when explicitly allowed', async () => {
+    const swap = await createChainSwap(SwapUpdateEvent.TransactionLockupFailed);
+    const queried = (await ChainSwapRepository.getChainSwap({
+      id: swap.chainSwap.id,
+    }))!;
+    const onchainAmount = queried.receivingData.expectedAmount! + 1;
+
+    const updated = await ChainSwapRepository.setUserLockupTransaction(
+      queried,
+      'tx',
+      onchainAmount,
+      true,
+      1,
+      { allowLockupFailedUpdate: true },
+    );
+
+    expect(updated.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    expect(updated.receivingData.transactionId).toEqual('tx');
+    expect(updated.receivingData.transactionVout).toEqual(1);
+    expect(updated.receivingData.amount).toEqual(onchainAmount);
+  });
+
   test('should set expected amounts', async () => {
     const swap = await createChainSwap();
 

--- a/test/integration/service/Renegotiator.spec.ts
+++ b/test/integration/service/Renegotiator.spec.ts
@@ -358,6 +358,7 @@ describe('Renegotiator', () => {
             confirmed
               ? TransactionStatus.Confirmed
               : TransactionStatus.ZeroConfSafe,
+            { allowLockupFailedUpdate: true },
           );
         },
       );
@@ -548,13 +549,18 @@ describe('Renegotiator', () => {
         expect(etherLockupTransaction).not.toHaveProperty('logs');
         expect(
           swapNursery.ethereumNurseries[0].checkEtherSwapLockup,
-        ).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
-          amount,
-          timelock,
-          preimageHash,
-          claimAddress: await signer.getAddress(),
-          refundAddress: await etherBase.getAddress(),
-        });
+        ).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          {
+            amount,
+            timelock,
+            preimageHash,
+            claimAddress: await signer.getAddress(),
+            refundAddress: await etherBase.getAddress(),
+          },
+          { allowLockupFailedUpdate: true },
+        );
       });
 
       test('should handle ERC20 lockups', async () => {
@@ -633,14 +639,19 @@ describe('Renegotiator', () => {
         expect(erc20LockupTransaction).not.toHaveProperty('logs');
         expect(
           swapNursery.ethereumNurseries[0].checkErc20SwapLockup,
-        ).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
-          amount,
-          timelock,
-          preimageHash,
-          tokenAddress: await token.getAddress(),
-          claimAddress: await signer.getAddress(),
-          refundAddress: await etherBase.getAddress(),
-        });
+        ).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          {
+            amount,
+            timelock,
+            preimageHash,
+            tokenAddress: await token.getAddress(),
+            claimAddress: await signer.getAddress(),
+            refundAddress: await etherBase.getAddress(),
+          },
+          { allowLockupFailedUpdate: true },
+        );
       });
     });
   });
@@ -713,12 +724,16 @@ describe('Renegotiator', () => {
         ).toHaveBeenCalledTimes(1);
         expect(
           swapNursery.arkNursery.checkChainSwapLockup,
-        ).toHaveBeenCalledWith(arkNode, {
-          txId: transactionId,
-          vout: transactionVout,
-          amount: 100_000,
-          address: lockupAddress,
-        });
+        ).toHaveBeenCalledWith(
+          arkNode,
+          {
+            txId: transactionId,
+            vout: transactionVout,
+            amount: 100_000,
+            address: lockupAddress,
+          },
+          { allowLockupFailedUpdate: true },
+        );
       } finally {
         if (previousArkCurrency) {
           currencies.set('ARK', previousArkCurrency);

--- a/test/unit/swap/ArkNursery.spec.ts
+++ b/test/unit/swap/ArkNursery.spec.ts
@@ -791,13 +791,7 @@ describe('ArkNursery', () => {
         },
         {
           status: {
-            [Op.in]: [
-              SwapUpdateEvent.SwapCreated,
-              SwapUpdateEvent.TransactionMempool,
-              SwapUpdateEvent.TransactionLockupFailed,
-              SwapUpdateEvent.TransactionZeroConfRejected,
-              SwapUpdateEvent.TransactionConfirmed,
-            ],
+            [Op.in]: ChainSwapRepository.getUserLockupTransactionStatuses(),
           },
         },
       );
@@ -853,6 +847,7 @@ describe('ArkNursery', () => {
         50000,
         true,
         0,
+        undefined,
       );
       expect(emittedEvent).not.toBeNull();
       expect(emittedEvent.swap).toEqual(updatedSwap);
@@ -914,12 +909,119 @@ describe('ArkNursery', () => {
         150000,
         true,
         0,
+        undefined,
       );
       expect(emittedEvent).not.toBeNull();
       expect(emittedEvent.swap).toEqual(updatedSwap);
       expect(emittedEvent.reason).toEqual(
         Errors.OVERPAID_AMOUNT(150000, 100000).message,
       );
+    });
+
+    test('should ignore duplicate lockup checks after chain swap lockup failed', async () => {
+      const swap = {
+        id: 'chain123',
+        type: SwapType.Chain,
+        receivingData: {
+          symbol: mockArkNode.symbol,
+          expectedAmount: 100000,
+        },
+      };
+
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(swap);
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          ...swap,
+          status: SwapUpdateEvent.TransactionLockupFailed,
+        });
+
+      const emitSpy = jest.spyOn(nursery, 'emit');
+
+      await nursery['checkChainSwapLockup'](mockArkNode, {
+        address: 'ark_address',
+        txId: 'txid',
+        vout: 0,
+        amount: 150000,
+      } as any);
+
+      expect(ChainSwapRepository.setUserLockupTransaction).toHaveBeenCalledWith(
+        swap,
+        'txid',
+        150000,
+        true,
+        0,
+        undefined,
+      );
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        'chainSwap.lockup',
+        expect.anything(),
+      );
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        'chainSwap.lockup.failed',
+        expect.anything(),
+      );
+
+      emitSpy.mockRestore();
+    });
+
+    test('should act on failed lockup when allowLockupFailedUpdate is set', async () => {
+      const swap = {
+        id: 'chain123',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.TransactionLockupFailed,
+        receivingData: {
+          symbol: mockArkNode.symbol,
+          expectedAmount: 100000,
+        },
+      };
+
+      const updatedSwap = {
+        ...swap,
+        status: SwapUpdateEvent.TransactionConfirmed,
+        receivingData: {
+          ...swap.receivingData,
+          lockupTransactionId: 'txid',
+          amount: 100000,
+        },
+      };
+
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(swap);
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue(updatedSwap);
+
+      let emittedEvent: any = null;
+      nursery.once('chainSwap.lockup', (data) => {
+        emittedEvent = data;
+      });
+
+      await nursery['checkChainSwapLockup'](
+        mockArkNode,
+        {
+          address: 'ark_address',
+          txId: 'txid',
+          vout: 0,
+          amount: 100000,
+        } as any,
+        { allowLockupFailedUpdate: true },
+      );
+
+      expect(ChainSwapRepository.setUserLockupTransaction).toHaveBeenCalledWith(
+        swap,
+        'txid',
+        100000,
+        true,
+        0,
+        { allowLockupFailedUpdate: true },
+      );
+      expect(emittedEvent).not.toBeNull();
+      expect(emittedEvent.swap).toEqual(updatedSwap);
+      expect(emittedEvent.lockupTransactionId).toEqual('txid');
     });
 
     test('should emit success for valid lockup', async () => {
@@ -969,6 +1071,7 @@ describe('ArkNursery', () => {
         100000,
         true,
         0,
+        undefined,
       );
       expect(emittedEvent).not.toBeNull();
       expect(emittedEvent.swap).toEqual(updatedSwap);

--- a/test/unit/swap/EthereumNursery.spec.ts
+++ b/test/unit/swap/EthereumNursery.spec.ts
@@ -1186,6 +1186,202 @@ describe('EthereumNursery', () => {
     await lockupFailedPromise;
   });
 
+  test('should ignore EtherSwap chain lockup after lockup failed', async () => {
+    const chainSwap = {
+      id: 'chain-eth-failed',
+      type: SwapType.Chain,
+      receivingData: {
+        symbol: 'ETH',
+        expectedAmount: 10,
+        timeoutBlockHeight: 11102219,
+      },
+    };
+
+    const setUserLockupTransaction = jest.fn().mockResolvedValue({
+      ...chainSwap,
+      status: SwapUpdateEvent.TransactionLockupFailed,
+    });
+    ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
+
+    const emitSpy = jest.spyOn(nursery, 'emit');
+
+    await nursery.checkEtherSwapLockup(
+      chainSwap as any,
+      exampleTransaction as any,
+      {
+        claimAddress: mockAddress,
+        amount: BigInt('100000000000'),
+        preimageHash: getHexString(examplePreimageHash),
+        timelock: chainSwap.receivingData.timeoutBlockHeight,
+      } as any,
+    );
+
+    expect(setUserLockupTransaction).toHaveBeenCalledWith(
+      chainSwap,
+      exampleTransaction.hash,
+      10,
+      true,
+      undefined,
+      undefined,
+    );
+    expect(emitSpy).not.toHaveBeenCalledWith('eth.lockup', expect.anything());
+    expect(emitSpy).not.toHaveBeenCalledWith(
+      'lockup.failed',
+      expect.anything(),
+    );
+
+    emitSpy.mockRestore();
+  });
+
+  test('should act on EtherSwap chain lockup when allowLockupFailedUpdate is set', async () => {
+    const chainSwap = {
+      id: 'chain-eth-allow',
+      type: SwapType.Chain,
+      receivingData: {
+        symbol: 'ETH',
+        expectedAmount: 10,
+        timeoutBlockHeight: 11102219,
+      },
+    };
+
+    const updatedSwap = {
+      ...chainSwap,
+      status: SwapUpdateEvent.TransactionConfirmed,
+    };
+
+    const setUserLockupTransaction = jest.fn().mockResolvedValue(updatedSwap);
+    ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
+
+    const lockupPromise = new Promise<void>((resolve) => {
+      nursery.once('eth.lockup', ({ swap, transactionHash }) => {
+        expect(swap).toEqual(updatedSwap);
+        expect(transactionHash).toEqual(exampleTransaction.hash);
+        resolve();
+      });
+    });
+
+    await nursery.checkEtherSwapLockup(
+      chainSwap as any,
+      exampleTransaction as any,
+      {
+        claimAddress: mockAddress,
+        amount: BigInt('100000000000'),
+        preimageHash: getHexString(examplePreimageHash),
+        timelock: chainSwap.receivingData.timeoutBlockHeight,
+      } as any,
+      { allowLockupFailedUpdate: true },
+    );
+
+    expect(setUserLockupTransaction).toHaveBeenCalledWith(
+      chainSwap,
+      exampleTransaction.hash,
+      10,
+      true,
+      undefined,
+      { allowLockupFailedUpdate: true },
+    );
+    await lockupPromise;
+  });
+
+  test('should ignore ERC20Swap chain lockup after lockup failed', async () => {
+    const chainSwap = {
+      id: 'chain-erc20-failed',
+      type: SwapType.Chain,
+      receivingData: {
+        symbol: 'USDT',
+        expectedAmount: 10,
+        timeoutBlockHeight: 11102222,
+      },
+    };
+
+    const setUserLockupTransaction = jest.fn().mockResolvedValue({
+      ...chainSwap,
+      status: SwapUpdateEvent.TransactionLockupFailed,
+    });
+    ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
+
+    const emitSpy = jest.spyOn(nursery, 'emit');
+
+    await nursery.checkErc20SwapLockup(
+      chainSwap as any,
+      exampleTransaction as any,
+      {
+        amount: BigInt('1000'),
+        claimAddress: mockAddress,
+        tokenAddress: mockTokenAddress,
+        timelock: chainSwap.receivingData.timeoutBlockHeight,
+        preimageHash: getHexString(examplePreimageHash),
+      } as any,
+    );
+
+    expect(setUserLockupTransaction).toHaveBeenCalledWith(
+      chainSwap,
+      exampleTransaction.hash,
+      10,
+      true,
+      undefined,
+      undefined,
+    );
+    expect(emitSpy).not.toHaveBeenCalledWith('erc20.lockup', expect.anything());
+    expect(emitSpy).not.toHaveBeenCalledWith(
+      'lockup.failed',
+      expect.anything(),
+    );
+
+    emitSpy.mockRestore();
+  });
+
+  test('should act on ERC20Swap chain lockup when allowLockupFailedUpdate is set', async () => {
+    const chainSwap = {
+      id: 'chain-erc20-allow',
+      type: SwapType.Chain,
+      receivingData: {
+        symbol: 'USDT',
+        expectedAmount: 10,
+        timeoutBlockHeight: 11102222,
+      },
+    };
+
+    const updatedSwap = {
+      ...chainSwap,
+      status: SwapUpdateEvent.TransactionConfirmed,
+    };
+
+    const setUserLockupTransaction = jest.fn().mockResolvedValue(updatedSwap);
+    ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
+
+    const lockupPromise = new Promise<void>((resolve) => {
+      nursery.once('erc20.lockup', ({ swap, transactionHash }) => {
+        expect(swap).toEqual(updatedSwap);
+        expect(transactionHash).toEqual(exampleTransaction.hash);
+        resolve();
+      });
+    });
+
+    await nursery.checkErc20SwapLockup(
+      chainSwap as any,
+      exampleTransaction as any,
+      {
+        amount: BigInt('1000'),
+        claimAddress: mockAddress,
+        tokenAddress: mockTokenAddress,
+        timelock: chainSwap.receivingData.timeoutBlockHeight,
+        preimageHash: getHexString(examplePreimageHash),
+      } as any,
+      { allowLockupFailedUpdate: true },
+    );
+
+    expect(setUserLockupTransaction).toHaveBeenCalledWith(
+      chainSwap,
+      exampleTransaction.hash,
+      10,
+      true,
+      undefined,
+      { allowLockupFailedUpdate: true },
+    );
+    await lockupPromise;
+  });
+
   test('should listen to ERC20Swap claim events', async () => {
     let emittedEvents = 0;
 

--- a/test/unit/swap/UtxoNursery.spec.ts
+++ b/test/unit/swap/UtxoNursery.spec.ts
@@ -381,13 +381,7 @@ describe('UtxoNursery', () => {
       { lockupAddress: address },
       {
         status: {
-          [Op.or]: [
-            SwapUpdateEvent.SwapCreated,
-            SwapUpdateEvent.TransactionMempool,
-            SwapUpdateEvent.TransactionLockupFailed,
-            SwapUpdateEvent.TransactionZeroConfRejected,
-            SwapUpdateEvent.TransactionConfirmed,
-          ],
+          [Op.in]: ChainSwapRepository.getUserLockupTransactionStatuses(),
         },
       },
     );
@@ -1431,10 +1425,92 @@ describe('UtxoNursery', () => {
           outputValue,
           true,
           0,
+          undefined,
         );
 
         getOutputValueSpy.mockRestore();
       },
     );
+
+    test('should ignore duplicate lockup checks after chain swap lockup failed', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+
+      const ourKeys = ECPair.makeRandom();
+      const theirPublicKey = Buffer.from(ECPair.makeRandom().publicKey);
+
+      const tree = swapTree(
+        false,
+        randomBytes(32),
+        Buffer.from(ourKeys.publicKey),
+        theirPublicKey,
+        210,
+      );
+
+      const transaction = new Transaction();
+      transaction.addOutput(
+        Scripts.p2trOutput(
+          tweakMusig(
+            CurrencyType.BitcoinLike,
+            createMusig(ourKeys, theirPublicKey),
+            tree,
+          ),
+        ),
+        123,
+      );
+
+      mockGetKeysByIndexResult = ourKeys;
+
+      const mockChainSwap = {
+        id: 'testChainSwap',
+        type: SwapType.Chain,
+        receivingData: {
+          keyIndex: 123,
+          expectedAmount: 100,
+          theirPublicKey: theirPublicKey.toString('hex'),
+          swapTree: JSON.stringify(SwapTreeSerializer.serializeSwapTree(tree)),
+        },
+      };
+
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          ...mockChainSwap,
+          status: SwapUpdateEvent.TransactionLockupFailed,
+        });
+
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(500);
+
+      const emitSpy = jest.spyOn(nursery, 'emit');
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(ChainSwapRepository.setUserLockupTransaction).toHaveBeenCalledWith(
+        mockChainSwap,
+        transaction.getId(),
+        500,
+        true,
+        0,
+        undefined,
+      );
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        'chainSwap.lockup.failed',
+        expect.anything(),
+      );
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        'chainSwap.lockup',
+        expect.anything(),
+      );
+
+      emitSpy.mockRestore();
+      getOutputValueSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/ArkLabsHQ/fulmine/pull/404#issuecomment-4359206462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of swap lockup state transitions to prevent invalid status updates.
  * System now exits early when a swap lockup has already failed, preventing unnecessary processing.

* **New Features**
  * Added control option for managing updates to failed lockup transactions.
  * Enhanced status verification consistency across all swap protocols (UTXO, Ethereum, Ark).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->