### PR TITLE
feat: forward non-interactive claim config for Ark reverse swaps

### DIFF
--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -962,15 +962,12 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/NonInteractiveClaim'
      *     NonInteractiveClaim:
      *       type: object
-     *       required: ["claimReceiverAddress", "emulatorPublicKey"]
-     *       description: Enables a non-interactive solver claim on the VHTLC (Ark Reverse Swaps only)
+     *       required: ["claimReceiverAddress"]
+     *       description: Enables a non-interactive solver claim on the VHTLC (Ark Reverse and Chain Swaps to Ark)
      *       properties:
      *         claimReceiverAddress:
      *           type: string
      *           description: Ark address the solver must pay when claiming
-     *         emulatorPublicKey:
-     *           type: string
-     *           description: Compressed (33 bytes) secp256k1 public key tweaked by the arkade EnforcePayTo script encoded as HEX
      */
     /**
      * @openapi
@@ -1373,6 +1370,8 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/WebhookData'
      *         extraFees:
      *           $ref: '#/components/schemas/ExtraFees'
+     *         nonInteractiveClaim:
+     *           $ref: '#/components/schemas/NonInteractiveClaim'
      */
 
     /**
@@ -2970,6 +2969,7 @@ class SwapRouter extends RouterBase {
       userLockAmount,
       refundPublicKey,
       serverLockAmount,
+      nonInteractiveClaim,
     } = validateRequest(req.body, [
       { name: 'to', type: 'string' },
       { name: 'from', type: 'string' },
@@ -2982,12 +2982,15 @@ class SwapRouter extends RouterBase {
       { name: 'serverLockAmount', type: 'number', optional: true },
       { name: 'claimPublicKey', type: 'string', hex: true, optional: true },
       { name: 'refundPublicKey', type: 'string', hex: true, optional: true },
+      { name: 'nonInteractiveClaim', type: 'object', optional: true },
     ]);
     const referralId = parseReferralId(req);
 
     checkPreimageHashLength(preimageHash);
     const webHookData = this.parseWebHook(webhook);
     const extraFeesData = this.parseExtraFees(extraFees);
+    const nonInteractiveClaimData =
+      this.parseNonInteractiveClaim(nonInteractiveClaim);
 
     const { pairId, orderSide } = this.service.convertToPairAndSide(from, to);
     const response = await this.service.createChainSwap({
@@ -3003,6 +3006,7 @@ class SwapRouter extends RouterBase {
       serverLockAmount,
       webHook: webHookData,
       extraFees: extraFeesData,
+      nonInteractiveClaim: nonInteractiveClaimData,
     });
 
     await markSwap(this.service.sidecar, req.ip, response.id);
@@ -3312,16 +3316,10 @@ class SwapRouter extends RouterBase {
 
     const res = validateRequest(data, [
       { name: 'claimReceiverAddress', type: 'string' },
-      {
-        name: 'emulatorPublicKey',
-        type: 'string',
-        hex: true,
-      },
     ]);
 
     return {
       claimReceiverAddress: res.claimReceiverAddress,
-      emulatorPublicKey: res.emulatorPublicKey,
     };
   };
 

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -962,18 +962,15 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/NonInteractiveClaim'
      *     NonInteractiveClaim:
      *       type: object
-     *       required: ["claimReceiverAddress", "introspectorPublicKey"]
+     *       required: ["claimReceiverAddress", "emulatorPublicKey"]
      *       description: Enables a non-interactive solver claim on the VHTLC (Ark Reverse Swaps only)
      *       properties:
      *         claimReceiverAddress:
      *           type: string
      *           description: Ark address the solver must pay when claiming
-     *         introspectorPublicKey:
+     *         emulatorPublicKey:
      *           type: string
      *           description: Compressed (33 bytes) secp256k1 public key tweaked by the arkade EnforcePayTo script encoded as HEX
-     *         extraPacket:
-     *           type: string
-     *           description: Optional hex encoded extension to attach to the VHTLC funding tx
      */
     /**
      * @openapi
@@ -3316,17 +3313,15 @@ class SwapRouter extends RouterBase {
     const res = validateRequest(data, [
       { name: 'claimReceiverAddress', type: 'string' },
       {
-        name: 'introspectorPublicKey',
+        name: 'emulatorPublicKey',
         type: 'string',
         hex: true,
       },
-      { name: 'extraPacket', type: 'string', hex: true, optional: true },
     ]);
 
     return {
       claimReceiverAddress: res.claimReceiverAddress,
-      introspectorPublicKey: res.introspectorPublicKey,
-      extraPacket: res.extraPacket,
+      emulatorPublicKey: res.emulatorPublicKey,
     };
   };
 

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -962,10 +962,10 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/NonInteractiveClaim'
      *     NonInteractiveClaim:
      *       type: object
-     *       required: ["claimReceiverAddress"]
+     *       required: ["claimAddress"]
      *       description: Enables a non-interactive solver claim on the VHTLC (Ark Reverse and Chain Swaps to Ark)
      *       properties:
-     *         claimReceiverAddress:
+     *         claimAddress:
      *           type: string
      *           description: Ark address the solver must pay when claiming
      */
