### PR TITLE
fix: sync linked swap and commitment on cooperative refund

### DIFF
--- a/lib/db/repositories/CommitmentRepository.ts
+++ b/lib/db/repositories/CommitmentRepository.ts
@@ -70,10 +70,6 @@ class CommitmentRepository {
         });
 
         if (existing !== null) {
-          if (existing.swapId !== null) {
-            throw new Error('linked commitment cannot be marked as refunded');
-          }
-
           existing.refunded = true;
           existing.transactionHash = transactionHash;
           await existing.save({ transaction });

--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -129,6 +129,16 @@ class EipSigner {
             lockupTransactionId,
           );
 
+      await EipSigner.setRefundSignatureCreated(swap);
+
+      const linkedCommitment = await CommitmentRepository.getBySwapId(swap.id);
+      if (linkedCommitment !== null) {
+        await CommitmentRepository.markRefunded(
+          linkedCommitment.lockupHash,
+          lockupTransactionId,
+        );
+      }
+
       const sidecarRes = await this.sidecar.signEvmRefund(
         manager.networkDetails.symbol,
         contractAddress,
@@ -139,12 +149,6 @@ class EipSigner {
           : (lockupValues as ERC20SwapValues).tokenAddress,
         lockupValues.timelock,
       );
-
-      if (swap.type === SwapType.Chain) {
-        await ChainSwapRepository.setRefundSignatureCreated(swap.id);
-      } else {
-        await SwapRepository.setRefundSignatureCreated(swap.id);
-      }
 
       return `0x${getHexString(sidecarRes)}`;
     });
@@ -216,9 +220,38 @@ class EipSigner {
         tokenAddress,
       });
 
-      this.logger.debug(
-        `Creating EIP-712 signature for refund of unlinked commitment ${lockupHash}: ${transactionHash}`,
-      );
+      let linkedSwap: Swap | ChainSwapInfo | undefined;
+      const existingCommitment =
+        await CommitmentRepository.getByLockupHash(lockupHash);
+      if (existingCommitment !== null && existingCommitment.swapId !== null) {
+        const { swap, lightningCurrency } = await this.getSwap(
+          existingCommitment.swapId,
+        );
+        linkedSwap = swap;
+        const rejectionReason = await MusigSigner.refundNonEligibilityReason(
+          swap,
+          lightningCurrency,
+        );
+        if (rejectionReason !== undefined) {
+          this.logger.verbose(
+            `Not creating EIP-712 signature for refund of commitment ${lockupHash} linked to ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${rejectionReason}`,
+          );
+          throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(rejectionReason);
+        }
+
+        this.logger.debug(
+          `Creating EIP-712 signature for refund of linked commitment ${lockupHash}: ${transactionHash}`,
+        );
+      } else {
+        this.logger.debug(
+          `Creating EIP-712 signature for refund of unlinked commitment ${lockupHash}: ${transactionHash}`,
+        );
+      }
+
+      if (linkedSwap !== undefined) {
+        await EipSigner.setRefundSignatureCreated(linkedSwap);
+      }
+      await CommitmentRepository.markRefunded(lockupHash, transactionHash);
 
       const sidecarRes = await this.sidecar.signEvmRefund(
         manager.networkDetails.symbol,
@@ -228,10 +261,19 @@ class EipSigner {
         tokenAddress,
         values.timelock,
       );
-      await CommitmentRepository.markRefunded(lockupHash, transactionHash);
 
       return `0x${getHexString(sidecarRes)}`;
     });
+
+  private static setRefundSignatureCreated = async (
+    swap: Swap | ChainSwapInfo,
+  ): Promise<void> => {
+    if (swap.type === SwapType.Chain) {
+      await ChainSwapRepository.setRefundSignatureCreated(swap.id);
+    } else {
+      await SwapRepository.setRefundSignatureCreated(swap.id);
+    }
+  };
 
   private validateRefundAddressSignature = (
     chainSymbol: string,

--- a/test/integration/db/repositories/CommitmentRepository.spec.ts
+++ b/test/integration/db/repositories/CommitmentRepository.spec.ts
@@ -259,16 +259,19 @@ describe('CommitmentRepository', () => {
       expect(result.swapId).toBeNull();
     });
 
-    test('should throw when commitment is already linked to a swap', async () => {
+    test('should mark existing linked commitment as refunded', async () => {
       const commitment = createCommitment({ swapId: 'linked-swap' });
       await CommitmentRepository.create(commitment);
 
-      await expect(
-        CommitmentRepository.markRefunded(
-          commitment.lockupHash,
-          commitment.transactionHash,
-        ),
-      ).rejects.toThrow('linked commitment cannot be marked as refunded');
+      const newTransactionHash = `0x${randomBytes(32).toString('hex')}`;
+      const result = await CommitmentRepository.markRefunded(
+        commitment.lockupHash,
+        newTransactionHash,
+      );
+
+      expect(result.refunded).toEqual(true);
+      expect(result.swapId).toEqual('linked-swap');
+      expect(result.transactionHash).toEqual(newTransactionHash);
     });
   });
 });

