### PR TITLE
fix: skip commitment lookup for server lockups

### DIFF
--- a/lib/service/cooperative/DeferredClaimer.ts
+++ b/lib/service/cooperative/DeferredClaimer.ts
@@ -486,6 +486,7 @@ class DeferredClaimer extends CoopSignerBase<{
               manager.provider,
               contracts.etherSwap,
               transactionId,
+              true,
             );
           },
           RPC_LOOKUP_CONCURRENCY,
@@ -535,6 +536,7 @@ class DeferredClaimer extends CoopSignerBase<{
               manager.provider,
               contracts.erc20Swap,
               transactionId,
+              true,
             );
           },
           RPC_LOOKUP_CONCURRENCY,

--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -121,12 +121,14 @@ class EipSigner {
             manager.provider,
             contracts.etherSwap,
             lockupTransactionId,
+            true,
           )
         : await queryERC20SwapValuesFromLock(
             swap,
             manager.provider,
             contracts.erc20Swap,
             lockupTransactionId,
+            true,
           );
 
       await EipSigner.setRefundSignatureCreated(swap);

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -924,6 +924,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
             manager.provider,
             contracts.etherSwap,
             txToClaim!,
+            true,
           ),
           payRes.preimage,
         );
@@ -948,6 +949,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
             manager.provider,
             contracts.erc20Swap,
             txToClaim!,
+            true,
           ),
           payRes.preimage,
         );
@@ -2140,6 +2142,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       nursery.ethereumManager!.provider,
       contracts.etherSwap,
       lockupTransactionId!,
+      false,
     );
     const contractTransaction = await contracts.contractHandler.refundEther(
       swap,
@@ -2196,6 +2199,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       nursery.ethereumManager.provider,
       contracts.erc20Swap,
       lockupTransactionId!,
+      false,
     );
     const contractTransaction = await contracts.contractHandler.refundToken(
       swap,

--- a/lib/wallet/ethereum/contracts/ContractUtils.ts
+++ b/lib/wallet/ethereum/contracts/ContractUtils.ts
@@ -123,12 +123,13 @@ export const queryEtherSwapValuesFromLock = async (
   provider: Provider,
   etherSwap: EtherSwap,
   lockTransactionHash: string,
+  lockedByUser: boolean,
 ): Promise<EtherSwapValues> =>
   querySwapValuesFromLock(
     provider,
     etherSwap,
     lockTransactionHash,
-    await getIdentifier(swap),
+    await getIdentifier(swap, lockedByUser),
     formatEtherSwapValues,
     undefined,
   );
@@ -138,12 +139,13 @@ export const queryERC20SwapValuesFromLock = async (
   provider: Provider,
   erc20Swap: ERC20Swap,
   lockTransactionHash: string,
+  lockedByUser: boolean,
 ): Promise<ERC20SwapValues> =>
   querySwapValuesFromLock(
     provider,
     erc20Swap,
     lockTransactionHash,
-    await getIdentifier(swap),
+    await getIdentifier(swap, lockedByUser),
     formatERC20SwapValues,
     undefined,
   );
@@ -203,11 +205,15 @@ export const formatERC20SwapValues = (
   };
 };
 