@@ -3315,11 +3315,11 @@ class SwapRouter extends RouterBase {
     }
 
     const res = validateRequest(data, [
-      { name: 'claimReceiverAddress', type: 'string' },
+      { name: 'claimAddress', type: 'string' },
     ]);
 
     return {
-      claimReceiverAddress: res.claimReceiverAddress,
+      claimAddress: res.claimAddress,
     };
   };
 

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express';
 import { Router } from 'express';
 import type Logger from '../../../Logger';
 import { getHexString, stringify } from '../../../Utils';
+import type { NonInteractiveClaim } from '../../../chain/ArkClient';
 import { SwapUpdateEvent, SwapVersion } from '../../../consts/Enums';
 import { unsafeKeys } from '../../../data/Utils';
 import ChainSwapRepository from '../../../db/repositories/ChainSwapRepository';
@@ -957,6 +958,22 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/WebhookData'
      *         extraFees:
      *           $ref: '#/components/schemas/ExtraFees'
+     *         nonInteractiveClaim:
+     *           $ref: '#/components/schemas/NonInteractiveClaim'
+     *     NonInteractiveClaim:
+     *       type: object
+     *       required: ["claimReceiverAddress", "introspectorPublicKey"]
+     *       description: Enables a non-interactive solver claim on the VHTLC (Ark Reverse Swaps only)
+     *       properties:
+     *         claimReceiverAddress:
+     *           type: string
+     *           description: Ark address the solver must pay when claiming
+     *         introspectorPublicKey:
+     *           type: string
+     *           description: Compressed (33 bytes) secp256k1 public key tweaked by the arkade EnforcePayTo script encoded as HEX
+     *         extraPacket:
+     *           type: string
+     *           description: Optional hex encoded extension to attach to the VHTLC funding tx
      */
     /**
      * @openapi
@@ -2786,6 +2803,7 @@ class SwapRouter extends RouterBase {
       claimPublicKey,
       descriptionHash,
       addressSignature,
+      nonInteractiveClaim,
     } = validateRequest(req.body, [
       { name: 'to', type: 'string' },
       { name: 'from', type: 'string' },
@@ -2801,6 +2819,7 @@ class SwapRouter extends RouterBase {
       { name: 'invoiceExpiry', type: 'number', optional: true },
       { name: 'onchainAmount', type: 'number', optional: true },
       { name: 'claimCovenant', type: 'boolean', optional: true },
+      { name: 'nonInteractiveClaim', type: 'object', optional: true },
       { name: 'preimageHash', type: 'string', hex: true, optional: true },
       { name: 'descriptionHash', type: 'string', hex: true, optional: true },
       { name: 'claimPublicKey', type: 'string', hex: true, optional: true },
@@ -2811,6 +2830,8 @@ class SwapRouter extends RouterBase {
     const { pairId, orderSide } = this.service.convertToPairAndSide(from, to);
     const webHookData = this.parseWebHook(webhook);
     const extraFeesData = this.parseExtraFees(extraFees);
+    const nonInteractiveClaimData =
+      this.parseNonInteractiveClaim(nonInteractiveClaim);
 
     const response = await this.service.createReverseSwap({
       pairId,
@@ -2834,6 +2855,7 @@ class SwapRouter extends RouterBase {
       extraFees: extraFeesData,
       version: SwapVersion.Taproot,
       userAddressSignature: addressSignature,
+      nonInteractiveClaim: nonInteractiveClaimData,
     });
 
     await markSwap(this.service.sidecar, req.ip, response.id);
@@ -3282,6 +3304,30 @@ class SwapRouter extends RouterBase {
     }
 
     return res;
+  };
+
+  private parseNonInteractiveClaim = (
+    data: Record<string, any> | undefined,
+  ): NonInteractiveClaim | undefined => {
+    if (data === undefined) {
+      return undefined;
+    }
+
+    const res = validateRequest(data, [
+      { name: 'claimReceiverAddress', type: 'string' },
+      {
+        name: 'introspectorPublicKey',
+        type: 'string',
+        hex: true,
+      },
+      { name: 'extraPacket', type: 'string', hex: true, optional: true },
+    ]);
+
+    return {
+      claimReceiverAddress: res.claimReceiverAddress,
+      introspectorPublicKey: res.introspectorPublicKey,
+      extraPacket: res.extraPacket,
+    };
   };
 
   private parseExtraFees = (

--- a/lib/chain/ArkClient.ts
+++ b/lib/chain/ArkClient.ts
@@ -82,8 +82,7 @@ type ArkAddress = {
 
 export type NonInteractiveClaim = {
   claimReceiverAddress: string;
-  introspectorPublicKey: Buffer;
-  extraPacket?: Buffer;
+  emulatorPublicKey: Buffer;
 };
 
 enum ArkBlockEventKind {
@@ -532,13 +531,7 @@ class ArkClient extends BaseClient<
     if (nonInteractiveClaim) {
       req.nonInteractiveClaim = {
         claimReceiverAddress: nonInteractiveClaim.claimReceiverAddress,
-        introspectorPubkey: getHexString(
-          nonInteractiveClaim.introspectorPublicKey,
-        ),
-        extraPacket:
-          nonInteractiveClaim.extraPacket !== undefined
-            ? getHexString(nonInteractiveClaim.extraPacket)
-            : undefined,
+        emulatorPubkey: getHexString(nonInteractiveClaim.emulatorPublicKey),
       };
     }
 

--- a/lib/chain/ArkClient.ts
+++ b/lib/chain/ArkClient.ts
@@ -529,7 +529,7 @@ class ArkClient extends BaseClient<
 
     if (nonInteractiveClaim) {
       req.nonInteractiveClaim = {
-        claimReceiverAddress: nonInteractiveClaim.claimReceiverAddress,
+        claimAddress: nonInteractiveClaim.claimReceiverAddress,
       };
     }
 

--- a/lib/chain/ArkClient.ts
+++ b/lib/chain/ArkClient.ts
@@ -82,7 +82,6 @@ type ArkAddress = {
 
 export type NonInteractiveClaim = {
   claimReceiverAddress: string;
-  emulatorPublicKey: Buffer;
 };
 
 enum ArkBlockEventKind {
@@ -531,7 +530,6 @@ class ArkClient extends BaseClient<
     if (nonInteractiveClaim) {
       req.nonInteractiveClaim = {
         claimReceiverAddress: nonInteractiveClaim.claimReceiverAddress,
-        emulatorPubkey: getHexString(nonInteractiveClaim.emulatorPublicKey),
       };
     }
 

--- a/lib/chain/ArkClient.ts
+++ b/lib/chain/ArkClient.ts
@@ -81,7 +81,7 @@ type ArkAddress = {
 };
 
 export type NonInteractiveClaim = {
-  claimReceiverAddress: string;
+  claimAddress: string;
 };
 
 enum ArkBlockEventKind {
@@ -529,7 +529,7 @@ class ArkClient extends BaseClient<
 
     if (nonInteractiveClaim) {
       req.nonInteractiveClaim = {
-        claimAddress: nonInteractiveClaim.claimReceiverAddress,
+        claimAddress: nonInteractiveClaim.claimAddress,
       };
     }
 

--- a/lib/chain/ArkClient.ts
+++ b/lib/chain/ArkClient.ts
@@ -80,6 +80,12 @@ type ArkAddress = {
   boardingAddress: string;
 };
 
+export type NonInteractiveClaim = {
+  claimReceiverAddress: string;
+  introspectorPublicKey: Buffer;
+  extraPacket?: Buffer;
+};
+
 enum ArkBlockEventKind {
   Height = 'height',
   MedianTime = 'medianTime',
@@ -475,6 +481,7 @@ class ArkClient extends BaseClient<
     refundDelay: number,
     claimPublicKey?: Buffer,
     refundPublicKey?: Buffer,
+    nonInteractiveClaim?: NonInteractiveClaim,
   ): Promise<{
     vHtlc: arkrpc.CreateVHTLCResponse;
     timeouts: Timeouts;
@@ -511,6 +518,7 @@ class ArkClient extends BaseClient<
       unilateralClaimDelay: undefined,
       unilateralRefundDelay: undefined,
       unilateralRefundWithoutReceiverDelay: undefined,
+      nonInteractiveClaim: undefined,
     };
 
     if (claimPublicKey) {
@@ -519,6 +527,19 @@ class ArkClient extends BaseClient<
 
     if (refundPublicKey) {
       req.senderPubkey = getHexString(refundPublicKey);
+    }
+
+    if (nonInteractiveClaim) {
+      req.nonInteractiveClaim = {
+        claimReceiverAddress: nonInteractiveClaim.claimReceiverAddress,
+        introspectorPubkey: getHexString(
+          nonInteractiveClaim.introspectorPublicKey,
+        ),
+        extraPacket:
+          nonInteractiveClaim.extraPacket !== undefined
+            ? getHexString(nonInteractiveClaim.extraPacket)
+            : undefined,
+      };
     }
 
     const currentHeight = await this.getBlockHeight();

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -31,7 +31,10 @@ import {
 } from '../Utils';
 import ApiErrors from '../api/Errors';
 import { checkPreimageHashLength, errorsNotToLog } from '../api/Utils';
-import type { Timeouts as ArkTimeouts } from '../chain/ArkClient';
+import type {
+  Timeouts as ArkTimeouts,
+  NonInteractiveClaim,
+} from '../chain/ArkClient';
 import type ArkClient from '../chain/ArkClient';
 import ElementsClient from '../chain/ElementsClient';
 import {
@@ -1797,6 +1800,9 @@ class Service {
 
     claimCovenant?: boolean;
 
+    // Only used for Reverse Swaps to Ark
+    nonInteractiveClaim?: NonInteractiveClaim;
+
     // Description for the invoice and magic routing hint
     description?: string;
     descriptionHash?: Buffer;
@@ -1922,6 +1928,13 @@ class Service {
         args.claimAddress = checkEvmAddress(args.claimAddress);
 
         break;
+    }
+
+    if (
+      args.nonInteractiveClaim !== undefined &&
+      sendingCurrency.type !== CurrencyType.Ark
+    ) {
+      throw ApiErrors.UNSUPPORTED_PARAMETER(sending, 'nonInteractiveClaim');
     }
 
     const [onchainTimeoutBlockDelta] =
@@ -2098,6 +2111,7 @@ class Service {
       claimPublicKey: args.claimPublicKey,
       descriptionHash: args.descriptionHash,
       claimCovenant: args.claimCovenant || false,
+      nonInteractiveClaim: args.nonInteractiveClaim,
       userAddressSignature: args.userAddressSignature,
       invoice:
         args.invoice !== undefined && decodedInvoice !== undefined

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -2251,6 +2251,8 @@ class Service {
 
     webHook?: WebHookData;
     extraFees?: ExtraFees;
+
+    nonInteractiveClaim?: NonInteractiveClaim;
   }) => {
     await this.checkSwapWithPreimageExists(SwapType.Chain, args.preimageHash);
 
@@ -2321,6 +2323,15 @@ class Service {
       if (args.refundPublicKey === undefined) {
         throw ApiErrors.UNDEFINED_PARAMETER('refundPublicKey');
       }
+    }
+
+    // The non-interactive claim leaf lives on the server-locked Ark VHTLC, so
+    // it is only valid when the server sends Ark (e.g. BTC -> ARK).
+    if (
+      args.nonInteractiveClaim !== undefined &&
+      sendingCurrency.type !== CurrencyType.Ark
+    ) {
+      throw ApiErrors.UNSUPPORTED_PARAMETER(sending, 'nonInteractiveClaim');
     }
 
     const sendingTimeoutBlockDelta = (
@@ -2440,6 +2451,7 @@ class Service {
       claimPublicKey: args.claimPublicKey,
       refundPublicKey: args.refundPublicKey,
       serverLockAmount: args.serverLockAmount,
+      nonInteractiveClaim: args.nonInteractiveClaim,
       acceptZeroConf: this.rateProvider.acceptZeroConf(
         receivingCurrency.symbol,
         args.userLockAmount,

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -1198,6 +1198,8 @@ class SwapManager {
     sendingTimeoutBlockDelta: number;
     receivingTimeoutBlockDelta: number;
 
+    nonInteractiveClaim?: NonInteractiveClaim;
+
     referralId?: string;
   }): Promise<CreatedChainSwap> => {
     const { sendingCurrency, receivingCurrency } = this.getCurrencies(
@@ -1303,6 +1305,7 @@ class SwapManager {
           timeoutBlockDelta,
           isSending ? theirPublicKey : undefined,
           isSending ? undefined : theirPublicKey,
+          isSending ? args.nonInteractiveClaim : undefined,
         );
         await currency.arkNode!.subscription.subscribeAddresses([
           {

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -33,7 +33,7 @@ import {
   getUnixTime,
   splitPairId,
 } from '../Utils';
-import type { Timeouts } from '../chain/ArkClient';
+import type { NonInteractiveClaim, Timeouts } from '../chain/ArkClient';
 import ArkClient from '../chain/ArkClient';
 import { LegacyReverseSwapOutputType } from '../consts/Consts';
 import DefaultMap from '../consts/DefaultMap';
@@ -796,6 +796,9 @@ class SwapManager {
 
     claimCovenant: boolean;
 
+    // Only used for Reverse Swaps to Ark
+    nonInteractiveClaim?: NonInteractiveClaim;
+
     memo?: string;
     descriptionHash?: Buffer;
 
@@ -1095,6 +1098,7 @@ class SwapManager {
         args.onchainTimeoutBlockDelta,
         args.claimPublicKey!,
         undefined,
+        args.nonInteractiveClaim,
       );
 
       result.refundPublicKey = getHexString(sendingCurrency.arkNode!.pubkey);

--- a/proto/ark/service.proto
+++ b/proto/ark/service.proto
@@ -419,7 +419,6 @@ message RelativeLocktime {
 
 message NonInteractiveClaim {
   string claim_receiver_address = 1; // fulmine will use it to compute the ArkadeScript (ark address)
-  string emulator_pubkey = 2; // tweaked by ArkadeScript (33 bytes compressed public key)
 }
 
 message Tapscripts {

--- a/proto/ark/service.proto
+++ b/proto/ark/service.proto
@@ -419,10 +419,7 @@ message RelativeLocktime {
 
 message NonInteractiveClaim {
   string claim_receiver_address = 1; // fulmine will use it to compute the ArkadeScript (ark address)
-  string introspector_pubkey = 2; // tweaked by ArkadeScript (33 bytes compressed public key)
-  // solver may require extra packet to be set when the VHTLC is funded
-  // if set, the funding tx should include an extension output with the extra_packet
-  optional string extra_packet = 3; // hex encoded
+  string emulator_pubkey = 2; // tweaked by ArkadeScript (33 bytes compressed public key)
 }
 
 message Tapscripts {

--- a/proto/ark/service.proto
+++ b/proto/ark/service.proto
@@ -274,8 +274,8 @@ message SignTransactionResponse {
 
 message CreateVHTLCRequest {
   string preimage_hash = 1;
-  string sender_pubkey = 2; 
-  string receiver_pubkey = 3; 
+  string sender_pubkey = 2;
+  string receiver_pubkey = 3;
   // Optional absolute locktime for refund condition (in blocks)
   uint32 refund_locktime = 4;
   // Optional unilateral claim delay (relative timelock)
@@ -284,6 +284,8 @@ message CreateVHTLCRequest {
   RelativeLocktime unilateral_refund_delay = 6;
   // Optional unilateral refund without receiver delay (relative timelock)
   RelativeLocktime unilateral_refund_without_receiver_delay = 7;
+  // Optional non-interactive claim config
+  NonInteractiveClaim non_interactive_claim = 8;
 }
 message CreateVHTLCResponse {
   string id = 1;
@@ -413,6 +415,14 @@ message RelativeLocktime {
   }
   LocktimeType type = 1;
   uint32 value = 2;
+}
+
+message NonInteractiveClaim {
+  string claim_receiver_address = 1; // fulmine will use it to compute the ArkadeScript (ark address)
+  string introspector_pubkey = 2; // tweaked by ArkadeScript (33 bytes compressed public key)
+  // solver may require extra packet to be set when the VHTLC is funded
+  // if set, the funding tx should include an extension output with the extra_packet
+  optional string extra_packet = 3; // hex encoded
 }
 
 message Tapscripts {

--- a/proto/ark/service.proto
+++ b/proto/ark/service.proto
@@ -418,7 +418,8 @@ message RelativeLocktime {
 }
 
 message NonInteractiveClaim {
-  string claim_receiver_address = 1; // fulmine will use it to compute the ArkadeScript (ark address)
+  // ark address of the claim tx recipient
+  string claim_address = 1;
 }
 
 message Tapscripts {


### PR DESCRIPTION
This PR adds support for an optional nonInteractiveClaim config on Ark reverse swaps, enabling a non-interactive tapscript path in the VHTLC contract : https://github.com/ArkLabsHQ/fulmine/pull/411

The change should be backward compatible.

The branch is not ready to be merged. it is used to run the boltz-swap PR e2e tests : https://github.com/arkade-os/boltz-swap/pull/150. 

@michael1011 please review 