### PR TITLE
fix: harden EVM broadcasts

### DIFF
--- a/lib/wallet/ethereum/EthereumUtils.ts
+++ b/lib/wallet/ethereum/EthereumUtils.ts
@@ -8,6 +8,78 @@ export const parseBuffer = (input: string): Buffer => {
   return getHexBuffer(input.slice(2));
 };
 
+const nonceConflictMessages = [
+  'nonce too low',
+  'nonce has already been used',
+  'already known',
+  'replacement transaction underpriced',
+];
+
+const nonceConflictCodes = ['NONCE_EXPIRED', 'REPLACEMENT_UNDERPRICED'];
+
+const collectErrorValues = (
+  error: unknown,
+  values: string[] = [],
+  seen = new Set<unknown>(),
+  depth = 0,
+): string[] => {
+  if (error === null || error === undefined || depth > 5) {
+    return values;
+  }
+
+  if (typeof error === 'string') {
+    values.push(error);
+
+    try {
+      collectErrorValues(JSON.parse(error), values, seen, depth + 1);
+    } catch {
+      // Not JSON; the string itself is enough for matching.
+    }
+    return values;
+  }
+
+  if (typeof error !== 'object' || seen.has(error)) {
+    return values;
+  }
+
+  seen.add(error);
+  const err = error as Error & { code?: unknown; shortMessage?: unknown };
+
+  if (err.message !== undefined) {
+    collectErrorValues(err.message, values, seen, depth + 1);
+  }
+  if (err.shortMessage !== undefined) {
+    collectErrorValues(err.shortMessage, values, seen, depth + 1);
+  }
+  if (err.code !== undefined) {
+    collectErrorValues(err.code, values, seen, depth + 1);
+  }
+
+  for (const value of Object.values(error)) {
+    collectErrorValues(value, values, seen, depth + 1);
+  }
+
+  return values;
+};
+
+/**
+ * Detects broadcast errors that may indicate the transaction is already
+ * in the mempool or mined. Per the ethers docs, NONCE_EXPIRED means the
+ * nonce is consumed - possibly by this same transaction - not that the
+ * broadcast failed. Arbitrum's sequencer can also advance state between
+ * sequencing our tx and the RPC response, producing "nonce too low" for
+ * a tx that just landed.
+ */
+export const isNonceConflictError = (error: unknown): boolean => {
+  const values = collectErrorValues(error);
+  if (values.some((value) => nonceConflictCodes.includes(value))) {
+    return true;
+  }
+
+  const haystack = values.join(' ').toLowerCase();
+  return nonceConflictMessages.some((needle) => haystack.includes(needle));
+};
+
 export const bumpGasLimit = (gasLimit: bigint): bigint => {
   return (gasLimit * 125n + 99n) / 100n;
 };

--- a/lib/wallet/ethereum/InjectedProvider.ts
+++ b/lib/wallet/ethereum/InjectedProvider.ts
@@ -20,15 +20,20 @@ import { JsonRpcProvider, Transaction } from 'ethers';
 import type { EthereumConfig, ProviderConfig } from '../../Config';
 import { shutdownSignal } from '../../ExitHandler';
 import type Logger from '../../Logger';
+import { racePromise, sleep } from '../../PromiseUtils';
 import Tracing from '../../Tracing';
 import { formatError } from '../../Utils';
 import PendingEthereumTransactionRepository from '../../db/repositories/PendingEthereumTransactionRepository';
 import Errors from './Errors';
+import { isNonceConflictError } from './EthereumUtils';
 import type { NetworkDetails } from './EvmNetworks';
 import WebSocketProvider, { type BlockEvent } from './WebSocketProvider';
 
 const bigIntReplacer = (_key: string, value: any) =>
   typeof value === 'bigint' ? { $bigint: value.toString() } : value;