-const getIdentifier = async (swap: AnySwap): Promise<LockupIdentifier> => {
-  // When there is a commitment, we use the lockup hash
-  const commitment = await CommitmentRepository.getBySwapId(swap.id);
-  if (commitment !== null && commitment !== undefined) {
-    return { lockupHash: commitment.lockupHash };
+const getIdentifier = async (
+  swap: AnySwap,
+  lockedByUser: boolean,
+): Promise<LockupIdentifier> => {
+  if (lockedByUser) {
+    const commitment = await CommitmentRepository.getBySwapId(swap.id);
+    if (commitment !== null && commitment !== undefined) {
+      return { lockupHash: commitment.lockupHash };
+    }
   }
 
   return { preimageHash: getHexBuffer(swap.preimageHash) };

--- a/test/integration/wallet/ethereum/contracts/ContractUtils.spec.ts
+++ b/test/integration/wallet/ethereum/contracts/ContractUtils.spec.ts
@@ -155,6 +155,7 @@ describe('ContractUtils', () => {
           setup.provider,
           etherSwap,
           etherSwapLockTransactionHash,
+          true,
         ),
       ).toEqual(etherSwapValues);
 
@@ -168,6 +169,7 @@ describe('ContractUtils', () => {
           setup.provider,
           erc20Swap,
           erc20SwapLockTransactionHash,
+          true,
         ),
       ).toEqual(erc20SwapValues);
 
@@ -186,6 +188,7 @@ describe('ContractUtils', () => {
           setup.provider,
           etherSwap,
           etherSwapLockTransactionHash,
+          true,
         ),
       ).rejects.toEqual(
         Errors.INVALID_LOCKUP_TRANSACTION(etherSwapLockTransactionHash),
@@ -205,6 +208,7 @@ describe('ContractUtils', () => {
           setup.provider,
           etherSwap,
           etherSwapLockTransactionHash,
+          true,
         ),
       ).toEqual(etherSwapValues);
 
@@ -222,6 +226,7 @@ describe('ContractUtils', () => {
           setup.provider,
           erc20Swap,
           erc20SwapLockTransactionHash,
+          true,
         ),
       ).toEqual(erc20SwapValues);
 
@@ -239,10 +244,59 @@ describe('ContractUtils', () => {
           setup.provider,
           etherSwap,
           etherSwapLockTransactionHash,
+          true,
         ),
       ).rejects.toEqual(
         Errors.INVALID_LOCKUP_TRANSACTION(etherSwapLockTransactionHash),
       );
+    });
+  });
+
+  describe('without consulting commitment', () => {
+    test('should not query commitments and match EtherSwap by preimageHash', async () => {
+      expect(
+        await queryEtherSwapValuesFromLock(
+          swap,
+          setup.provider,
+          etherSwap,
+          etherSwapLockTransactionHash,
+          false,
+        ),
+      ).toEqual(etherSwapValues);
+
+      expect(CommitmentRepository.getBySwapId).not.toHaveBeenCalled();
+    });
+
+    test('should not query commitments and match ERC20Swap by preimageHash', async () => {
+      expect(
+        await queryERC20SwapValuesFromLock(
+          swap,
+          setup.provider,
+          erc20Swap,
+          erc20SwapLockTransactionHash,
+          false,
+        ),
+      ).toEqual(erc20SwapValues);
+
+      expect(CommitmentRepository.getBySwapId).not.toHaveBeenCalled();
+    });
+
+    test('should ignore an existing commitment row when lockedByUser is false', async () => {
+      getBySwapIdSpy.mockResolvedValue({
+        lockupHash: '0x' + 'aa'.repeat(32),
+      } as any);
+
+      expect(
+        await queryEtherSwapValuesFromLock(
+          swap,
+          setup.provider,
+          etherSwap,
+          etherSwapLockTransactionHash,
+          false,
+        ),
+      ).toEqual(etherSwapValues);
+
+      expect(CommitmentRepository.getBySwapId).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -12,6 +12,7 @@ import type ReverseSwap from '../../../lib/db/models/ReverseSwap';
 import { NodeType } from '../../../lib/db/models/ReverseSwap';
 import type { ChainSwapInfo } from '../../../lib/db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
+import RefundTransactionRepository from '../../../lib/db/repositories/RefundTransactionRepository';
 import ReverseSwapRepository from '../../../lib/db/repositories/ReverseSwapRepository';
 import SwapRepository from '../../../lib/db/repositories/SwapRepository';
 import WrappedSwapRepository from '../../../lib/db/repositories/WrappedSwapRepository';
@@ -20,6 +21,10 @@ import type NotificationClient from '../../../lib/notifications/NotificationClie
 import Errors from '../../../lib/swap/Errors';
 import SwapNursery from '../../../lib/swap/SwapNursery';
 import type { Currency } from '../../../lib/wallet/WalletManager';
+import {
+  queryERC20SwapValuesFromLock,
+  queryEtherSwapValuesFromLock,
+} from '../../../lib/wallet/ethereum/contracts/ContractUtils';
 
 let mockGetSwapResult: any = null;
 let mockGetChainSwapResult: any = null;
@@ -28,6 +33,11 @@ jest.mock('../../../lib/db/repositories/SwapRepository');
 jest.mock('../../../lib/db/repositories/ReverseSwapRepository');
 jest.mock('../../../lib/db/repositories/ChainSwapRepository');
 jest.mock('../../../lib/db/repositories/WrappedSwapRepository');
+jest.mock('../../../lib/db/repositories/RefundTransactionRepository');
+jest.mock('../../../lib/wallet/ethereum/contracts/ContractUtils', () => ({
+  queryEtherSwapValuesFromLock: jest.fn(),
+  queryERC20SwapValuesFromLock: jest.fn(),
+}));
 
 // Mock all the classes that SwapNursery instantiates
 jest.mock('../../../lib/swap/hooks/TransactionHook', () =>
@@ -1479,6 +1489,113 @@ describe('SwapNursery', () => {
         confirmed: true,
         emitFailure: false,
         refundTransaction: refundTransactionId,
+      });
+    });
+
+    describe('EVM refund', () => {
+      const lockupTxId = '0xservertx';
+
+      const buildEthereumNursery = (extras: Record<string, any> = {}) => ({
+        ethereumManager: {
+          provider: {} as any,
+          address: '0xboltz',
+          networkDetails: { name: 'Ethereum' },
+          hasSymbol: jest.fn().mockReturnValue(true),
+          contractsForAddress: jest.fn().mockResolvedValue({
+            etherSwap: {} as any,
+            erc20Swap: {} as any,
+            contractHandler: {
+              refundEther: jest.fn().mockResolvedValue({
+                hash: '0xrefund',
+                gasPrice: 1n,
+                gasLimit: 1n,
+              }),
+              refundToken: jest.fn().mockResolvedValue({
+                hash: '0xrefund',
+                gasPrice: 1n,
+                gasLimit: 1n,
+              }),
+            },
+          }),
+          ...extras,
+        },
+      });
+
+      const buildChainSwap = () =>
+        ({
+          id: 'chain-swap-id',
+          type: SwapType.Chain,
+          preimageHash: 'aa'.repeat(32),
+          sendingData: {
+            lockupAddress: '0xserverlock',
+            transactionId: lockupTxId,
+          },
+        }) as unknown as ChainSwapInfo;
+
+      beforeEach(() => {
+        (
+          WrappedSwapRepository.setTransactionRefunded as jest.Mock
+        ).mockImplementation(async (swap) => swap);
+        (
+          RefundTransactionRepository.addTransaction as jest.Mock
+        ).mockResolvedValue(undefined);
+        (queryEtherSwapValuesFromLock as jest.Mock)
+          .mockReset()
+          .mockResolvedValue({
+            amount: 1n,
+            claimAddress: '0xclaim',
+            refundAddress: '0xboltz',
+            timelock: 1,
+            preimageHash: Buffer.alloc(32),
+          });
+        (queryERC20SwapValuesFromLock as jest.Mock)
+          .mockReset()
+          .mockResolvedValue({
+            amount: 1n,
+            claimAddress: '0xclaim',
+            refundAddress: '0xboltz',
+            timelock: 1,
+            preimageHash: Buffer.alloc(32),
+            tokenAddress: '0xtoken',
+          });
+      });
+
+      test('refundEther passes lockedByUser: false (regression: chain swap server-side refund must not consult user-side commitment)', async () => {
+        (swapNursery as any).ethereumNurseries = [buildEthereumNursery()];
+        const swap = buildChainSwap();
+
+        await (swapNursery as any).refundEther(swap, 'ETH');
+
+        expect(queryEtherSwapValuesFromLock).toHaveBeenCalledTimes(1);
+        expect(queryEtherSwapValuesFromLock).toHaveBeenCalledWith(
+          swap,
+          expect.anything(),
+          expect.anything(),
+          lockupTxId,
+          false,
+        );
+      });
+
+      test('refundERC20 passes lockedByUser: false (regression: chain swap server-side refund must not consult user-side commitment)', async () => {
+        (swapNursery as any).ethereumNurseries = [buildEthereumNursery()];
+        const erc20Wallet = { walletProvider: {} } as any;
+        swapNursery.currencies = new Map([['USDT', mockCurrency]]);
+        (swapNursery as any).walletManager = {
+          ethereumManagers: [],
+          wallets: new Map([['USDT', erc20Wallet]]),
+        };
+        const swap = buildChainSwap();
+
+        await (swapNursery as any).refundERC20(swap, 'USDT');
+
+        expect(queryERC20SwapValuesFromLock).toHaveBeenCalledTimes(1);
+        expect(queryERC20SwapValuesFromLock).toHaveBeenCalledWith(
+          swap,
+          expect.anything(),
+          expect.anything(),
+          lockupTxId,
+          false,
+        );
       });
     });
 


### PR DESCRIPTION
Chain swap server-side EVM refunds (refundEther / refundERC20) failed with INVALID_LOCKUP_TRANSACTION whenever a Commitment row existed for the swap, because getIdentifier returned the user-side commitment's lockupHash on every query. That hash is computed against the receiving chain's contract and could never match a Lockup event on the sending chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Ethereum swap claim and refund processing with refined parameter handling for lockup value queries.

* **Tests**
  * Expanded integration and unit test coverage for Ethereum contract utilities with additional refund operation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->