### PR TITLE
refactor: poll block height instead of subscription

### DIFF
--- a/lib/Boltz.ts
+++ b/lib/Boltz.ts
@@ -108,12 +108,35 @@ class Boltz {
     }
 
     registerExitHandler(async () => {
+      const t = (label: string, start: number) =>
+        this.logger.debug(`Shutdown ${label}: ${Date.now() - start}ms`);
+      let t0 = Date.now();
+
+      await Promise.all(
+        this.ethereumManagers.map((manager) => manager.destroy()),
+      );
+      t('evm', t0);
+      t0 = Date.now();
+
       await this.grpcServer.close();
+      t('grpc', t0);
+      t0 = Date.now();
+
       await this.db.close();
+      t('db', t0);
+      t0 = Date.now();
+
       this.redis?.disconnect();
+      t('redis', t0);
+      t0 = Date.now();
 
       await Profiling.stop();
+      t('profiling', t0);
+      t0 = Date.now();
+
       await Tracing.stop();
+      t('tracing', t0);
+      t0 = Date.now();
 
       await this.logger.close();
     });

--- a/lib/Tracing.ts
+++ b/lib/Tracing.ts
@@ -8,6 +8,7 @@ import { WinstonInstrumentation } from '@opentelemetry/instrumentation-winston';
 import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { NodeSDK } from '@opentelemetry/sdk-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import process from 'process';
 import packageJson from '../package.json';
 
@@ -25,6 +26,13 @@ class Tracing {
   private sdk?: NodeSDK;
 
   public init = (endpoint: string, network: string) => {
+    const exporter = new OTLPTraceExporter({
+      url: endpoint,
+      concurrencyLimit: 2_000,
+      compression: CompressionAlgorithm.GZIP,
+      timeoutMillis: 1_000,
+    });
+
     this.sdk = new NodeSDK({
       instrumentations,
       resource: resourceFromAttributes({
@@ -32,11 +40,13 @@ class Tracing {
         ['service.version']: packageJson.version,
         ['service.name']: `${packageJson.name}-${network}`,
       }),
-      traceExporter: new OTLPTraceExporter({
-        url: endpoint,
-        concurrencyLimit: 2_000,
-        compression: CompressionAlgorithm.GZIP,
-      }),
+      spanProcessors: [
+        new BatchSpanProcessor(exporter, {
+          exportTimeoutMillis: 1_000,
+        }),
+      ],
+      logRecordProcessors: [],
+      metricReaders: [],
     });
 
     this.sdk.start();

--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -95,8 +95,6 @@ class EthereumNursery extends TypedEventEmitter<{
       this.emit('lockup.failedToSend', data);
     });
 
-    this.listenBlocks();
-
     this.listenEtherSwap();
     this.listenERC20Swap();
   }
@@ -146,6 +144,8 @@ class EthereumNursery extends TypedEventEmitter<{
         // If the provider can't find the transaction, it is not on the Ethereum chain
       }
     }
+
+    this.listenBlocks();
   };
 
   public listenContractTransaction = (

--- a/lib/wallet/ethereum/ArbitrumProvider.ts
+++ b/lib/wallet/ethereum/ArbitrumProvider.ts
@@ -2,6 +2,7 @@ import type { ArbitrumConfig } from '../../Config';
 import type Logger from '../../Logger';
 import { type NetworkDetails, networks } from './EvmNetworks';
 import InjectedProvider from './InjectedProvider';
+import type { BlockEvent } from './WebSocketProvider';
 
 class ArbitrumProvider extends InjectedProvider {
   private l1Provider: InjectedProvider;
@@ -30,6 +31,14 @@ class ArbitrumProvider extends InjectedProvider {
 
   public getLocktimeHeight = async (): Promise<number> => {
     return await this.l1Provider.getBlockNumber();
+  };
+
+  protected override getLatestBlock = async (): Promise<BlockEvent> => {
+    const [number, l1BlockNumber] = await Promise.all([
+      this.getBlockNumber(),
+      this.l1Provider.getBlockNumber(),
+    ]);
+    return { number, l1BlockNumber };
   };
 }
 

--- a/lib/wallet/ethereum/ArbitrumProvider.ts
+++ b/lib/wallet/ethereum/ArbitrumProvider.ts
@@ -34,11 +34,18 @@ class ArbitrumProvider extends InjectedProvider {
   };
 
   protected override getLatestBlock = async (): Promise<BlockEvent> => {
-    const [number, l1BlockNumber] = await Promise.all([
-      this.getBlockNumber(),
-      this.l1Provider.getBlockNumber(),
-    ]);
-    return { number, l1BlockNumber };
+    const raw = await this.forwardMethod<{
+      number: string;
+      l1BlockNumber?: string;
+    }>('send', 'eth_getBlockByNumber', ['latest', false]);
+
+    return {
+      number: parseInt(raw.number, 16),
+      l1BlockNumber:
+        raw.l1BlockNumber !== undefined
+          ? parseInt(raw.l1BlockNumber, 16)
+          : undefined,
+    };
   };
 }
 

--- a/lib/wallet/ethereum/Errors.ts
+++ b/lib/wallet/ethereum/Errors.ts
@@ -41,8 +41,4 @@ export default {
     message: 'unsupported contract',
     code: concatErrorCode(ErrorCodePrefix.Ethereum, 6),
   }),
-  NEED_WEBSOCKET_PROVIDER: (): Error => ({
-    message: 'at least one WebSocket provider is needed',
-    code: concatErrorCode(ErrorCodePrefix.Ethereum, 7),
-  }),
 };

--- a/lib/wallet/ethereum/EthereumManager.ts
+++ b/lib/wallet/ethereum/EthereumManager.ts
@@ -163,33 +163,23 @@ class EthereumManager {
       this.logger.silly(`Got new ${this.networkDetails.name} block: ${number}`);
 
       if (number <= lastBlockNumber) {
-        this.logger.debug(
-          `Ignoring stale ${this.networkDetails.name} block notification ${number}; last processed block is ${lastBlockNumber}`,
-        );
         return;
       }
-
-      const gap = number - lastBlockNumber;
-      if (gap > 1) {
-        if (this.missedEventsCheckPromise === undefined) {
-          this.logger.warn(
-            `${this.networkDetails.name} block gap detected: ${gap}; rescanning for missed events`,
-          );
-        } else {
-          this.logger.info(
-            `${this.networkDetails.name} block gap detected while a missed-events rescan is already running: ${gap}`,
-          );
-        }
-
-        this.scheduleMissedEventChecks();
-      }
-
       lastBlockNumber = number;
 
       await Promise.all([
         ChainTipRepository.updateTip(chainTip, number),
         transactionTracker.scanPendingTransactions(),
       ]);
+    });
+
+    this.provider.onReconnect(() => {
+      if (this.missedEventsCheckPromise === undefined) {
+        this.logger.info(
+          `${this.networkDetails.name} WebSocket reconnected; rescanning for missed events`,
+        );
+      }
+      this.scheduleMissedEventChecks();
     });
 
     const wallets = new Map<string, Wallet>();

