### PR TITLE
refactor: getting claim tx from Fulmine

### DIFF
--- a/docs/boltz.conf
+++ b/docs/boltz.conf
@@ -454,6 +454,8 @@ symbol = "RBTC"  # Native token (no decimals/contractAddress)
 #
 # useLocktimeSeconds = true  # Use seconds for locktimes instead of blocks
 #
+# rescanInterval = 300  # Periodic vHTLC state rescan interval in seconds (default: 300)
+#
 # [ark.unilateralDelays]
 # claim = 16  # In blocks
 # refund = 32

--- a/lib/chain/ArkClient.ts
+++ b/lib/chain/ArkClient.ts
@@ -638,6 +638,19 @@ class ArkClient extends BaseClient<
     );
   };
 
+  public getVhtlcSpendingTx = async (vhtlcId: string) => {
+    const req: arkrpc.GetVHTLCSpendingTxRequest = {
+      vhtlcId,
+    };
+
+    const res = await this.unaryCall<
+      arkrpc.GetVHTLCSpendingTxRequest,
+      arkrpc.GetVHTLCSpendingTxResponse
+    >('getVhtlcSpendingTx', req);
+
+    return Transaction.fromPSBT(Uint8Array.from(Buffer.from(res.tx, 'base64')));
+  };
+
   private listenBlocks = async (block: { height: number; symbol: string }) => {
     if (block.symbol !== this.chainClient?.symbol) {
       return;

--- a/lib/chain/ArkClient.ts
+++ b/lib/chain/ArkClient.ts
@@ -48,6 +48,9 @@ export type ArkConfig = {
 
   useLocktimeSeconds?: boolean;
 
+  // Interval in seconds for the periodic vHTLC state rescan
+  rescanInterval?: number;
+
   unilateralDelays?: Delays;
 };
 
@@ -292,6 +295,7 @@ class ArkClient extends BaseClient<
       this.meta,
       this.unaryCall,
       this.unaryNotificationCall,
+      this.config.rescanInterval,
     );
     this.subscription.on('vhtlc.created', (vHtlc) => {
       this.emit('vhtlc.created', vHtlc);

--- a/lib/chain/ArkSubscription.ts
+++ b/lib/chain/ArkSubscription.ts
@@ -75,10 +75,12 @@ class AddressMapper {
 }
 
 class ArkSubscription extends TypedEventEmitter<Events> {
+  public static readonly defaultRescanIntervalSeconds = 300;
+
   private static readonly reconnectInterval = 2_500;
-  private static readonly rescanIntervalMinutes = 5;
 
   private readonly subscribedAddresses = new Map<string, string>();
+  private readonly rescanIntervalSeconds: number;
 
   private shouldDisconnect = false;
   private isReconnecting = false;
@@ -93,8 +95,18 @@ class ArkSubscription extends TypedEventEmitter<Events> {
     private readonly metadata: Metadata,
     private readonly unaryCall: (typeof ArkClient.prototype)['unaryCall'],
     private readonly unaryNotificationCall: (typeof ArkClient.prototype)['unaryNotificationCall'],
+    rescanIntervalSeconds?: number,
   ) {
     super();
+
+    if (rescanIntervalSeconds !== undefined && rescanIntervalSeconds < 1) {
+      throw new RangeError(
+        `rescan interval must be at least 1 second (got ${rescanIntervalSeconds})`,
+      );
+    }
+
+    this.rescanIntervalSeconds =
+      rescanIntervalSeconds ?? ArkSubscription.defaultRescanIntervalSeconds;
   }
 
   public connect = async () => {
@@ -108,26 +120,23 @@ class ArkSubscription extends TypedEventEmitter<Events> {
     this.streamVhtlcs();
 
     this.logger.debug(
-      `Rescanning ${this.client.serviceName()} ${this.client.symbol} every ${ArkSubscription.rescanIntervalMinutes} minutes`,
+      `Rescanning ${this.client.serviceName()} ${this.client.symbol} every ${this.rescanIntervalSeconds} seconds`,
     );
-    this.rescanTimer = setInterval(
-      async () => {
-        if (
-          !this.shouldDisconnect &&
-          !this.isReconnecting &&
-          !this.isRescanning
-        ) {
-          try {
-            await this.rescan();
-          } catch (e) {
-            this.logger.error(
-              `Error rescanning ${this.client.serviceName()} ${this.client.symbol}: ${formatError(e)}`,
-            );
-          }
+    this.rescanTimer = setInterval(async () => {
+      if (
+        !this.shouldDisconnect &&
+        !this.isReconnecting &&
+        !this.isRescanning
+      ) {
+        try {
+          await this.rescan();
+        } catch (e) {
+          this.logger.error(
+            `Error rescanning ${this.client.serviceName()} ${this.client.symbol}: ${formatError(e)}`,
+          );
         }
-      },
-      ArkSubscription.rescanIntervalMinutes * 1_000 * 60,
-    );
+      }
+    }, this.rescanIntervalSeconds * 1_000);
   };
 
   public disconnect = () => {

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -503,6 +503,9 @@ class Service {
 
       endHeight = await manager.provider.getBlockNumber();
       await manager.contractEventHandler.rescan(startHeight);
+    } else if (currency.arkNode) {
+      await currency.arkNode.subscription.rescan();
+      endHeight = await currency.arkNode.getBlockHeight();
     } else {
       throw Errors.NO_CHAIN_FOR_SYMBOL();
     }

--- a/lib/swap/ArkNursery.ts
+++ b/lib/swap/ArkNursery.ts
@@ -3,7 +3,7 @@ import AsyncLock from 'async-lock';
 import { createHash } from 'crypto';
 import { Op } from 'sequelize';
 import type Logger from '../Logger';
-import { getHexString } from '../Utils';
+import { getHexBuffer, getHexString } from '../Utils';
 import ArkClient, {
   ArkBlockEventKind,
   type CreatedVHtlc,
@@ -317,23 +317,27 @@ class ArkNursery extends TypedEventEmitter<{
     onUnsubscribe?: UnsubscribeHandler,
   ) => {
     this.logger.debug(
-      `Checking claims for ${ArkClient.symbol} vHTLC in: ${vHtlc.spentBy}`,
+      `Checking claims for ${ArkClient.symbol} vHTLC ${vHtlc.outpoint.txid}:${vHtlc.outpoint.vout} spent by ${vHtlc.spentBy}`,
     );
-    const claimTx = await arkNode.getTx(vHtlc.spentBy);
-    for (const preimage of ArkNursery.extractPreimages(claimTx)) {
-      const preimageHash = createHash('sha256').update(preimage).digest('hex');
 
-      const [reverseSwap, chainSwap] = await Promise.all([
-        ReverseSwapRepository.getReverseSwap({
-          status: {
-            [Op.in]: [
-              SwapUpdateEvent.TransactionMempool,
-              SwapUpdateEvent.TransactionConfirmed,
-            ],
-          },
-          preimageHash,
-        }),
-        ChainSwapRepository.getChainSwap({
+    const [reverseSwap, chainSwap] = await Promise.all([
+      ReverseSwapRepository.getReverseSwap({
+        status: {
+          [Op.in]: [
+            SwapUpdateEvent.TransactionMempool,
+            SwapUpdateEvent.TransactionConfirmed,
+          ],
+        },
+        transactionId: vHtlc.outpoint.txid,
+        transactionVout: vHtlc.outpoint.vout,
+      }),
+      ChainSwapRepository.getChainSwapByData(
+        {
+          symbol: arkNode.symbol,
+          transactionId: vHtlc.outpoint.txid,
+          transactionVout: vHtlc.outpoint.vout,
+        },
+        {
           status: {
             [Op.in]: [
               SwapUpdateEvent.TransactionServerMempool,
@@ -341,42 +345,76 @@ class ArkNursery extends TypedEventEmitter<{
               SwapUpdateEvent.TransactionRefunded,
             ],
           },
-          preimageHash,
-        }),
-      ]);
+        },
+      ),
+    ]);
 
-      const logPreimage = (swap: ReverseSwap | ChainSwapInfo) => {
-        this.logger.debug(
-          `Found preimage for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in ${vHtlc.spentBy}: ${getHexString(preimage)}`,
+    const handleClaim = async (
+      swap: ReverseSwap | ChainSwapInfo,
+      receiverPubkeyHex: string,
+      lockupAddress: string,
+      emit: (preimage: Buffer) => void,
+    ) => {
+      const vhtlcId = ArkClient.createVhtlcId(
+        getHexBuffer(swap.preimageHash),
+        arkNode.pubkey,
+        getHexBuffer(receiverPubkeyHex),
+      );
+      const preimage = await this.fetchClaimPreimage(
+        arkNode,
+        vhtlcId,
+        swap.preimageHash,
+      );
+      if (preimage === undefined) {
+        this.logger.warn(
+          `No matching preimage in spending tx ${vHtlc.spentBy} for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
         );
-      };
-
-      if (reverseSwap !== null && reverseSwap !== undefined) {
-        logPreimage(reverseSwap);
-        this.emit('reverseSwap.claimed', {
-          reverseSwap,
-          preimage,
-        });
-        await this.handleUnsubscribe(
-          arkNode,
-          reverseSwap.lockupAddress,
-          onUnsubscribe,
-        );
+        return;
       }
 
-      if (chainSwap !== null && chainSwap !== undefined) {
-        logPreimage(chainSwap);
-        this.emit('chainSwap.claimed', {
-          swap: chainSwap,
-          preimage,
-        });
-        await this.handleUnsubscribe(
-          arkNode,
-          chainSwap.sendingData.lockupAddress,
-          onUnsubscribe,
-        );
+      this.logger.debug(
+        `Found preimage for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in ${vHtlc.spentBy}: ${getHexString(preimage)}`,
+      );
+      emit(preimage);
+      await this.handleUnsubscribe(arkNode, lockupAddress, onUnsubscribe);
+    };
+
+    if (reverseSwap !== null && reverseSwap !== undefined) {
+      await handleClaim(
+        reverseSwap,
+        reverseSwap.claimPublicKey!,
+        reverseSwap.lockupAddress,
+        (preimage) =>
+          this.emit('reverseSwap.claimed', { reverseSwap, preimage }),
+      );
+    }
+
+    if (chainSwap !== null && chainSwap !== undefined) {
+      await handleClaim(
+        chainSwap,
+        chainSwap.sendingData.theirPublicKey!,
+        chainSwap.sendingData.lockupAddress,
+        (preimage) =>
+          this.emit('chainSwap.claimed', { swap: chainSwap, preimage }),
+      );
+    }
+  };
+
+  private fetchClaimPreimage = async (
+    arkNode: ArkClient,
+    vhtlcId: string,
+    preimageHash: string,
+  ): Promise<Buffer | undefined> => {
+    const claimTx = await arkNode.getVhtlcSpendingTx(vhtlcId);
+    for (const preimage of ArkNursery.extractPreimages(claimTx)) {
+      if (
+        createHash('sha256').update(preimage).digest('hex') === preimageHash
+      ) {
+        return preimage;
       }
     }
+
+    return undefined;
   };
 
   private handleUnsubscribe = async (

--- a/proto/ark/service.proto
+++ b/proto/ark/service.proto
@@ -113,6 +113,13 @@ service Service {
       get: "/v1/vhtlcs"
     };
   };
+  // GetVHTLCSpendingTx returns the fully signed ark transaction for a spent VHTLC,
+  // whether the VHTLC is spent by a finalized or pending tx.
+  rpc GetVHTLCSpendingTx(GetVHTLCSpendingTxRequest) returns (GetVHTLCSpendingTxResponse) {
+    option (google.api.http) = {
+      get: "/v1/vhtlc/spendTx/{vhtlc_id}"
+    };
+  };
   rpc GetInvoice(GetInvoiceRequest) returns (GetInvoiceResponse) {
     option (google.api.http) = {
       post: "/v1/invoice"
@@ -350,6 +357,15 @@ message ListVHTLCsRequest {
 }
 message ListVHTLCsResponse {
   repeated Vtxo vhtlcs = 1;
+}
+
+message GetVHTLCSpendingTxRequest {
+  string vhtlc_id = 1;
+}
+
+message GetVHTLCSpendingTxResponse {
+  // The fully signed ark transaction in hex format.
+  string tx = 1;
 }
 
 message GetInvoiceRequest {

--- a/test/unit/chain/ArkSubscription.spec.ts
+++ b/test/unit/chain/ArkSubscription.spec.ts
@@ -23,7 +23,7 @@ describe('ArkSubscription', () => {
     symbol: 'ARK',
   } as unknown as ArkClient;
 
-  const createSubscription = () => {
+  const createSubscription = (rescanIntervalSeconds?: number) => {
     const stream = new MockStream();
     const notificationClient = {
       getVtxoNotifications: jest.fn().mockReturnValue(stream),
@@ -40,6 +40,7 @@ describe('ArkSubscription', () => {
       metadata,
       unaryCall as any,
       unaryNotificationCall as any,
+      rescanIntervalSeconds,
     );
 
     return {
@@ -179,6 +180,55 @@ describe('ArkSubscription', () => {
     expect(subscription['subscribedAddresses'].has('address-two')).toEqual(
       false,
     );
+  });
+
+  describe('rescan interval', () => {
+    test('falls back to the default when none is configured', () => {
+      const { subscription } = createSubscription();
+
+      expect((subscription as any).rescanIntervalSeconds).toEqual(
+        ArkSubscription.defaultRescanIntervalSeconds,
+      );
+    });
+
+    test('uses the configured value', () => {
+      const { subscription } = createSubscription(123);
+
+      expect((subscription as any).rescanIntervalSeconds).toEqual(123);
+    });
+
+    test.each([0, -1])(
+      'throws when the configured value is below 1 (%i)',
+      (value) => {
+        expect(() => createSubscription(value)).toThrow(RangeError);
+      },
+    );
+
+    test('accepts the minimum value of 1', () => {
+      const { subscription } = createSubscription(1);
+
+      expect((subscription as any).rescanIntervalSeconds).toEqual(1);
+    });
+
+    test('schedules the periodic rescan timer with the configured interval', async () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      const { subscription } = createSubscription(45);
+
+      await subscription.connect();
+
+      try {
+        expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+        expect(setIntervalSpy).toHaveBeenCalledWith(
+          expect.any(Function),
+          45_000,
+        );
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          'Rescanning ark ARK every 45 seconds',
+        );
+      } finally {
+        subscription.disconnect();
+      }
+    });
   });
 
   test('ignores invalid subscribed addresses during rescan and still emits valid vHTLCs', async () => {

--- a/test/unit/swap/ArkNursery.spec.ts
+++ b/test/unit/swap/ArkNursery.spec.ts
@@ -2,8 +2,7 @@ import { Transaction } from '@scure/btc-signer';
 import { Op } from 'sequelize';
 import Logger from '../../../lib/Logger';
 import { getHexBuffer, getHexString } from '../../../lib/Utils';
-import { ArkBlockEventKind } from '../../../lib/chain/ArkClient';
-import type ArkClient from '../../../lib/chain/ArkClient';
+import ArkClient, { ArkBlockEventKind } from '../../../lib/chain/ArkClient';
 import {
   CurrencyType,
   SwapType,
@@ -33,10 +32,17 @@ describe('ArkNursery', () => {
     '741163593eb1fab813e6986dfbb2bd92d91c76f8f5e2f04ca5dc67e8170e1f08',
   );
 
+  const claimTxPreimageHash =
+    '12882524ddbee7d099e2bf6dc2f32d320dfc0a01939bf2fd2cef181f27f5e26c';
+  const arkNodePubkey = Buffer.alloc(33, 1);
+  const userPubkey = Buffer.alloc(33, 2);
+
   describe('checkClaims', () => {
     test('should check reverse swap claims', async () => {
       const arkClient = {
-        getTx: jest.fn().mockResolvedValue(claimTx),
+        symbol: 'ARK',
+        pubkey: arkNodePubkey,
+        getVhtlcSpendingTx: jest.fn().mockResolvedValue(claimTx),
         subscription: {
           unsubscribeAddress: jest.fn(),
         },
@@ -45,20 +51,24 @@ describe('ArkNursery', () => {
       const swap = {
         id: 'rev',
         lockupAddress: 'ark_address',
+        preimageHash: claimTxPreimageHash,
+        claimPublicKey: getHexString(userPubkey),
       };
       ReverseSwapRepository.getReverseSwap = jest.fn().mockResolvedValue(swap);
-      ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(null);
 
       jest.spyOn(nursery, 'emit');
 
       await nursery['checkClaims'](
         arkClient as unknown as ArkClient,
         {
-          spentBy: 'txid',
+          outpoint: { txid: 'lockup_txid', vout: 1 },
+          spentBy: 'spending_txid',
         } as unknown as any,
       );
 
-      expect(arkClient.getTx).toHaveBeenCalledWith('txid');
       expect(ReverseSwapRepository.getReverseSwap).toHaveBeenCalledWith({
         status: {
           [Op.in]: [
@@ -66,20 +76,33 @@ describe('ArkNursery', () => {
             SwapUpdateEvent.TransactionConfirmed,
           ],
         },
-        preimageHash:
-          '12882524ddbee7d099e2bf6dc2f32d320dfc0a01939bf2fd2cef181f27f5e26c',
+        transactionId: 'lockup_txid',
+        transactionVout: 1,
       });
-      expect(ChainSwapRepository.getChainSwap).toHaveBeenCalledWith({
-        status: {
-          [Op.in]: [
-            SwapUpdateEvent.TransactionServerMempool,
-            SwapUpdateEvent.TransactionServerConfirmed,
-            SwapUpdateEvent.TransactionRefunded,
-          ],
+      expect(ChainSwapRepository.getChainSwapByData).toHaveBeenCalledWith(
+        {
+          symbol: 'ARK',
+          transactionId: 'lockup_txid',
+          transactionVout: 1,
         },
-        preimageHash:
-          '12882524ddbee7d099e2bf6dc2f32d320dfc0a01939bf2fd2cef181f27f5e26c',
-      });
+        {
+          status: {
+            [Op.in]: [
+              SwapUpdateEvent.TransactionServerMempool,
+              SwapUpdateEvent.TransactionServerConfirmed,
+              SwapUpdateEvent.TransactionRefunded,
+            ],
+          },
+        },
+      );
+      expect(arkClient.getVhtlcSpendingTx).toHaveBeenCalledTimes(1);
+      expect(arkClient.getVhtlcSpendingTx).toHaveBeenCalledWith(
+        ArkClient.createVhtlcId(
+          getHexBuffer(claimTxPreimageHash),
+          arkNodePubkey,
+          userPubkey,
+        ),
+      );
       expect(nursery.emit).toHaveBeenCalledWith('reverseSwap.claimed', {
         reverseSwap: swap,
         preimage: claimTxPreimage,
@@ -91,7 +114,9 @@ describe('ArkNursery', () => {
 
     test('should check chain swap claims', async () => {
       const arkClient = {
-        getTx: jest.fn().mockResolvedValue(claimTx),
+        symbol: 'ARK',
+        pubkey: arkNodePubkey,
+        getVhtlcSpendingTx: jest.fn().mockResolvedValue(claimTx),
         subscription: {
           unsubscribeAddress: jest.fn(),
         },
@@ -99,34 +124,51 @@ describe('ArkNursery', () => {
 
       const swap = {
         id: 'chain',
+        preimageHash: claimTxPreimageHash,
         sendingData: {
           lockupAddress: 'ark_sending_address',
+          theirPublicKey: getHexString(userPubkey),
         },
       };
       ReverseSwapRepository.getReverseSwap = jest.fn().mockResolvedValue(null);
-      ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(swap);
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(swap);
 
       jest.spyOn(nursery, 'emit');
 
       await nursery['checkClaims'](
         arkClient as unknown as ArkClient,
         {
-          spentBy: 'txid',
+          outpoint: { txid: 'lockup_txid', vout: 0 },
+          spentBy: 'spending_txid',
         } as unknown as any,
       );
 
-      expect(arkClient.getTx).toHaveBeenCalledWith('txid');
-      expect(ChainSwapRepository.getChainSwap).toHaveBeenCalledWith({
-        status: {
-          [Op.in]: [
-            SwapUpdateEvent.TransactionServerMempool,
-            SwapUpdateEvent.TransactionServerConfirmed,
-            SwapUpdateEvent.TransactionRefunded,
-          ],
+      expect(ChainSwapRepository.getChainSwapByData).toHaveBeenCalledWith(
+        {
+          symbol: 'ARK',
+          transactionId: 'lockup_txid',
+          transactionVout: 0,
         },
-        preimageHash:
-          '12882524ddbee7d099e2bf6dc2f32d320dfc0a01939bf2fd2cef181f27f5e26c',
-      });
+        {
+          status: {
+            [Op.in]: [
+              SwapUpdateEvent.TransactionServerMempool,
+              SwapUpdateEvent.TransactionServerConfirmed,
+              SwapUpdateEvent.TransactionRefunded,
+            ],
+          },
+        },
+      );
+      expect(arkClient.getVhtlcSpendingTx).toHaveBeenCalledTimes(1);
+      expect(arkClient.getVhtlcSpendingTx).toHaveBeenCalledWith(
+        ArkClient.createVhtlcId(
+          getHexBuffer(claimTxPreimageHash),
+          arkNodePubkey,
+          userPubkey,
+        ),
+      );
       expect(nursery.emit).toHaveBeenCalledWith('chainSwap.claimed', {
         swap,
         preimage: claimTxPreimage,
@@ -134,6 +176,47 @@ describe('ArkNursery', () => {
       expect(arkClient.subscription.unsubscribeAddress).toHaveBeenCalledWith(
         'ark_sending_address',
       );
+    });
+
+    test('should skip emit and unsubscribe when spending tx has no matching preimage', async () => {
+      const isolatedNursery = new ArkNursery(
+        Logger.disabledLogger,
+        new OverpaymentProtector(Logger.disabledLogger),
+      );
+
+      const arkClient = {
+        symbol: 'ARK',
+        pubkey: arkNodePubkey,
+        getVhtlcSpendingTx: jest.fn().mockResolvedValue(claimTx),
+        subscription: {
+          unsubscribeAddress: jest.fn(),
+        },
+      };
+
+      const swap = {
+        id: 'rev',
+        lockupAddress: 'ark_address',
+        preimageHash: 'aa'.repeat(32),
+        claimPublicKey: getHexString(userPubkey),
+      };
+      ReverseSwapRepository.getReverseSwap = jest.fn().mockResolvedValue(swap);
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      jest.spyOn(isolatedNursery, 'emit');
+
+      await isolatedNursery['checkClaims'](
+        arkClient as unknown as ArkClient,
+        {
+          outpoint: { txid: 'lockup_txid', vout: 0 },
+          spentBy: 'spending_txid',
+        } as unknown as any,
+      );
+
+      expect(arkClient.getVhtlcSpendingTx).toHaveBeenCalledTimes(1);
+      expect(isolatedNursery.emit).not.toHaveBeenCalled();
+      expect(arkClient.subscription.unsubscribeAddress).not.toHaveBeenCalled();
     });
   });
 
@@ -432,7 +515,8 @@ describe('ArkNursery', () => {
     test('collects spent claims for batched unsubscribe without unsubscribing immediately', async () => {
       const mockArkNode = {
         symbol: 'ARK',
-        getTx: jest.fn().mockResolvedValue(claimTx),
+        pubkey: arkNodePubkey,
+        getVhtlcSpendingTx: jest.fn().mockResolvedValue(claimTx),
         subscription: {
           unsubscribeAddress: jest.fn(),
         },
@@ -441,18 +525,24 @@ describe('ArkNursery', () => {
       const reverseSwap = {
         id: 'rev',
         lockupAddress: 'ark_reverse_address',
+        preimageHash: claimTxPreimageHash,
+        claimPublicKey: getHexString(userPubkey),
       };
       const chainSwap = {
         id: 'chain',
+        preimageHash: claimTxPreimageHash,
         sendingData: {
           lockupAddress: 'ark_chain_address',
+          theirPublicKey: getHexString(userPubkey),
         },
       };
 
       ReverseSwapRepository.getReverseSwap = jest
         .fn()
         .mockResolvedValue(reverseSwap);
-      ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(chainSwap);
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(chainSwap);
 
       let reverseClaim: any = null;
       let chainClaim: any = null;
@@ -479,7 +569,7 @@ describe('ArkNursery', () => {
         },
       );
 
-      expect(mockArkNode.getTx).toHaveBeenCalledWith('txid');
+      expect(mockArkNode.getVhtlcSpendingTx).toHaveBeenCalled();
       expect(
         mockArkNode.subscription.unsubscribeAddress,
       ).not.toHaveBeenCalled();
@@ -1344,25 +1434,30 @@ describe('ArkNursery', () => {
       );
 
       const arkClient = {
-        getTx: jest.fn().mockResolvedValue(claimTx),
+        symbol: 'ARK',
+        pubkey: arkNodePubkey,
+        getVhtlcSpendingTx: jest.fn().mockResolvedValue(claimTx),
         subscription: {
           unsubscribeAddress: jest.fn(),
         },
       };
 
       ReverseSwapRepository.getReverseSwap = jest.fn().mockResolvedValue(null);
-      ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(null);
 
       jest.spyOn(isolatedNursery, 'emit');
 
       await isolatedNursery['checkClaims'](
         arkClient as unknown as ArkClient,
         {
-          spentBy: 'txid',
+          outpoint: { txid: 'lockup_txid', vout: 0 },
+          spentBy: 'spending_txid',
         } as unknown as any,
       );
 
-      expect(arkClient.getTx).toHaveBeenCalledWith('txid');
+      expect(arkClient.getVhtlcSpendingTx).not.toHaveBeenCalled();
       expect(arkClient.subscription.unsubscribeAddress).not.toHaveBeenCalled();
       expect(isolatedNursery.emit).not.toHaveBeenCalled();
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API to fetch fully-signed vHTLC spending transactions.

* **Improvements**
  * Claim-checking optimized to use spending-transaction preimages for accurate claim detection.
  * Configurable periodic vHTLC rescan interval and ARK-backed currency rescan support.

* **Tests**
  * Updated and added unit tests covering vHTLC spending lookups and rescan interval behavior.

* **Documentation**
  * Added commented rescanInterval option to ARK pool config examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-backend/pull/1399)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->