+
+const broadcastRecoveryDelays = [250, 750, 1_500, 3_000, 5_000, 8_000, 11_500];
+const broadcastTransactionLookupTimeout = 5_000;
 
 /**
  * This provider is a wrapper for the Provider of ethers, but it writes sent transactions to the database
@@ -312,11 +317,67 @@ class InjectedProvider implements Provider {
       return results[0];
     }
 
-    const error = (settled[0] as PromiseRejectedResult).reason;
+    const rejections = settled as PromiseRejectedResult[];
+    const nonceConflict = rejections.find((r) =>
+      isNonceConflictError(r.reason),
+    );
+
+    // Arbitrum (and any RPC fanout) can return "nonce too low" / "already known"
+    // for a transaction that the sequencer has already accepted. Before treating
+    // the broadcast as failed, check whether this exact signed tx is on chain.
+    if (nonceConflict !== undefined) {
+      const onchain = await this.lookupBroadcastedTransactionWithRetry(
+        tx.hash!,
+      );
+      if (onchain !== null) {
+        this.logger.warn(
+          `Broadcast of ${this.networkDetails.name} transaction ${tx.hash} returned a nonce conflict but the transaction is on the chain; treating as success`,
+        );
+        return onchain;
+      }
+    }
+
+    const error = (nonceConflict ?? rejections[0]).reason;
     this.logger.error(
       `Failed to broadcast ${this.networkDetails.name} transaction ${tx.hash}: ${formatError(error)}`,
     );
     throw error;
+  };
+
+  private lookupBroadcastedTransactionWithRetry = async (
+    hash: string,
+  ): Promise<TransactionResponse | null> => {
+    let transaction = await this.lookupBroadcastedTransaction(hash);
+    for (const delay of broadcastRecoveryDelays) {
+      if (transaction !== null) {
+        return transaction;
+      }
+
+      await sleep(delay);
+      transaction = await this.lookupBroadcastedTransaction(hash);
+    }
+
+    return transaction;
+  };
+
+  private lookupBroadcastedTransaction = async (
+    hash: string,
+  ): Promise<TransactionResponse | null> => {
+    const lookups = Array.from(this.providers.values()).map((provider) =>
+      racePromise(
+        provider.getTransaction(hash),
+        (reject) =>
+          reject(new Error(`timed out looking up broadcasted tx ${hash}`)),
+        broadcastTransactionLookupTimeout,
+      ),
+    );
+    const settled = await Promise.allSettled(lookups);
+    for (const res of settled) {
+      if (res.status === 'fulfilled' && res.value !== null) {
+        return res.value;
+      }
+    }
+    return null;
   };
 
   public sendTransaction = async (

--- a/test/unit/wallet/ethereum/EthereumUtils.spec.ts
+++ b/test/unit/wallet/ethereum/EthereumUtils.spec.ts
@@ -3,6 +3,7 @@ import { getHexBuffer } from '../../../../lib/Utils';
 import {
   bumpGasLimit,
   getGasPrices,
+  isNonceConflictError,
   parseBuffer,
 } from '../../../../lib/wallet/ethereum/EthereumUtils';
 
@@ -57,5 +58,56 @@ describe('EthereumUtils', () => {
     expect(await getGasPrices(provider)).toEqual(expected);
 
     expect(mockGetFeeData).toHaveBeenCalledTimes(1);
+  });
+
+  describe('isNonceConflictError', () => {
+    test.each`
+      name                                 | error
+      ${'ethers NONCE_EXPIRED code'}       | ${{ code: 'NONCE_EXPIRED', message: 'whatever' }}
+      ${'ethers REPLACEMENT_UNDERPRICED'}  | ${{ code: 'REPLACEMENT_UNDERPRICED', message: 'whatever' }}
+      ${'nonce too low message'}           | ${{ message: 'nonce too low: address 0x..., tx: 2909 state: 2910' }}
+      ${'nonce has already been used'}     | ${new Error('nonce has already been used (transaction=...)')}
+      ${'already known'}                   | ${{ message: 'ALREADY KNOWN' }}
+      ${'replacement underpriced message'} | ${{ shortMessage: 'replacement transaction underpriced' }}
+      ${'nested RPC message'}              | ${{ info: { error: { message: 'nonce too low: address 0x..., tx: 2909 state: 2910' } } }}
+      ${'nested cause code'}               | ${{ cause: { code: 'NONCE_EXPIRED' } }}
+      ${'JSON-RPC body message'}           | ${{ body: JSON.stringify({ error: { message: 'replacement transaction underpriced' } }) }}
+    `('matches $name', ({ error }) => {
+      expect(isNonceConflictError(error)).toBe(true);
+    });
+
+    test.each`
+      name             | error
+      ${'null'}        | ${null}
+      ${'undefined'}   | ${undefined}
+      ${'unrelated'}   | ${{ code: 'INSUFFICIENT_FUNDS', message: 'insufficient funds for gas' }}
+      ${'empty error'} | ${new Error('boom')}
+    `('does not match $name', ({ error }) => {
+      expect(isNonceConflictError(error)).toBe(false);
+    });
+
+    test('matches the real ethers v6 error from the Arbitrum log (Chain Swap uqUNFMq6M1Tu)', () => {
+      const realError = Object.assign(
+        new Error(
+          'nonce has already been used (transaction="0x02f9011082a4b1820b5d80...", ' +
+            'info={ "error": { "code": -32000, "message": "nonce too low: address ' +
+            '0xA6D0956216da39AA1989066A9B22b64c30924DCd, tx: 2909 state: 2910" } }, ' +
+            'code=NONCE_EXPIRED, version=6.16.0)',
+        ),
+        {
+          code: 'NONCE_EXPIRED',
+          shortMessage: 'nonce has already been used',
+          info: {
+            error: {
+              code: -32000,
+              message:
+                'nonce too low: address 0xA6D0956216da39AA1989066A9B22b64c30924DCd, tx: 2909 state: 2910',
+            },
+          },
+        },
+      );
+
+      expect(isNonceConflictError(realError)).toBe(true);
+    });
   });
 });

--- a/test/unit/wallet/ethereum/InjectedProvider.spec.ts
+++ b/test/unit/wallet/ethereum/InjectedProvider.spec.ts
@@ -1,3 +1,4 @@
+import { Wallet } from 'ethers';
 import EventEmitter from 'events';
 import Logger from '../../../../lib/Logger';
 import Errors from '../../../../lib/wallet/ethereum/Errors';
@@ -407,6 +408,259 @@ describe('InjectedProvider', () => {
 
       jest.useRealTimers();
       await provider.destroy();
+    });
+  });
+
+  describe('broadcastTransaction', () => {
+    type BroadcastMock = {
+      broadcastTransaction: jest.Mock;
+      getTransaction: jest.Mock;
+      destroy: jest.Mock;
+    };
+
+    const buildBroadcastProvider = (
+      ...mocks: Array<Partial<BroadcastMock>>
+    ): { provider: InjectedProvider; underlying: BroadcastMock[] } => {
+      const provider = new InjectedProvider(
+        Logger.disabledLogger,
+        networks.Ethereum,
+        { providerEndpoint: 'http://127.0.0.1:0' } as never,
+      );
+
+      for (const real of provider['providers'].values()) {
+        void real.destroy();
+      }
+
+      const underlying: BroadcastMock[] = mocks.map((overrides) => ({
+        broadcastTransaction: jest.fn(),
+        getTransaction: jest.fn(),
+        destroy: jest.fn().mockResolvedValue(undefined),
+        ...overrides,
+      }));
+
+      provider['providers'] = new Map(
+        underlying.map((u, i) => [`mock${i}`, u as any]),
+      );
+      provider['network'] = { chainId: 1n, name: 'mainnet' } as never;
+      return { provider, underlying };
+    };
+
+    let signedTx: string;
+    let txHash: string;
+
+    beforeAll(async () => {
+      const wallet = Wallet.createRandom();
+      signedTx = await wallet.signTransaction({
+        chainId: 1n,
+        nonce: 0,
+        gasLimit: 21_000n,
+        maxFeePerGas: 1_000_000_000n,
+        maxPriorityFeePerGas: 0n,
+        to: wallet.address,
+        value: 1n,
+      });
+      const { Transaction } = await import('ethers');
+      txHash = Transaction.from(signedTx).hash!;
+    });
+
+    test('returns the first fulfilled provider response on the happy path', async () => {
+      const response = { hash: txHash } as never;
+      const { provider, underlying } = buildBroadcastProvider(
+        { broadcastTransaction: jest.fn().mockResolvedValue(response) },
+        {
+          broadcastTransaction: jest
+            .fn()
+            .mockRejectedValue(new Error('nonce too low')),
+        },
+      );
+
+      await expect(provider.broadcastTransaction(signedTx)).resolves.toBe(
+        response,
+      );
+      expect(underlying[0].getTransaction).not.toHaveBeenCalled();
+      expect(underlying[1].getTransaction).not.toHaveBeenCalled();
+    });
+
+    test('recovers when all providers report nonce-too-low but tx is on chain', async () => {
+      const onchain = { hash: txHash, blockNumber: 123 } as never;
+      const { provider, underlying } = buildBroadcastProvider(
+        {
+          broadcastTransaction: jest.fn().mockRejectedValue(
+            Object.assign(new Error('nonce too low'), {
+              code: 'NONCE_EXPIRED',
+            }),
+          ),
+          getTransaction: jest.fn().mockResolvedValue(null),
+        },
+        {
+          broadcastTransaction: jest
+            .fn()
+            .mockRejectedValue(new Error('already known')),
+          getTransaction: jest.fn().mockResolvedValue(onchain),
+        },
+      );
+
+      await expect(provider.broadcastTransaction(signedTx)).resolves.toBe(
+        onchain,
+      );
+      expect(underlying[0].getTransaction).toHaveBeenCalledWith(txHash);
+      expect(underlying[1].getTransaction).toHaveBeenCalledWith(txHash);
+    });
+
+    test('recovers when tx appears after the nonce-conflict lookup is retried', async () => {
+      jest.useFakeTimers();
+      try {
+        const onchain = { hash: txHash, blockNumber: 123 } as never;
+        const { provider, underlying } = buildBroadcastProvider({
+          broadcastTransaction: jest.fn().mockRejectedValue(
+            Object.assign(new Error('nonce too low'), {
+              code: 'NONCE_EXPIRED',
+            }),
+          ),
+          getTransaction: jest
+            .fn()
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(onchain),
+        });
+
+        const result = provider.broadcastTransaction(signedTx);
+        await jest.advanceTimersByTimeAsync(250);
+
+        await expect(result).resolves.toBe(onchain);
+        expect(underlying[0].getTransaction).toHaveBeenCalledTimes(2);
+        expect(underlying[0].getTransaction).toHaveBeenCalledWith(txHash);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('ignores lookup errors while another provider later returns the tx', async () => {
+      jest.useFakeTimers();
+      try {
+        const onchain = { hash: txHash, blockNumber: 123 } as never;
+        const { provider, underlying } = buildBroadcastProvider(
+          {
+            broadcastTransaction: jest.fn().mockRejectedValue(
+              Object.assign(new Error('nonce too low'), {
+                code: 'NONCE_EXPIRED',
+              }),
+            ),
+            getTransaction: jest.fn().mockRejectedValue(new Error('down')),
+          },
+          {
+            broadcastTransaction: jest
+              .fn()
+              .mockRejectedValue(new Error('already known')),
+            getTransaction: jest
+              .fn()
+              .mockResolvedValueOnce(null)
+              .mockResolvedValueOnce(onchain),
+          },
+        );
+
+        const result = provider.broadcastTransaction(signedTx);
+        await jest.advanceTimersByTimeAsync(250);
+
+        await expect(result).resolves.toBe(onchain);
+        expect(underlying[0].getTransaction).toHaveBeenCalledTimes(2);
+        expect(underlying[1].getTransaction).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('times out hung lookup providers while another provider returns the tx', async () => {
+      jest.useFakeTimers();
+      try {
+        const onchain = { hash: txHash, blockNumber: 123 } as never;
+        const { provider, underlying } = buildBroadcastProvider(
+          {
+            broadcastTransaction: jest.fn().mockRejectedValue(
+              Object.assign(new Error('nonce too low'), {
+                code: 'NONCE_EXPIRED',
+              }),
+            ),
+            getTransaction: jest.fn().mockReturnValue(new Promise(() => {})),
+          },
+          {
+            broadcastTransaction: jest
+              .fn()
+              .mockRejectedValue(new Error('already known')),
+            getTransaction: jest.fn().mockResolvedValue(onchain),
+          },
+        );
+
+        const result = provider.broadcastTransaction(signedTx);
+        await jest.advanceTimersByTimeAsync(5_000);
+
+        await expect(result).resolves.toBe(onchain);
+        expect(underlying[0].getTransaction).toHaveBeenCalledWith(txHash);
+        expect(underlying[1].getTransaction).toHaveBeenCalledWith(txHash);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('throws the original error after the retry budget when nonce-too-low but tx is not on chain', async () => {
+      jest.useFakeTimers();
+      try {
+        const original = Object.assign(new Error('nonce too low'), {
+          code: 'NONCE_EXPIRED',
+        });
+        const { provider, underlying } = buildBroadcastProvider({
+          broadcastTransaction: jest.fn().mockRejectedValue(original),
+          getTransaction: jest.fn().mockResolvedValue(null),
+        });
+
+        const result = provider.broadcastTransaction(signedTx).catch((e) => e);
+        await jest.advanceTimersByTimeAsync(30_000);
+
+        await expect(result).resolves.toBe(original);
+        expect(underlying[0].getTransaction).toHaveBeenCalledTimes(8);
+        expect(underlying[0].getTransaction).toHaveBeenCalledWith(txHash);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('throws the nonce-conflict rejection (not an unrelated one) after the retry budget', async () => {
+      jest.useFakeTimers();
+      try {
+        const unrelated = new Error('rate limited');
+        const nonceConflict = Object.assign(new Error('nonce too low'), {
+          code: 'NONCE_EXPIRED',
+        });
+        const { provider } = buildBroadcastProvider(
+          {
+            broadcastTransaction: jest.fn().mockRejectedValue(unrelated),
+            getTransaction: jest.fn().mockResolvedValue(null),
+          },
+          {
+            broadcastTransaction: jest.fn().mockRejectedValue(nonceConflict),
+            getTransaction: jest.fn().mockResolvedValue(null),
+          },
+        );
+
+        const result = provider.broadcastTransaction(signedTx).catch((e) => e);
+        await jest.advanceTimersByTimeAsync(30_000);
+
+        await expect(result).resolves.toBe(nonceConflict);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('throws without lookup for unrelated broadcast errors', async () => {
+      const original = new Error('insufficient funds for gas');
+      const { provider, underlying } = buildBroadcastProvider({
+        broadcastTransaction: jest.fn().mockRejectedValue(original),
+        getTransaction: jest.fn(),
+      });
+
+      await expect(provider.broadcastTransaction(signedTx)).rejects.toBe(
+        original,
+      );
+      expect(underlying[0].getTransaction).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transaction broadcasting resilience. When nonce conflicts are detected, the system now automatically retries to verify if the transaction was successfully recorded on-chain before failing, reducing unnecessary transaction rebroadcasts.

* **Tests**
  * Added comprehensive test coverage for transaction broadcast handling and nonce-conflict detection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-backend/pull/1408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->