--- a/lib/wallet/ethereum/EthereumManager.ts
+++ b/lib/wallet/ethereum/EthereumManager.ts
@@ -264,8 +264,8 @@ class EthereumManager {
 
   public destroy = async () => {
     this.missedEventsCheckPending = false;
-    await this.provider.removeAllListeners();
     await this.missedEventsCheckPromise;
+    this.contractEventHandler.destroy();
     await this.provider.destroy();
   };
 

--- a/lib/wallet/ethereum/InjectedProvider.ts
+++ b/lib/wallet/ethereum/InjectedProvider.ts
@@ -35,15 +35,18 @@ const bigIntReplacer = (_key: string, value: any) =>
  * and, depending on the configuration, falls back to alternative providers
  */
 class InjectedProvider implements Provider {
-  public static allowHttpOnly = false;
-
   public readonly provider: this;
 
   private providers = new Map<string, AbstractProvider>();
   private network!: Network;
   private destroyed = false;
 
+  private blockListeners = new Set<(block: BlockEvent) => void>();
+  private blockPollTimer: NodeJS.Timeout | undefined;
+  private reconnectCallbacks = new Set<() => void>();
+
   private static readonly requestTimeout = 5000;
+  private static readonly blockPollIntervalMs = 2_500;
 
   constructor(
     private readonly logger: Logger,
@@ -106,15 +109,6 @@ class InjectedProvider implements Provider {
       throw Errors.UNEQUAL_PROVIDER_NETWORKS(networks);
     }
 
-    if (
-      !InjectedProvider.allowHttpOnly &&
-      !Array.from(this.providers.values()).some(
-        (provider) => provider instanceof WebSocketProvider,
-      )
-    ) {
-      throw Errors.NEED_WEBSOCKET_PROVIDER();
-    }
-
     this.network = networks[0];
     this.logger.info(
       `Connected to ${this.providers.size} ${
@@ -144,7 +138,7 @@ class InjectedProvider implements Provider {
         : new JsonRpcProvider(config.endpoint, undefined, {
             staticNetwork: true,
             polling: true,
-            pollingInterval: 2_500,
+            pollingInterval: InjectedProvider.blockPollIntervalMs,
           }),
     );
 
@@ -161,6 +155,21 @@ class InjectedProvider implements Provider {
 
   public async destroy(): Promise<void> {
     this.destroyed = true;
+    if (this.blockPollTimer !== undefined) {
+      clearInterval(this.blockPollTimer);
+      this.blockPollTimer = undefined;
+    }
+    this.blockListeners.clear();
+
+    for (const provider of this.providers.values()) {
+      if (provider instanceof WebSocketProvider) {
+        for (const cb of this.reconnectCallbacks) {
+          provider.ws.off('reconnected', cb);
+        }
+      }
+    }
+    this.reconnectCallbacks.clear();
+
     await Promise.all(
       Array.from(this.providers.values()).map((provider) => provider.destroy()),
     );
@@ -399,13 +408,6 @@ class InjectedProvider implements Provider {
   public onBlock = async (
     listener: (block: BlockEvent) => void,
   ): Promise<this> => {
-    // Start a block listener for subscription to be created
-    await this.on('block', () => {});
-
-    const webSocketProviders = Array.from(this.providers.values()).filter(
-      (provider) => provider instanceof WebSocketProvider,
-    );
-
     const guarded = (block: BlockEvent) => {
       if (this.destroyed || shutdownSignal.aborted) {
         return;
@@ -413,16 +415,66 @@ class InjectedProvider implements Provider {
       listener(block);
     };
 
-    const injected = this.createInjectedListener(
-      guarded,
-      webSocketProviders.length,
-    );
-
-    for (const provider of webSocketProviders) {
-      provider.ws.on('block', injected);
-    }
+    this.blockListeners.add(guarded);
+    this.startBlockPoll();
 
     return this;
+  };
+
+  public onReconnect = (callback: () => void): void => {
+    this.reconnectCallbacks.add(callback);
+    for (const provider of this.providers.values()) {
+      if (provider instanceof WebSocketProvider) {
+        provider.ws.on('reconnected', callback);
+      }
+    }
+  };
+
+  protected getLatestBlock = async (): Promise<BlockEvent> => {
+    return { number: await this.getBlockNumber() };
+  };
+
+  private startBlockPoll = () => {
+    if (this.blockPollTimer !== undefined || this.destroyed) {
+      return;
+    }
+
+    let inFlight = false;
+    const tick = async () => {
+      if (inFlight || this.destroyed) {
+        return;
+      }
+      inFlight = true;
+
+      try {
+        let block: BlockEvent;
+        try {
+          block = await this.getLatestBlock();
+        } catch (error) {
+          this.logger.warn(
+            `${this.networkDetails.name} block poll failed: ${formatError(error)}`,
+          );
+          return;
+        }
+
+        for (const listener of this.blockListeners) {
+          try {
+            listener(block);
+          } catch (error) {
+            this.logger.error(
+              `${this.networkDetails.name} block listener threw: ${formatError(error)}`,
+            );
+          }
+        }
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    void tick();
+    this.blockPollTimer = setInterval(() => {
+      void tick();
+    }, InjectedProvider.blockPollIntervalMs);
   };
 
   public once = async (

--- a/lib/wallet/ethereum/InjectedProvider.ts
+++ b/lib/wallet/ethereum/InjectedProvider.ts
@@ -518,7 +518,7 @@ class InjectedProvider implements Provider {
    * Helper utils
    */
 
-  private forwardMethod = async <T = any>(
+  protected forwardMethod = async <T = any>(
     method: string,
     ...args: any[]
   ): Promise<T> => {

--- a/lib/wallet/ethereum/WebSocketProvider.ts
+++ b/lib/wallet/ethereum/WebSocketProvider.ts
@@ -95,9 +95,13 @@ class ReconnectingWebSocket
       };
 
       this.ws.onerror = (event) => {
-        this.logger.error(
-          `${this.symbol} WebSocket ${this.name} error: ${event?.error?.name}${event?.error?.message ? `: ${event.error.message}` : ''}`,
-        );
+        const msg = `${this.symbol} WebSocket ${this.name} error: ${event?.error?.name}${event?.error?.message ? `: ${event.error.message}` : ''}`;
+
+        if (this.isDestroyed) {
+          this.logger.debug(msg);
+        } else {
+          this.logger.error(msg);
+        }
         if (this.onerror) {
           this.onerror(event);
         }
@@ -240,18 +244,18 @@ class WebSocketProvider extends EthersWebSocketProvider {
   }
 
   public async destroy(): Promise<void> {
+    this.ws.close();
+
     try {
-      await this.removeAllListeners();
       await super.destroy();
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
-      // Ignored; fails with Anvil
+      // Anvil sometimes throws here when its socket is already gone.
     }
 
     this.registeredListeners.clear();
     this.registeredOnceListeners.clear();
     this.onceWrappedListeners.clear();
-    this.ws.close();
   }
 
   private reregisterListeners = async (): Promise<void> => {

--- a/lib/wallet/ethereum/WebSocketProvider.ts
+++ b/lib/wallet/ethereum/WebSocketProvider.ts
@@ -16,7 +16,6 @@ type BlockEvent = {
 class ReconnectingWebSocket
   extends TypedEventEmitter<{
     reconnected: void;
-    block: BlockEvent;
   }>
   implements WebSocketLike
 {
@@ -90,8 +89,6 @@ class ReconnectingWebSocket
       };
 
       this.ws.onmessage = (event) => {
-        this.emitBlock(event);
-
         if (this.onmessage) {
           this.onmessage(event);
         }
@@ -140,32 +137,6 @@ class ReconnectingWebSocket
       this.reconnectTimeout = undefined;
       this.connect();
     }, ReconnectingWebSocket.reconnectDelay);
-  };
-
-  private emitBlock = (event: MessageEvent) => {
-    try {
-      const parsed = JSON.parse(event.data);
-      if (parsed.method === 'eth_blockNumber') {
-        return;
-      }
-
-      const data = parsed.params?.result;
-
-      if (data && 'number' in data && 'stateRoot' in data) {
-        const res: BlockEvent = {
-          number: Number(data.number),
-        };
-
-        if ('l1BlockNumber' in data) {
-          res.l1BlockNumber = Number(data.l1BlockNumber);
-        }
-
-        this.emit('block', res);
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (e) {
-      // Ignored; there might be other messages coming in
-    }
   };
 }
 

--- a/test/integration/swap/RefundWatcher.spec.ts
+++ b/test/integration/swap/RefundWatcher.spec.ts
@@ -44,8 +44,6 @@ describe('RefundWatcher', () => {
   let evmProvider: InjectedProvider;
 
   beforeAll(async () => {
-    InjectedProvider.allowHttpOnly = true;
-
     setup = await getSigner();
     await fundSignerWallet(setup.signer, setup.etherBase);
     evmProvider = new InjectedProvider(

--- a/test/integration/wallet/ethereum/ArbitrumProvider.spec.ts
+++ b/test/integration/wallet/ethereum/ArbitrumProvider.spec.ts
@@ -1,0 +1,87 @@
+import Logger from '../../../../lib/Logger';
+import ArbitrumProvider from '../../../../lib/wallet/ethereum/ArbitrumProvider';
+import { networks } from '../../../../lib/wallet/ethereum/EvmNetworks';
+
+jest.mock(
+  '../../../../lib/db/repositories/PendingEthereumTransactionRepository',
+  () => ({
+    addTransaction: jest.fn().mockResolvedValue(null),
+    getHighestNonce: jest.fn().mockResolvedValue(undefined),
+  }),
+);
+
+const arbitrumEndpoint = 'https://arb1.arbitrum.io/rpc';
+const ethereumEndpoint = 'https://ethereum-rpc.publicnode.com';
+
+describe('ArbitrumProvider (integration)', () => {
+  jest.setTimeout(60_000);
+
+  let provider: ArbitrumProvider;
+
+  beforeAll(async () => {
+    provider = new ArbitrumProvider(Logger.disabledLogger, networks.Arbitrum, {
+      providers: [{ name: 'arb1', endpoint: arbitrumEndpoint }],
+      l1Providers: [{ name: 'eth', endpoint: ethereumEndpoint }],
+    } as never);
+    await provider.init();
+  });
+
+  afterAll(async () => {
+    await provider.destroy();
+  });
+
+  describe('getLatestBlock', () => {
+    test('returns the L1 block referenced by the latest L2 block', async () => {
+      const blk = await provider['getLatestBlock']();
+
+      expect(typeof blk.number).toEqual('number');
+      expect(blk.number).toBeGreaterThan(0);
+      expect(typeof blk.l1BlockNumber).toEqual('number');
+      expect(blk.l1BlockNumber).toBeGreaterThan(0);
+    });
+
+    test('l1BlockNumber never exceeds the live L1 tip', async () => {
+      const blk = await provider['getLatestBlock']();
+      const liveL1 = await provider['l1Provider'].getBlockNumber();
+
+      expect(blk.l1BlockNumber).toBeLessThanOrEqual(liveL1);
+      expect(liveL1 - (blk.l1BlockNumber as number)).toBeGreaterThanOrEqual(0);
+    });
+
+    test('agrees with the L1 ref reported by a separate eth_getBlockByNumber call', async () => {
+      const [blk, raw] = await Promise.all([
+        provider['getLatestBlock'](),
+        provider['forwardMethod']<{ number: string; l1BlockNumber: string }>(
+          'send',
+          'eth_getBlockByNumber',
+          ['latest', false],
+        ),
+      ]);
+
+      const rawL2 = parseInt(raw.number, 16);
+      const rawL1 = parseInt(raw.l1BlockNumber, 16);
+
+      expect(Math.abs(blk.number - rawL2)).toBeLessThanOrEqual(5);
+      expect(
+        Math.abs((blk.l1BlockNumber as number) - rawL1),
+      ).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('block poller', () => {
+    test('delivers a BlockEvent with both number and l1BlockNumber via onBlock', async () => {
+      const block = await new Promise<{
+        number: number;
+        l1BlockNumber?: number;
+      }>((resolve) => {
+        provider.onBlock(resolve);
+      });
+
+      expect(block.number).toBeGreaterThan(0);
+      expect(block.l1BlockNumber).toBeGreaterThan(0);
+
+      const liveL1 = await provider['l1Provider'].getBlockNumber();
+      expect(block.l1BlockNumber as number).toBeLessThanOrEqual(liveL1);
+    });
+  });
+});

--- a/test/integration/wallet/ethereum/EthereumManager.spec.ts
+++ b/test/integration/wallet/ethereum/EthereumManager.spec.ts
@@ -6,7 +6,6 @@ import Errors from '../../../../lib/wallet/Errors';
 import type Wallet from '../../../../lib/wallet/Wallet';
 import EthereumManager from '../../../../lib/wallet/ethereum/EthereumManager';
 import { networks } from '../../../../lib/wallet/ethereum/EvmNetworks';
-import InjectedProvider from '../../../../lib/wallet/ethereum/InjectedProvider';
 import type Contracts from '../../../../lib/wallet/ethereum/contracts/Contracts';
 import type ERC20WalletProvider from '../../../../lib/wallet/providers/ERC20WalletProvider';
 import type { EthereumSetup } from '../EthereumTools';
@@ -29,8 +28,6 @@ jest.mock(
 jest.mock('../../../../lib/db/repositories/ChainTipRepository');
 
 describe('EthereumManager', () => {
-  InjectedProvider.allowHttpOnly = true;
-
   let database: Database;
 
   let setup: EthereumSetup;

--- a/test/integration/wallet/ethereum/InjectedProvider.spec.ts
+++ b/test/integration/wallet/ethereum/InjectedProvider.spec.ts
@@ -19,8 +19,6 @@ jest.mock(
 );
 
 describe('InjectedProvider', () => {
-  InjectedProvider.allowHttpOnly = true;
-
   let provider: InjectedProvider;
 
   beforeAll(async () => {

--- a/test/unit/wallet/ethereum/ArbitrumProvider.spec.ts
+++ b/test/unit/wallet/ethereum/ArbitrumProvider.spec.ts
@@ -14,20 +14,42 @@ jest.mock(
   }),
 );
 
-type UnderlyingMock = {
+type L2Mock = {
+  send: jest.Mock;
+  destroy: jest.Mock;
+};
+
+type L1Mock = {
   getBlockNumber: jest.Mock;
   destroy: jest.Mock;
 };
 
-const makeUnder = (height: number): UnderlyingMock => ({
+const hexBlock = (l2: number, l1?: number) => ({
+  number: `0x${l2.toString(16)}`,
+  ...(l1 !== undefined ? { l1BlockNumber: `0x${l1.toString(16)}` } : {}),
+});
+
+const makeL2 = (
+  payload: { number: string; l1BlockNumber?: string } | Error,
+): L2Mock => ({
+  send: jest.fn().mockImplementation(() => {
+    if (payload instanceof Error) {
+      return Promise.reject(payload);
+    }
+    return Promise.resolve(payload);
+  }),
+  destroy: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeL1 = (height: number): L1Mock => ({
   getBlockNumber: jest.fn().mockResolvedValue(height),
   destroy: jest.fn().mockResolvedValue(undefined),
 });
 
 const buildProvider = (
-  l2Height: number,
-  l1Height: number,
-): { provider: ArbitrumProvider; l2: UnderlyingMock; l1: UnderlyingMock } => {
+  l2Payload: { number: string; l1BlockNumber?: string } | Error,
+  l1Height = 0,
+): { provider: ArbitrumProvider; l2: L2Mock; l1: L1Mock } => {
   const provider = new ArbitrumProvider(
     Logger.disabledLogger,
     networks.Arbitrum,
@@ -46,10 +68,9 @@ const buildProvider = (
     void real.destroy();
   }
 
-  const l2 = makeUnder(l2Height);
-  const l1 = makeUnder(l1Height);
+  const l2 = makeL2(l2Payload);
+  const l1 = makeL1(l1Height);
 
-  // Swap the real underlying providers (both L2 and L1) for controllable mocks.
   provider['providers'] = new Map([['l2', l2 as any]]);
   provider['network'] = { chainId: 42161n, name: 'arbitrum' } as never;
 
@@ -62,39 +83,37 @@ const buildProvider = (
 
 describe('ArbitrumProvider', () => {
   describe('getLatestBlock', () => {
-    test('combines L2 height and L1 height into one BlockEvent', async () => {
-      const { provider, l2, l1 } = buildProvider(2_000, 123);
+    test('parses number and l1BlockNumber from the raw L2 block', async () => {
+      const { provider, l2, l1 } = buildProvider(hexBlock(2_000, 123));
 
       await expect(provider['getLatestBlock']()).resolves.toEqual({
         number: 2_000,
         l1BlockNumber: 123,
       });
 
-      expect(l2.getBlockNumber).toHaveBeenCalledTimes(1);
-      expect(l1.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(l2.send).toHaveBeenCalledTimes(1);
+      expect(l2.send).toHaveBeenCalledWith('eth_getBlockByNumber', [
+        'latest',
+        false,
+      ]);
+      expect(l1.getBlockNumber).not.toHaveBeenCalled();
 
       await provider.destroy();
     });
 
-    test('rejects when the L1 fetch fails', async () => {
-      const { provider, l1 } = buildProvider(2_000, 123);
-      l1.getBlockNumber.mockReset().mockRejectedValue(new Error('L1 down'));
+    test('returns l1BlockNumber undefined when the raw payload omits it', async () => {
+      const { provider } = buildProvider(hexBlock(2_000));
 
-      let caught: unknown;
-      try {
-        await provider['getLatestBlock']();
-      } catch (e) {
-        caught = e;
-      }
-      expect(caught).toBeDefined();
-      expect((caught as { message: string }).message).toMatch(/L1 down/);
+      await expect(provider['getLatestBlock']()).resolves.toEqual({
+        number: 2_000,
+        l1BlockNumber: undefined,
+      });
 
       await provider.destroy();
     });
 
-    test('rejects when the L2 fetch fails', async () => {
-      const { provider, l2 } = buildProvider(2_000, 123);
-      l2.getBlockNumber.mockReset().mockRejectedValue(new Error('L2 down'));
+    test('rejects when the underlying send fails', async () => {
+      const { provider } = buildProvider(new Error('L2 down'));
 
       let caught: unknown;
       try {
@@ -119,7 +138,7 @@ describe('ArbitrumProvider', () => {
     });
 
     test('emits BlockEvents that carry l1BlockNumber to listeners', async () => {
-      const { provider, l2, l1 } = buildProvider(2_000, 123);
+      const { provider, l2, l1 } = buildProvider(hexBlock(2_000, 123));
 
       const listener = jest.fn();
       await provider.onBlock(listener);
@@ -130,19 +149,19 @@ describe('ArbitrumProvider', () => {
         number: 2_000,
         l1BlockNumber: 123,
       });
-      expect(l2.getBlockNumber).toHaveBeenCalledTimes(1);
-      expect(l1.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(l2.send).toHaveBeenCalledTimes(1);
+      expect(l1.getBlockNumber).not.toHaveBeenCalled();
 
       await provider.destroy();
     });
 
-    test('listener receives the latest L1 height as it advances', async () => {
-      const { provider, l1 } = buildProvider(2_000, 123);
-      l1.getBlockNumber
+    test('listener receives the latest l1BlockNumber as the L2 block advances', async () => {
+      const { provider, l2 } = buildProvider(hexBlock(2_000, 123));
+      l2.send
         .mockReset()
-        .mockResolvedValueOnce(123)
-        .mockResolvedValueOnce(124)
-        .mockResolvedValueOnce(125);
+        .mockResolvedValueOnce(hexBlock(2_000, 123))
+        .mockResolvedValueOnce(hexBlock(2_001, 124))
+        .mockResolvedValueOnce(hexBlock(2_002, 125));
 
       const listener = jest.fn();
       await provider.onBlock(listener);
@@ -156,11 +175,11 @@ describe('ArbitrumProvider', () => {
         l1BlockNumber: 123,
       });
       expect(listener).toHaveBeenNthCalledWith(2, {
-        number: 2_000,
+        number: 2_001,
         l1BlockNumber: 124,
       });
       expect(listener).toHaveBeenNthCalledWith(3, {
-        number: 2_000,
+        number: 2_002,
         l1BlockNumber: 125,
       });
 
@@ -168,9 +187,20 @@ describe('ArbitrumProvider', () => {
     });
   });
 
+  describe('getLocktimeHeight', () => {
+    test('returns the live L1 tip from the L1 provider', async () => {
+      const { provider, l1 } = buildProvider(hexBlock(2_000, 123), 999);
+
+      await expect(provider.getLocktimeHeight()).resolves.toEqual(999);
+      expect(l1.getBlockNumber).toHaveBeenCalledTimes(1);
+
+      await provider.destroy();
+    });
+  });
+
   describe('destroy', () => {
     test('tears down the L1 provider in addition to the L2 one', async () => {
-      const { provider, l2, l1 } = buildProvider(2_000, 123);
+      const { provider, l2, l1 } = buildProvider(hexBlock(2_000, 123));
 
       await provider.destroy();
 

--- a/test/unit/wallet/ethereum/ArbitrumProvider.spec.ts
+++ b/test/unit/wallet/ethereum/ArbitrumProvider.spec.ts
@@ -1,0 +1,181 @@
+import Logger from '../../../../lib/Logger';
+import ArbitrumProvider from '../../../../lib/wallet/ethereum/ArbitrumProvider';
+import { networks } from '../../../../lib/wallet/ethereum/EvmNetworks';
+
+jest.mock('../../../../lib/ExitHandler', () => ({
+  shutdownSignal: { aborted: false },
+}));
+
+jest.mock(
+  '../../../../lib/db/repositories/PendingEthereumTransactionRepository',
+  () => ({
+    addTransaction: jest.fn().mockResolvedValue(null),
+    getHighestNonce: jest.fn().mockResolvedValue(undefined),
+  }),
+);
+
+type UnderlyingMock = {
+  getBlockNumber: jest.Mock;
+  destroy: jest.Mock;
+};
+
+const makeUnder = (height: number): UnderlyingMock => ({
+  getBlockNumber: jest.fn().mockResolvedValue(height),
+  destroy: jest.fn().mockResolvedValue(undefined),
+});
+
+const buildProvider = (
+  l2Height: number,
+  l1Height: number,
+): { provider: ArbitrumProvider; l2: UnderlyingMock; l1: UnderlyingMock } => {
+  const provider = new ArbitrumProvider(
+    Logger.disabledLogger,
+    networks.Arbitrum,
+    {
+      providerEndpoint: 'http://127.0.0.1:0',
+      l1Providers: [{ name: 'mainnet', endpoint: 'http://127.0.0.1:0' }],
+    } as never,
+  );
+
+  // Tear down the real JsonRpcProviders before replacing the maps so their
+  // internal polling timers don't outlive the test.
+  for (const real of provider['providers'].values()) {
+    void real.destroy();
+  }
+  for (const real of provider['l1Provider']['providers'].values()) {
+    void real.destroy();
+  }
+
+  const l2 = makeUnder(l2Height);
+  const l1 = makeUnder(l1Height);
+
+  // Swap the real underlying providers (both L2 and L1) for controllable mocks.
+  provider['providers'] = new Map([['l2', l2 as any]]);
+  provider['network'] = { chainId: 42161n, name: 'arbitrum' } as never;
+
+  const l1Provider = provider['l1Provider'];
+  l1Provider['providers'] = new Map([['l1', l1 as any]]);
+  l1Provider['network'] = { chainId: 1n, name: 'mainnet' } as never;
+
+  return { provider, l2, l1 };
+};
+
+describe('ArbitrumProvider', () => {
+  describe('getLatestBlock', () => {
+    test('combines L2 height and L1 height into one BlockEvent', async () => {
+      const { provider, l2, l1 } = buildProvider(2_000, 123);
+
+      await expect(provider['getLatestBlock']()).resolves.toEqual({
+        number: 2_000,
+        l1BlockNumber: 123,
+      });
+
+      expect(l2.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(l1.getBlockNumber).toHaveBeenCalledTimes(1);
+
+      await provider.destroy();
+    });
+
+    test('rejects when the L1 fetch fails', async () => {
+      const { provider, l1 } = buildProvider(2_000, 123);
+      l1.getBlockNumber.mockReset().mockRejectedValue(new Error('L1 down'));
+
+      let caught: unknown;
+      try {
+        await provider['getLatestBlock']();
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeDefined();
+      expect((caught as { message: string }).message).toMatch(/L1 down/);
+
+      await provider.destroy();
+    });
+
+    test('rejects when the L2 fetch fails', async () => {
+      const { provider, l2 } = buildProvider(2_000, 123);
+      l2.getBlockNumber.mockReset().mockRejectedValue(new Error('L2 down'));
+
+      let caught: unknown;
+      try {
+        await provider['getLatestBlock']();
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeDefined();
+      expect((caught as { message: string }).message).toMatch(/L2 down/);
+
+      await provider.destroy();
+    });
+  });
+
+  describe('poller integration', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('emits BlockEvents that carry l1BlockNumber to listeners', async () => {
+      const { provider, l2, l1 } = buildProvider(2_000, 123);
+
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledWith({
+        number: 2_000,
+        l1BlockNumber: 123,
+      });
+      expect(l2.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(l1.getBlockNumber).toHaveBeenCalledTimes(1);
+
+      await provider.destroy();
+    });
+
+    test('listener receives the latest L1 height as it advances', async () => {
+      const { provider, l1 } = buildProvider(2_000, 123);
+      l1.getBlockNumber
+        .mockReset()
+        .mockResolvedValueOnce(123)
+        .mockResolvedValueOnce(124)
+        .mockResolvedValueOnce(125);
+
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      await jest.advanceTimersByTimeAsync(0);
+      await jest.advanceTimersByTimeAsync(2_500);
+      await jest.advanceTimersByTimeAsync(2_500);
+
+      expect(listener).toHaveBeenNthCalledWith(1, {
+        number: 2_000,
+        l1BlockNumber: 123,
+      });
+      expect(listener).toHaveBeenNthCalledWith(2, {
+        number: 2_000,
+        l1BlockNumber: 124,
+      });
+      expect(listener).toHaveBeenNthCalledWith(3, {
+        number: 2_000,
+        l1BlockNumber: 125,
+      });
+
+      await provider.destroy();
+    });
+  });
+
+  describe('destroy', () => {
+    test('tears down the L1 provider in addition to the L2 one', async () => {
+      const { provider, l2, l1 } = buildProvider(2_000, 123);
+
+      await provider.destroy();
+
+      expect(l2.destroy).toHaveBeenCalledTimes(1);
+      expect(l1.destroy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/unit/wallet/ethereum/EthereumManager.spec.ts
+++ b/test/unit/wallet/ethereum/EthereumManager.spec.ts
@@ -20,6 +20,7 @@ jest.mock('../../../../lib/wallet/ethereum/InjectedProvider', () => {
     destroy: jest.fn().mockResolvedValue(undefined),
     removeAllListeners: jest.fn().mockResolvedValue(undefined),
     onBlock: jest.fn(),
+    onReconnect: jest.fn(),
     on: jest.fn(),
   }));
 });

--- a/test/unit/wallet/ethereum/EthereumManagerReconnect.spec.ts
+++ b/test/unit/wallet/ethereum/EthereumManagerReconnect.spec.ts
@@ -1,0 +1,166 @@
+import type { EthereumConfig } from '../../../../lib/Config';
+import Logger from '../../../../lib/Logger';
+import OverpaymentProtector from '../../../../lib/swap/OverpaymentProtector';
+import EthereumManager from '../../../../lib/wallet/ethereum/EthereumManager';
+import { networks } from '../../../../lib/wallet/ethereum/EvmNetworks';
+
+jest.mock('../../../../lib/wallet/ethereum/InjectedProvider', () => {
+  return jest.fn().mockImplementation(() => ({
+    init: jest.fn().mockResolvedValue(undefined),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    removeAllListeners: jest.fn().mockResolvedValue(undefined),
+    onBlock: jest.fn().mockResolvedValue(undefined),
+    onReconnect: jest.fn(),
+    on: jest.fn().mockResolvedValue(undefined),
+    getNetwork: jest.fn().mockResolvedValue({ chainId: 1n, name: 'mainnet' }),
+    getBlockNumber: jest.fn().mockResolvedValue(0),
+  }));
+});
+
+jest.mock('../../../../lib/wallet/ethereum/contracts/Contracts', () => {
+  return jest.fn().mockImplementation(() => ({
+    init: jest.fn().mockResolvedValue(undefined),
+    version: 6n,
+    features: new Set(),
+    contractEventHandler: {
+      checkMissedEvents: jest.fn().mockResolvedValue(undefined),
+    },
+    etherSwap: {
+      getAddress: jest.fn().mockResolvedValue('0xA'),
+    },
+    erc20Swap: {
+      getAddress: jest.fn().mockResolvedValue('0xB'),
+    },
+  }));
+});
+
+jest.mock('../../../../lib/wallet/ethereum/EthereumTransactionTracker', () => {
+  return jest.fn().mockImplementation(() => ({
+    init: jest.fn().mockResolvedValue(undefined),
+    scanPendingTransactions: jest.fn().mockResolvedValue(undefined),
+  }));
+});
+
+jest.mock('../../../../lib/wallet/ethereum/ConsolidatedEventHandler', () => {
+  return jest.fn().mockImplementation(() => ({
+    destroy: jest.fn(),
+  }));
+});
+
+jest.mock('../../../../lib/wallet/ethereum/contracts/Commitments', () => {
+  return jest.fn().mockImplementation(() => ({
+    init: jest.fn(),
+  }));
+});
+
+jest.mock('../../../../lib/db/repositories/ChainTipRepository', () => ({
+  findOrCreateTip: jest.fn().mockResolvedValue({}),
+  updateTip: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock(
+  '../../../../lib/db/repositories/PendingEthereumTransactionRepository',
+  () => ({
+    addTransaction: jest.fn().mockResolvedValue(null),
+    getHighestNonce: jest.fn().mockResolvedValue(undefined),
+  }),
+);
+
+describe('EthereumManager WebSocket reconnect wiring', () => {
+  const mnemonic =
+    'test test test test test test test test test test test junk';
+
+  const overpaymentProtector = new OverpaymentProtector(Logger.disabledLogger);
+
+  const createConfig = (): EthereumConfig => ({
+    providerEndpoint: 'http://127.0.0.1:0',
+    requiredConfirmations: 1,
+    contracts: [
+      {
+        etherSwap: '0xA',
+        erc20Swap: '0xB',
+      },
+    ],
+    tokens: [
+      {
+        symbol: networks.Ethereum.symbol,
+        minWalletBalance: 100_000,
+      },
+    ],
+  });
+
+  const buildAndInit = async () => {
+    const manager = new EthereumManager(
+      Logger.disabledLogger,
+      networks.Ethereum,
+      createConfig(),
+      overpaymentProtector,
+    );
+    await manager.init(mnemonic);
+    return manager;
+  };
+
+  test('registers an onReconnect handler during init', async () => {
+    const manager = await buildAndInit();
+
+    const onReconnect = (manager['provider'] as any).onReconnect as jest.Mock;
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(typeof onReconnect.mock.calls[0][0]).toBe('function');
+
+    await manager.destroy();
+  });
+
+  test('the registered handler triggers a missed-event rescan', async () => {
+    const manager = await buildAndInit();
+
+    const onReconnect = (manager['provider'] as any).onReconnect as jest.Mock;
+    const handler = onReconnect.mock.calls[0][0] as () => void;
+
+    const scheduleSpy = jest.fn();
+    (manager as any).scheduleMissedEventChecks = scheduleSpy;
+
+    handler();
+
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+
+    await manager.destroy();
+  });
+
+  test('each back-to-back reconnect invokes scheduleMissedEventChecks', async () => {
+    const manager = await buildAndInit();
+
+    const onReconnect = (manager['provider'] as any).onReconnect as jest.Mock;
+    const handler = onReconnect.mock.calls[0][0] as () => void;
+
+    const scheduleSpy = jest.fn();
+    (manager as any).scheduleMissedEventChecks = scheduleSpy;
+
+    handler();
+    handler();
+    handler();
+
+    expect(scheduleSpy).toHaveBeenCalledTimes(3);
+
+    await manager.destroy();
+  });
+
+  test('onBlock callback no longer schedules a rescan based on a block gap', async () => {
+    const manager = await buildAndInit();
+
+    const onBlock = (manager['provider'] as any).onBlock as jest.Mock;
+    expect(onBlock).toHaveBeenCalledTimes(1);
+
+    const blockCallback = onBlock.mock.calls[0][0] as (block: {
+      number: number;
+    }) => Promise<void>;
+
+    const scheduleSpy = jest.fn();
+    (manager as any).scheduleMissedEventChecks = scheduleSpy;
+
+    await blockCallback({ number: 1_000_000 });
+
+    expect(scheduleSpy).not.toHaveBeenCalled();
+
+    await manager.destroy();
+  });
+});

--- a/test/unit/wallet/ethereum/InjectedProvider.spec.ts
+++ b/test/unit/wallet/ethereum/InjectedProvider.spec.ts
@@ -1,0 +1,412 @@
+import EventEmitter from 'events';
+import Logger from '../../../../lib/Logger';
+import Errors from '../../../../lib/wallet/ethereum/Errors';
+import { networks } from '../../../../lib/wallet/ethereum/EvmNetworks';
+import InjectedProvider from '../../../../lib/wallet/ethereum/InjectedProvider';
+import WebSocketProvider, {
+  type BlockEvent,
+} from '../../../../lib/wallet/ethereum/WebSocketProvider';
+
+jest.mock('../../../../lib/ExitHandler', () => ({
+  shutdownSignal: { aborted: false },
+}));
+const mockedExitHandler = jest.requireMock('../../../../lib/ExitHandler') as {
+  shutdownSignal: { aborted: boolean };
+};
+
+jest.mock(
+  '../../../../lib/db/repositories/PendingEthereumTransactionRepository',
+  () => ({
+    addTransaction: jest.fn().mockResolvedValue(null),
+    getHighestNonce: jest.fn().mockResolvedValue(undefined),
+  }),
+);
+
+type UnderlyingMock = {
+  getBlockNumber: jest.Mock;
+  destroy: jest.Mock;
+};
+
+const buildProvider = (
+  overrides?: Partial<UnderlyingMock>,
+): { provider: InjectedProvider; mockUnder: UnderlyingMock } => {
+  const provider = new InjectedProvider(
+    Logger.disabledLogger,
+    networks.Ethereum,
+    { providerEndpoint: 'http://127.0.0.1:0' } as never,
+  );
+
+  for (const real of provider['providers'].values()) {
+    void real.destroy();
+  }
+
+  const mockUnder: UnderlyingMock = {
+    getBlockNumber: jest.fn().mockResolvedValue(100),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+
+  provider['providers'] = new Map([['mock', mockUnder as any]]);
+  provider['network'] = { chainId: 1n, name: 'mainnet' } as never;
+  return { provider, mockUnder };
+};
+
+describe('InjectedProvider', () => {
+  beforeEach(() => {
+    mockedExitHandler.shutdownSignal.aborted = false;
+  });
+
+  describe('constructor', () => {
+    test('throws when no providers are configured', () => {
+      expect(
+        () =>
+          new InjectedProvider(Logger.disabledLogger, networks.Ethereum, {
+            providers: [],
+          } as never),
+      ).toThrow(Errors.NO_PROVIDER_SPECIFIED().message);
+    });
+
+    test('accepts an HTTP-only endpoint (NEED_WEBSOCKET_PROVIDER no longer enforced)', () => {
+      const provider = new InjectedProvider(
+        Logger.disabledLogger,
+        networks.Ethereum,
+        { providerEndpoint: 'http://127.0.0.1:0' } as never,
+      );
+
+      expect(provider['providers'].size).toEqual(1);
+    });
+
+    test('skips blank-endpoint providers and throws if none remain', () => {
+      expect(
+        () =>
+          new InjectedProvider(Logger.disabledLogger, networks.Ethereum, {
+            providers: [{ endpoint: '' }],
+          } as never),
+      ).toThrow(Errors.NO_PROVIDER_SPECIFIED().message);
+    });
+  });
+
+  describe('onBlock polling', () => {
+    let provider: InjectedProvider;
+    let mockUnder: UnderlyingMock;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      ({ provider, mockUnder } = buildProvider());
+    });
+
+    afterEach(async () => {
+      jest.useRealTimers();
+      await provider.destroy();
+    });
+
+    test('does not start polling until the first listener is added', () => {
+      expect(provider['blockPollTimer']).toBeUndefined();
+    });
+
+    test('starts polling and fires the listener on the immediate first tick', async () => {
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      expect(provider['blockPollTimer']).toBeDefined();
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(mockUnder.getBlockNumber).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith({ number: 100 });
+
+      await jest.advanceTimersByTimeAsync(2_500);
+
+      expect(mockUnder.getBlockNumber).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    test('fires the listener on every tick (no internal height dedup)', async () => {
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      await jest.advanceTimersByTimeAsync(0); // immediate
+      await jest.advanceTimersByTimeAsync(2_500);
+      await jest.advanceTimersByTimeAsync(2_500);
+
+      expect(listener).toHaveBeenCalledTimes(3);
+      expect(listener).toHaveBeenNthCalledWith(1, { number: 100 });
+      expect(listener).toHaveBeenNthCalledWith(2, { number: 100 });
+      expect(listener).toHaveBeenNthCalledWith(3, { number: 100 });
+    });
+
+    test('multiple onBlock calls share a single poll timer', async () => {
+      const l1 = jest.fn();
+      const l2 = jest.fn();
+
+      await provider.onBlock(l1);
+      const timerBefore = provider['blockPollTimer'];
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      await provider.onBlock(l2);
+      const timerAfter = provider['blockPollTimer'];
+
+      expect(timerBefore).toBe(timerAfter);
+
+      expect(l1).toHaveBeenCalledTimes(1);
+      expect(l2).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(2_500);
+
+      expect(l1).toHaveBeenCalledTimes(2);
+      expect(l2).toHaveBeenCalledTimes(1);
+      expect(mockUnder.getBlockNumber).toHaveBeenCalledTimes(2);
+    });
+
+    test('continues firing other listeners when one throws', async () => {
+      const broken = jest.fn(() => {
+        throw new Error('boom');
+      });
+      const ok = jest.fn();
+
+      await provider.onBlock(broken);
+      await jest.advanceTimersByTimeAsync(0);
+      await provider.onBlock(ok);
+
+      await jest.advanceTimersByTimeAsync(2_500);
+
+      expect(broken).toHaveBeenCalledTimes(2);
+      expect(ok).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(2_500);
+
+      expect(broken).toHaveBeenCalledTimes(3);
+      expect(ok).toHaveBeenCalledTimes(2);
+    });
+
+    test('keeps polling after an RPC failure', async () => {
+      mockUnder.getBlockNumber
+        .mockRejectedValueOnce(new Error('rpc down'))
+        .mockResolvedValueOnce(101)
+        .mockResolvedValueOnce(102);
+
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(listener).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(2_500);
+      expect(listener).toHaveBeenLastCalledWith({ number: 101 });
+
+      await jest.advanceTimersByTimeAsync(2_500);
+      expect(listener).toHaveBeenLastCalledWith({ number: 102 });
+    });
+
+    test('skips scheduled ticks while a previous tick is still in flight', async () => {
+      let resolveFirst: (block: BlockEvent) => void = () => {};
+      const firstCall = new Promise<BlockEvent>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const getLatest = jest
+        .fn()
+        .mockImplementationOnce(() => firstCall)
+        .mockResolvedValue({ number: 200 });
+      (provider as any).getLatestBlock = getLatest;
+
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(getLatest).toHaveBeenCalledTimes(1);
+      expect(listener).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(2_500);
+      await jest.advanceTimersByTimeAsync(2_500);
+      await jest.advanceTimersByTimeAsync(2_500);
+      expect(getLatest).toHaveBeenCalledTimes(1);
+
+      resolveFirst({ number: 100 });
+      await jest.advanceTimersByTimeAsync(0);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenLastCalledWith({ number: 100 });
+
+      await jest.advanceTimersByTimeAsync(2_500);
+      expect(getLatest).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith({ number: 200 });
+    });
+
+    test('does not fire listeners after destroy', async () => {
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      await jest.advanceTimersByTimeAsync(0);
+      const callsBeforeDestroy = listener.mock.calls.length;
+
+      await provider.destroy();
+      await jest.advanceTimersByTimeAsync(10_000);
+
+      expect(listener).toHaveBeenCalledTimes(callsBeforeDestroy);
+    });
+
+    test('does not fire listeners while shutdown signal is aborted', async () => {
+      const listener = jest.fn();
+      mockedExitHandler.shutdownSignal.aborted = true;
+
+      await provider.onBlock(listener);
+      await jest.advanceTimersByTimeAsync(2_500);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('destroy clears the poll timer and listener set', async () => {
+      await provider.onBlock(jest.fn());
+      expect(provider['blockPollTimer']).toBeDefined();
+      expect(provider['blockListeners'].size).toEqual(1);
+
+      await provider.destroy();
+
+      expect(provider['blockPollTimer']).toBeUndefined();
+      expect(provider['blockListeners'].size).toEqual(0);
+    });
+
+    test('startBlockPoll is idempotent once a timer is active', async () => {
+      await provider.onBlock(jest.fn());
+      const timerBefore = provider['blockPollTimer'];
+
+      provider['startBlockPoll']();
+
+      expect(provider['blockPollTimer']).toBe(timerBefore);
+    });
+
+    test('startBlockPoll is a no-op after destroy', async () => {
+      await provider.destroy();
+
+      provider['startBlockPoll']();
+
+      expect(provider['blockPollTimer']).toBeUndefined();
+    });
+  });
+
+  describe('getLatestBlock', () => {
+    test('returns { number } sourced from getBlockNumber', async () => {
+      const { provider, mockUnder } = buildProvider();
+      mockUnder.getBlockNumber.mockResolvedValue(42);
+
+      await expect(provider['getLatestBlock']()).resolves.toEqual({
+        number: 42,
+      });
+
+      await provider.destroy();
+    });
+  });
+
+  describe('onReconnect', () => {
+    const buildWithFakeProviders = (
+      providers: Array<{ name: string; impl: any }>,
+    ): InjectedProvider => {
+      const provider = new InjectedProvider(
+        Logger.disabledLogger,
+        networks.Ethereum,
+        { providerEndpoint: 'http://127.0.0.1:0' } as never,
+      );
+      for (const real of provider['providers'].values()) {
+        void real.destroy();
+      }
+      provider['providers'] = new Map(
+        providers.map(({ name, impl }) => [name, impl as any]),
+      );
+      return provider;
+    };
+
+    test('registers the callback on every WebSocket provider', async () => {
+      const ws1 = new EventEmitter();
+      const ws2 = new EventEmitter();
+      const fake1: any = {
+        ws: ws1,
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+      const fake2: any = {
+        ws: ws2,
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+      // Make the duck-typed mocks pass `instanceof WebSocketProvider`.
+      Object.setPrototypeOf(fake1, WebSocketProvider.prototype);
+      Object.setPrototypeOf(fake2, WebSocketProvider.prototype);
+
+      const provider = buildWithFakeProviders([
+        { name: 'a', impl: fake1 },
+        { name: 'b', impl: fake2 },
+      ]);
+
+      const callback = jest.fn();
+      provider.onReconnect(callback);
+
+      ws1.emit('reconnected');
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      ws2.emit('reconnected');
+      expect(callback).toHaveBeenCalledTimes(2);
+
+      await provider.destroy();
+    });
+
+    test('skips providers that are not WebSocketProvider instances', async () => {
+      const plain: any = {
+        destroy: jest.fn().mockResolvedValue(undefined),
+        ws: new EventEmitter(),
+      };
+      // Deliberately do NOT set WebSocketProvider.prototype.
+
+      const provider = buildWithFakeProviders([{ name: 'plain', impl: plain }]);
+
+      const callback = jest.fn();
+      expect(() => provider.onReconnect(callback)).not.toThrow();
+
+      plain.ws.emit('reconnected');
+      expect(callback).not.toHaveBeenCalled();
+
+      await provider.destroy();
+    });
+
+    test('destroy unregisters callbacks so subsequent reconnects do not fire them', async () => {
+      const ws1 = new EventEmitter();
+      const fake1: any = {
+        ws: ws1,
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+      Object.setPrototypeOf(fake1, WebSocketProvider.prototype);
+
+      const provider = buildWithFakeProviders([{ name: 'a', impl: fake1 }]);
+
+      const callback = jest.fn();
+      provider.onReconnect(callback);
+      expect(provider['reconnectCallbacks'].size).toEqual(1);
+
+      await provider.destroy();
+
+      expect(provider['reconnectCallbacks'].size).toEqual(0);
+
+      ws1.emit('reconnected');
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('integration of poller and listener fan-out', () => {
+    test('emits the BlockEvent shape produced by an overridden getLatestBlock', async () => {
+      jest.useFakeTimers();
+
+      const { provider, mockUnder } = buildProvider();
+      const augmented: BlockEvent = { number: 50, l1BlockNumber: 12 };
+      (provider as any).getLatestBlock = jest.fn().mockResolvedValue(augmented);
+
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      // Immediate first tick.
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledWith(augmented);
+      expect(mockUnder.getBlockNumber).not.toHaveBeenCalled();
+
+      jest.useRealTimers();
+      await provider.destroy();
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block notifications now work for HTTP-only providers via polling
  * Arbitrum L2 blocks include corresponding L1 block height when available
  * Providers expose a public reconnect hook that triggers missed-event rescans

* **Behavior Changes**
  * WebSocket layer forwards raw messages (no parsed block events)
  * Removed previously exported "need websocket provider" error

* **Tests**
  * Added extensive unit and integration tests for polling, Arbitrum, and reconnect behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-backend/pull/1401)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->