--- a/test/integration/service/cooperative/EipSigner.spec.ts
+++ b/test/integration/service/cooperative/EipSigner.spec.ts
@@ -11,8 +11,10 @@ import {
   SwapUpdateEvent,
   SwapVersion,
 } from '../../../../lib/consts/Enums';
+import { RefundStatus } from '../../../../lib/db/models/RefundTransaction';
 import ChainSwapRepository from '../../../../lib/db/repositories/ChainSwapRepository';
 import CommitmentRepository from '../../../../lib/db/repositories/CommitmentRepository';
+import RefundTransactionRepository from '../../../../lib/db/repositories/RefundTransactionRepository';
 import SwapRepository from '../../../../lib/db/repositories/SwapRepository';
 import Errors from '../../../../lib/service/Errors';
 import EipSigner from '../../../../lib/service/cooperative/EipSigner';
@@ -32,12 +34,21 @@ jest.mock('../../../../lib/db/repositories/SwapRepository', () => ({
 
 jest.mock('../../../../lib/db/repositories/ChainSwapRepository', () => ({
   getChainSwap: jest.fn().mockResolvedValue(null),
+  setRefundSignatureCreated: jest.fn(),
 }));
 
 jest.mock('../../../../lib/db/repositories/CommitmentRepository', () => ({
   getBySwapId: jest.fn().mockResolvedValue(null),
+  getByLockupHash: jest.fn().mockResolvedValue(null),
   markRefunded: jest.fn().mockResolvedValue(undefined),
 }));
+
+jest.mock(
+  '../../../../lib/db/repositories/RefundTransactionRepository',
+  () => ({
+    getTransactionForSwap: jest.fn().mockResolvedValue(null),
+  }),
+);
 
 describe('EipSigner', () => {
   let setup: EthereumSetup;
@@ -127,9 +138,15 @@ describe('EipSigner', () => {
     jest.clearAllMocks();
 
     SwapRepository.getSwap = jest.fn().mockResolvedValue(null);
+    SwapRepository.setRefundSignatureCreated = jest.fn();
     ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
+    ChainSwapRepository.setRefundSignatureCreated = jest.fn();
     CommitmentRepository.getBySwapId = jest.fn().mockResolvedValue(null);
+    CommitmentRepository.getByLockupHash = jest.fn().mockResolvedValue(null);
     CommitmentRepository.markRefunded = jest.fn().mockResolvedValue(undefined);
+    RefundTransactionRepository.getTransactionForSwap = jest
+      .fn()
+      .mockResolvedValue(null);
 
     ethereumManager.contractsForAddress = jest.fn().mockResolvedValue({
       etherSwap,
@@ -241,6 +258,58 @@ describe('EipSigner', () => {
 
     expect(SwapRepository.setRefundSignatureCreated).toHaveBeenCalledTimes(1);
     expect(SwapRepository.setRefundSignatureCreated).toHaveBeenCalledWith(id);
+    expect(CommitmentRepository.markRefunded).not.toHaveBeenCalled();
+  });
+
+  test('should mark a linked commitment refunded after a swap-id refund', async () => {
+    const zerosPreimageHash = Buffer.alloc(32, 0);
+    const amount = BigInt(10) ** BigInt(17);
+    const timelock = (await setup.provider.getBlockNumber()) + 21;
+    const claimAddress = await setup.etherBase.getAddress();
+
+    const lockupTx = await etherSwap['lock(bytes32,address,uint256)'](
+      zerosPreimageHash,
+      claimAddress,
+      timelock,
+      { value: amount },
+    );
+    await lockupTx.wait(1);
+
+    const linkedLockupHash = await computeLockupHash(etherSwap, {
+      preimageHash: zerosPreimageHash,
+      amount,
+      claimAddress,
+      refundAddress: claimAddress,
+      timelock: BigInt(timelock),
+    });
+
+    const lockupAddress = await etherSwap.getAddress();
+    const id = 'linked-submarine-swap';
+    SwapRepository.getSwap = jest.fn().mockResolvedValue({
+      id,
+      lockupAddress,
+      orderSide: 1,
+      pair: 'RBTC/BTC',
+      type: SwapType.Submarine,
+      version: SwapVersion.Taproot,
+      timeoutBlockHeight: timelock,
+      preimageHash: getHexString(zerosPreimageHash),
+      status: SwapUpdateEvent.InvoiceFailedToPay,
+      onchainAmount: Number(amount / etherDecimals),
+      lockupTransactionId: lockupTx.hash,
+    });
+    CommitmentRepository.getBySwapId = jest.fn().mockResolvedValue({
+      lockupHash: linkedLockupHash,
+      swapId: id,
+    });
+
+    await eipSigner.signSwapRefund(id);
+
+    expect(CommitmentRepository.getBySwapId).toHaveBeenCalledWith(id);
+    expect(CommitmentRepository.markRefunded).toHaveBeenCalledWith(
+      linkedLockupHash,
+      lockupTx.hash,
+    );
   });
 
   test('should refund chain EtherSwap cooperatively', async () => {
@@ -293,6 +362,65 @@ describe('EipSigner', () => {
 
     expect(ChainSwapRepository.setRefundSignatureCreated).toHaveBeenCalledTimes(
       1,
+    );
+    expect(ChainSwapRepository.setRefundSignatureCreated).toHaveBeenCalledWith(
+      id,
+    );
+    expect(CommitmentRepository.markRefunded).not.toHaveBeenCalled();
+  });
+
+  test('should mark a linked commitment refunded after a chain-swap-id refund', async () => {
+    const zerosPreimageHash = Buffer.alloc(32, 0);
+    const amount = BigInt(10) ** BigInt(17);
+    const timelock = (await setup.provider.getBlockNumber()) + 21;
+    const claimAddress = await setup.etherBase.getAddress();
+
+    const lockupTx = await etherSwap['lock(bytes32,address,uint256)'](
+      zerosPreimageHash,
+      claimAddress,
+      timelock,
+      { value: amount },
+    );
+    await lockupTx.wait(1);
+
+    const linkedLockupHash = await computeLockupHash(etherSwap, {
+      preimageHash: zerosPreimageHash,
+      amount,
+      claimAddress,
+      refundAddress: claimAddress,
+      timelock: BigInt(timelock),
+    });
+
+    const lockupAddress = await etherSwap.getAddress();
+    const id = 'linked-chain-swap';
+    ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
+      id,
+      type: SwapType.Chain,
+      version: SwapVersion.Taproot,
+      preimageHash: getHexString(zerosPreimageHash),
+      status: SwapUpdateEvent.InvoiceFailedToPay,
+      sendingData: {
+        transactionId: null,
+      },
+      receivingData: {
+        lockupAddress,
+        symbol: 'RBTC',
+        timeoutBlockHeight: timelock,
+        amount: Number(amount / etherDecimals),
+        lockupTransactionId: lockupTx.hash,
+      },
+    });
+    CommitmentRepository.getBySwapId = jest.fn().mockResolvedValue({
+      lockupHash: linkedLockupHash,
+      swapId: id,
+    });
+
+    await eipSigner.signSwapRefund(id);
+
+    expect(CommitmentRepository.getBySwapId).toHaveBeenCalledWith(id);
+    expect(CommitmentRepository.markRefunded).toHaveBeenCalledWith(
+      linkedLockupHash,
+      lockupTx.hash,
     );
     expect(ChainSwapRepository.setRefundSignatureCreated).toHaveBeenCalledWith(
       id,
@@ -1054,6 +1182,283 @@ describe('EipSigner', () => {
           'invalid refund address signature',
         ),
       );
+    });
+
+    test('should refund linked commitment when the swap is in a failed status', async () => {
+      const amount = BigInt(10) ** BigInt(17);
+      const timelock = (await setup.provider.getBlockNumber()) + 21;
+      const claimAddress = await setup.etherBase.getAddress();
+
+      const lockupTx = await etherSwap['lock(bytes32,address,uint256)'](
+        zerosPreimageHash,
+        claimAddress,
+        timelock,
+        { value: amount },
+      );
+      await lockupTx.wait(1);
+
+      const expectedLockupHash = await computeLockupHash(etherSwap, {
+        preimageHash: zerosPreimageHash,
+        amount,
+        claimAddress,
+        refundAddress: claimAddress,
+        timelock: BigInt(timelock),
+      });
+
+      CommitmentRepository.getByLockupHash = jest.fn().mockResolvedValue({
+        lockupHash: expectedLockupHash,
+        swapId: 'linked-failed-swap',
+      });
+      SwapRepository.getSwap = jest.fn().mockResolvedValue({
+        id: 'linked-failed-swap',
+        orderSide: 1,
+        pair: 'RBTC/BTC',
+        type: SwapType.Submarine,
+        version: SwapVersion.Taproot,
+        status: SwapUpdateEvent.InvoiceFailedToPay,
+      });
+
+      const refundAddressSignature = await signRefundAddressProof(
+        'RBTC',
+        lockupTx.hash,
+      );
+
+      const signature = await eipSigner.signCommitmentRefund(
+        'RBTC',
+        lockupTx.hash,
+        refundAddressSignature,
+      );
+      expect(signature).toBeDefined();
+      expect(CommitmentRepository.markRefunded).toHaveBeenCalledWith(
+        expectedLockupHash,
+        lockupTx.hash,
+      );
+      expect(SwapRepository.setRefundSignatureCreated).toHaveBeenCalledWith(
+        'linked-failed-swap',
+      );
+    });
+
+    test('should mark a linked chain swap refund signature created', async () => {
+      const amount = BigInt(10) ** BigInt(17);
+      const timelock = (await setup.provider.getBlockNumber()) + 21;
+      const claimAddress = await setup.etherBase.getAddress();
+
+      const lockupTx = await etherSwap['lock(bytes32,address,uint256)'](
+        zerosPreimageHash,
+        claimAddress,
+        timelock,
+        { value: amount },
+      );
+      await lockupTx.wait(1);
+
+      const expectedLockupHash = await computeLockupHash(etherSwap, {
+        preimageHash: zerosPreimageHash,
+        amount,
+        claimAddress,
+        refundAddress: claimAddress,
+        timelock: BigInt(timelock),
+      });
+
+      CommitmentRepository.getByLockupHash = jest.fn().mockResolvedValue({
+        lockupHash: expectedLockupHash,
+        swapId: 'linked-failed-chain-swap',
+      });
+      ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
+        id: 'linked-failed-chain-swap',
+        type: SwapType.Chain,
+        version: SwapVersion.Taproot,
+        status: SwapUpdateEvent.InvoiceFailedToPay,
+        sendingData: {
+          transactionId: null,
+        },
+        receivingData: {
+          symbol: 'RBTC',
+        },
+      });
+
+      const refundAddressSignature = await signRefundAddressProof(
+        'RBTC',
+        lockupTx.hash,
+      );
+
+      await eipSigner.signCommitmentRefund(
+        'RBTC',
+        lockupTx.hash,
+        refundAddressSignature,
+      );
+
+      expect(
+        ChainSwapRepository.setRefundSignatureCreated,
+      ).toHaveBeenCalledWith('linked-failed-chain-swap');
+      expect(SwapRepository.setRefundSignatureCreated).not.toHaveBeenCalled();
+    });
+
+    test('should not touch swap repos when commitment exists but is unlinked', async () => {
+      const amount = BigInt(10) ** BigInt(17);
+      const timelock = (await setup.provider.getBlockNumber()) + 21;
+      const claimAddress = await setup.etherBase.getAddress();
+
+      const lockupTx = await etherSwap['lock(bytes32,address,uint256)'](
+        zerosPreimageHash,
+        claimAddress,
+        timelock,
+        { value: amount },
+      );
+      await lockupTx.wait(1);
+
+      const expectedLockupHash = await computeLockupHash(etherSwap, {
+        preimageHash: zerosPreimageHash,
+        amount,
+        claimAddress,
+        refundAddress: claimAddress,
+        timelock: BigInt(timelock),
+      });
+
+      CommitmentRepository.getByLockupHash = jest.fn().mockResolvedValue({
+        lockupHash: expectedLockupHash,
+        swapId: null,
+      });
+
+      const refundAddressSignature = await signRefundAddressProof(
+        'RBTC',
+        lockupTx.hash,
+      );
+
+      await eipSigner.signCommitmentRefund(
+        'RBTC',
+        lockupTx.hash,
+        refundAddressSignature,
+      );
+
+      expect(CommitmentRepository.markRefunded).toHaveBeenCalledWith(
+        expectedLockupHash,
+        lockupTx.hash,
+      );
+      expect(SwapRepository.getSwap).not.toHaveBeenCalled();
+      expect(ChainSwapRepository.getChainSwap).not.toHaveBeenCalled();
+      expect(SwapRepository.setRefundSignatureCreated).not.toHaveBeenCalled();
+      expect(
+        ChainSwapRepository.setRefundSignatureCreated,
+      ).not.toHaveBeenCalled();
+    });
+
+    test('should reject linked commitment when the swap is not in a failed status', async () => {
+      const amount = BigInt(10) ** BigInt(17);
+      const timelock = (await setup.provider.getBlockNumber()) + 21;
+      const claimAddress = await setup.etherBase.getAddress();
+
+      const lockupTx = await etherSwap['lock(bytes32,address,uint256)'](
+        zerosPreimageHash,
+        claimAddress,
+        timelock,
+        { value: amount },
+      );
+      await lockupTx.wait(1);
+
+      const expectedLockupHash = await computeLockupHash(etherSwap, {
+        preimageHash: zerosPreimageHash,
+        amount,
+        claimAddress,
+        refundAddress: claimAddress,
+        timelock: BigInt(timelock),
+      });
+
+      CommitmentRepository.getByLockupHash = jest.fn().mockResolvedValue({
+        lockupHash: expectedLockupHash,
+        swapId: 'linked-active-swap',
+      });
+      SwapRepository.getSwap = jest.fn().mockResolvedValue({
+        id: 'linked-active-swap',
+        orderSide: 1,
+        pair: 'RBTC/BTC',
+        type: SwapType.Submarine,
+        version: SwapVersion.Taproot,
+        status: SwapUpdateEvent.InvoiceSet,
+      });
+
+      const refundAddressSignature = await signRefundAddressProof(
+        'RBTC',
+        lockupTx.hash,
+      );
+
+      await expect(
+        eipSigner.signCommitmentRefund(
+          'RBTC',
+          lockupTx.hash,
+          refundAddressSignature,
+        ),
+      ).rejects.toEqual(
+        Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+          RefundRejectionReason.StatusNotEligible,
+        ),
+      );
+      expect(CommitmentRepository.markRefunded).not.toHaveBeenCalled();
+    });
+
+    test('should reject linked chain swap when its refund tx is not confirmed', async () => {
+      const amount = BigInt(10) ** BigInt(17);
+      const timelock = (await setup.provider.getBlockNumber()) + 21;
+      const claimAddress = await setup.etherBase.getAddress();
+
+      const lockupTx = await etherSwap['lock(bytes32,address,uint256)'](
+        zerosPreimageHash,
+        claimAddress,
+        timelock,
+        { value: amount },
+      );
+      await lockupTx.wait(1);
+
+      const expectedLockupHash = await computeLockupHash(etherSwap, {
+        preimageHash: zerosPreimageHash,
+        amount,
+        claimAddress,
+        refundAddress: claimAddress,
+        timelock: BigInt(timelock),
+      });
+
+      const id = 'linked-chain-swap-pending-refund';
+      CommitmentRepository.getByLockupHash = jest.fn().mockResolvedValue({
+        lockupHash: expectedLockupHash,
+        swapId: id,
+      });
+      ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
+        id,
+        type: SwapType.Chain,
+        version: SwapVersion.Taproot,
+        status: SwapUpdateEvent.TransactionRefunded,
+        sendingData: {
+          transactionId: 'sending-tx',
+        },
+        receivingData: {
+          symbol: 'RBTC',
+        },
+      });
+      RefundTransactionRepository.getTransactionForSwap = jest
+        .fn()
+        .mockResolvedValue({
+          status: RefundStatus.Pending,
+        });
+
+      const refundAddressSignature = await signRefundAddressProof(
+        'RBTC',
+        lockupTx.hash,
+      );
+
+      await expect(
+        eipSigner.signCommitmentRefund(
+          'RBTC',
+          lockupTx.hash,
+          refundAddressSignature,
+        ),
+      ).rejects.toEqual(
+        Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
+          RefundRejectionReason.RefundNotConfirmed,
+        ),
+      );
+      expect(CommitmentRepository.markRefunded).not.toHaveBeenCalled();
+      expect(
+        ChainSwapRepository.setRefundSignatureCreated,
+      ).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #1384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refund processing for commitments linked to swaps no longer blocks the operation and now properly updates transaction records.

* **Improvements**
  * Enhanced refund signature tracking and eligibility validation when commitments are associated with swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->