### PR TITLE
feat: add metrics to Node async locks

### DIFF
--- a/lib/InstrumentedLock.ts
+++ b/lib/InstrumentedLock.ts
@@ -1,0 +1,135 @@
+import AsyncLock from 'async-lock';
+
+type HeldEntry = {
+  op: string;
+  since: number;
+};
+
+type LockSnapshotEntry = {
+  name: string;
+  key: string;
+  // The operation currently holding the lock, undefined if it is not held
+  op?: string;
+  holdAgeMs: number;
+  pending: number;
+  rejections: number;
+};
+
+/**
+ * Thin wrapper around {@link AsyncLock} that records, per lock key, which
+ * operation currently holds the lock, how many tasks are waiting for it and how
+ * often the queue overflowed. This makes "Too many pending tasks in queue"
+ * rejections debuggable: the rejection (which {@link AsyncLock} delivers to the
+ * waiter, not the holder) is enriched with the stuck holder and queue depth, and
+ * the live state is exposed via {@link InstrumentedLock.snapshot} for metrics.
+ */
+class InstrumentedLock {
+  private static readonly instances = new Set<InstrumentedLock>();
+
+  private readonly lock: AsyncLock;
+
+  // Current holder per key (one at a time, since the lock serializes)
+  private readonly held = new Map<string, HeldEntry>();
+  // Number of tasks currently waiting to acquire each key
+  private readonly pending = new Map<string, number>();
+  // Cumulative number of tasks rejected because the queue was full
+  private readonly rejections = new Map<string, number>();
+
+  constructor(
+    public readonly name: string,
+    options?: ConstructorParameters<typeof AsyncLock>[0],
+  ) {
+    this.lock = new AsyncLock(options);
+    InstrumentedLock.instances.add(this);
+  }
+
+  public acquire = async <T>(
+    key: string,
+    op: string,
+    cb: () => Promise<T>,
+  ): Promise<T> => {
+    this.changePending(key, 1);
+
+    let entered = false;
+
+    try {
+      return await this.lock.acquire(key, async () => {
+        entered = true;
+        this.changePending(key, -1);
+        this.held.set(key, { op, since: Date.now() });
+
+        try {
+          return await cb();
+        } finally {
+          this.held.delete(key);
+        }
+      });
+    } catch (error) {
+      if (!entered) {
+        // The task never started, so its pending slot was never cleared
+        this.changePending(key, -1);
+
+        if (InstrumentedLock.isOverflowError(error)) {
+          this.rejections.set(key, (this.rejections.get(key) ?? 0) + 1);
+          throw new Error(this.formatOverflowError(key, op));
+        }
+      }
+
+      throw error;
+    }
+  };
+
+  public isBusy = (key?: string): boolean => this.lock.isBusy(key);
+
+  public destroy = (): void => {
+    InstrumentedLock.instances.delete(this);
+  };
+
+  private changePending = (key: string, delta: number): void => {
+    this.pending.set(key, Math.max(0, (this.pending.get(key) ?? 0) + delta));
+  };
+
+  private formatOverflowError = (key: string, op: string): string => {
+    const holder = this.held.get(key);
+    const heldFor = holder === undefined ? 0 : Date.now() - holder.since;
+
+    return (
+      `lock ${this.name}.${key} overflow (op=${op}); ` +
+      `holder=${holder?.op ?? 'none'} held for ${heldFor}ms, ` +
+      `${this.pending.get(key) ?? 0} pending`
+    );
+  };
+
+  private static isOverflowError = (error: unknown): boolean =>
+    error instanceof Error && error.message.includes('Too many pending tasks');
+
+  public static snapshot = (): LockSnapshotEntry[] => {
+    const now = Date.now();
+    const entries: LockSnapshotEntry[] = [];
+
+    for (const instance of InstrumentedLock.instances) {
+      const keys = new Set<string>([
+        ...instance.pending.keys(),
+        ...instance.held.keys(),
+        ...instance.rejections.keys(),
+      ]);
+
+      for (const key of keys) {
+        const holder = instance.held.get(key);
+        entries.push({
+          name: instance.name,
+          key,
+          op: holder?.op,
+          holdAgeMs: holder === undefined ? 0 : now - holder.since,
+          pending: instance.pending.get(key) ?? 0,
+          rejections: instance.rejections.get(key) ?? 0,
+        });
+      }
+    }
+
+    return entries;
+  };
+}
+
+export default InstrumentedLock;
+export { LockSnapshotEntry };

--- a/lib/Prometheus.ts
+++ b/lib/Prometheus.ts
@@ -1,6 +1,7 @@
 import type { Response } from 'express';
 import express from 'express';
 import { Gauge, Registry, collectDefaultMetrics } from 'prom-client';
+import InstrumentedLock from './InstrumentedLock';
 import type Logger from './Logger';
 import { getPairId } from './Utils';
 import type Api from './api/Api';
@@ -379,6 +380,53 @@ class Prometheus {
             maxRisk,
           } of service.lockupTransactionTracker.maxRisks()) {
             this.set({ symbol }, Number(maxRisk));
+          }
+        },
+      }),
+    );
+
+    this.swapRegistry!.registerMetric(
+      new Gauge({
+        name: `${Prometheus.metricPrefix}lock_pending`,
+        labelNames: ['name', 'key'],
+        help: 'number of tasks waiting to acquire a lock',
+        collect: function () {
+          this.reset();
+          for (const entry of InstrumentedLock.snapshot()) {
+            this.set({ name: entry.name, key: entry.key }, entry.pending);
+          }
+        },
+      }),
+    );
+
+    this.swapRegistry!.registerMetric(
+      new Gauge({
+        name: `${Prometheus.metricPrefix}lock_hold_age_seconds`,
+        labelNames: ['name', 'key', 'op'],
+        help: 'age of the operation currently holding a lock in seconds',
+        collect: function () {
+          this.reset();
+          for (const entry of InstrumentedLock.snapshot()) {
+            if (entry.op !== undefined) {
+              this.set(
+                { name: entry.name, key: entry.key, op: entry.op },
+                entry.holdAgeMs / 1_000,
+              );
+            }
+          }
+        },
+      }),
+    );
+
+    this.swapRegistry!.registerMetric(
+      new Gauge({
+        name: `${Prometheus.metricPrefix}lock_rejections`,
+        labelNames: ['name', 'key'],
+        help: 'cumulative number of tasks rejected because a lock queue was full',
+        collect: function () {
+          this.reset();
+          for (const entry of InstrumentedLock.snapshot()) {
+            this.set({ name: entry.name, key: entry.key }, entry.rejections);
           }
         },
       }),

--- a/lib/service/Renegotiator.ts
+++ b/lib/service/Renegotiator.ts
@@ -60,8 +60,8 @@ class Renegotiator {
   // Do this in the refund signature lock to avoid creating refund signatures
   // while accepting new quotes and changing the status
   public acceptQuote = (swapId: string, newQuote: number) =>
-    this.chainSwapSigner.refundSignatureLock(() =>
-      this.eipSigner.refundSignatureLock(async () => {
+    this.chainSwapSigner.refundSignatureLock('acceptQuote', () =>
+      this.eipSigner.refundSignatureLock('acceptQuote', async () => {
         const { swap, receivingCurrency } = await this.getSwap(swapId);
         await this.validateEligibility(swap, receivingCurrency);
 

--- a/lib/service/cooperative/ChainSwapSigner.ts
+++ b/lib/service/cooperative/ChainSwapSigner.ts
@@ -1,6 +1,6 @@
-import AsyncLock from 'async-lock';
 import { SwapTreeSerializer } from 'boltz-core';
 import { Op } from 'sequelize';
+import InstrumentedLock from '../../InstrumentedLock';
 import type Logger from '../../Logger';
 import { formatError, getHexBuffer, getHexString } from '../../Utils';
 import {
@@ -53,7 +53,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
     preimage?: Buffer,
   ) => Promise<void>;
 
-  private readonly lock = new AsyncLock();
+  private readonly lock = new InstrumentedLock('chainSwapSigner');
   private readonly signerControlRegistry = SignerControlRegistry.getInstance();
   private readonly swapsToClaim = new Map<string, SwapToClaim<ChainSwapInfo>>();
 
@@ -66,8 +66,11 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
     super(logger, walletManager, swapOutputType);
   }
 
-  public refundSignatureLock = <T>(cb: () => Promise<T>): Promise<T> =>
-    this.lock.acquire(ChainSwapSigner.refundSignatureLock, cb);
+  public refundSignatureLock = <T>(
+    op: string,
+    cb: () => Promise<T>,
+  ): Promise<T> =>
+    this.lock.acquire(ChainSwapSigner.refundSignatureLock, op, cb);
 
   public init = async () => {
     const claimableChainSwaps = await ChainSwapRepository.getChainSwaps({
@@ -94,7 +97,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
     transaction: Buffer,
     index: number,
   ): Promise<PartialSignature> =>
-    this.refundSignatureLock(async () => {
+    this.refundSignatureLock('signRefund', async () => {
       const swap = await ChainSwapRepository.getChainSwap({ id: swapId });
       if (!swap) {
         throw Errors.SWAP_NOT_FOUND(swapId);
@@ -151,7 +154,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
     transaction: string,
     checkpoint: string,
   ): Promise<{ transaction: string; checkpoint: string }> => {
-    return await this.refundSignatureLock(async () => {
+    return await this.refundSignatureLock('signRefundArk', async () => {
       const swap = await ChainSwapRepository.getChainSwap({ id: swapId });
       if (!swap) {
         throw Errors.SWAP_NOT_FOUND(swapId);
@@ -215,25 +218,33 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
   };
 
   public registerForClaim = async (swap: ChainSwapInfo) => {
-    await this.lock.acquire(ChainSwapSigner.swapsToClaimLock, async () => {
-      if (this.swapsToClaim.has(swap.id)) {
-        return;
-      }
+    await this.lock.acquire(
+      ChainSwapSigner.swapsToClaimLock,
+      'registerForClaim',
+      async () => {
+        if (this.swapsToClaim.has(swap.id)) {
+          return;
+        }
 
-      if (!this.canClaimCooperatively(swap)) {
-        return;
-      }
+        if (!this.canClaimCooperatively(swap)) {
+          return;
+        }
 
-      this.swapsToClaim.set(swap.id, {
-        swap,
-      });
-    });
+        this.swapsToClaim.set(swap.id, {
+          swap,
+        });
+      },
+    );
   };
 
   public removeFromClaimable = async (id: string) => {
-    await this.lock.acquire(ChainSwapSigner.swapsToClaimLock, async () => {
-      this.swapsToClaim.delete(id);
-    });
+    await this.lock.acquire(
+      ChainSwapSigner.swapsToClaimLock,
+      'removeFromClaimable',
+      async () => {
+        this.swapsToClaim.delete(id);
+      },
+    );
   };
 
   public getCooperativeDetails = async (
@@ -280,6 +291,7 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
 
     return await this.lock.acquire(
       ChainSwapSigner.cooperativeBroadcastLock,
+      'signClaim',
       async () => {
         if (
           this.signerControlRegistry.isDisabled(
@@ -392,9 +404,13 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
 
   private getToClaimDetails = async (id: string) => {
     let details: SwapToClaim<ChainSwapInfo> | undefined;
-    await this.lock.acquire(ChainSwapSigner.swapsToClaimLock, async () => {
-      details = this.swapsToClaim.get(id);
-    });
+    await this.lock.acquire(
+      ChainSwapSigner.swapsToClaimLock,
+      'getToClaimDetails',
+      async () => {
+        details = this.swapsToClaim.get(id);
+      },
+    );
 
     return details;
   };

--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -1,6 +1,6 @@
-import AsyncLock from 'async-lock';
 import { type Provider, verifyMessage } from 'ethers';
 import { Op } from 'sequelize';
+import InstrumentedLock from '../../InstrumentedLock';
 import type Logger from '../../Logger';
 import {
   getChainCurrency,
@@ -35,7 +35,10 @@ import SignerControlRegistry from '../SignerControlRegistry';
 import { cooperativeSignaturesDisabledMessage } from './CoopSignerBase';
 import MusigSigner from './MusigSigner';
 
-export type RefundSignatureLock = <T>(cb: () => Promise<T>) => Promise<T>;
+export type RefundSignatureLock = <T>(
+  op: string,
+  cb: () => Promise<T>,
+) => Promise<T>;
 
 class EipSigner {
   private static readonly refundSignatureLock = 'refundSignature';
@@ -52,7 +55,7 @@ class EipSigner {
       `logIndex: ${logIndex ?? 'none'}`,
     ].join('\n');
 
-  private readonly lock = new AsyncLock();
+  private readonly lock = new InstrumentedLock('eipSigner');
   private readonly signerControlRegistry = SignerControlRegistry.getInstance();
 
   constructor(
@@ -62,11 +65,13 @@ class EipSigner {
     private readonly sidecar: Sidecar,
   ) {}
 
-  public refundSignatureLock = <T>(cb: () => Promise<T>): Promise<T> =>
-    this.lock.acquire(EipSigner.refundSignatureLock, cb);
+  public refundSignatureLock = <T>(
+    op: string,
+    cb: () => Promise<T>,
+  ): Promise<T> => this.lock.acquire(EipSigner.refundSignatureLock, op, cb);
 
   public signSwapRefund = async (swapIdOrPreimageHash: string) =>
-    this.refundSignatureLock(async () => {
+    this.refundSignatureLock('signSwapRefund', async () => {
       if (
         this.signerControlRegistry.isDisabled(
           Signer.SIGNER_EVM_REFUND_COOPERATIVE,
@@ -175,7 +180,7 @@ class EipSigner {
     refundAddressSignature: string,
     logIndex?: number,
   ) =>
-    this.refundSignatureLock(async () => {
+    this.refundSignatureLock('signCommitmentRefund', async () => {
       if (
         this.signerControlRegistry.isDisabled(
           Signer.SIGNER_EVM_COMMITMENT_REFUND_COOPERATIVE,

--- a/lib/wallet/ethereum/contracts/Commitments.ts
+++ b/lib/wallet/ethereum/contracts/Commitments.ts
@@ -126,7 +126,7 @@ class Commitments {
     logIndex?: number,
     maxOverpaymentPercentage?: number,
   ) =>
-    this.refundSignatureLock(async () => {
+    this.refundSignatureLock('commit', async () => {
       let swap: Swap | ChainSwapInfo | null = await SwapRepository.getSwap({
         id: swapId,
       });

--- a/test/integration/service/Renegotiator.spec.ts
+++ b/test/integration/service/Renegotiator.spec.ts
@@ -72,11 +72,11 @@ describe('Renegotiator', () => {
   } as any as SwapNursery;
 
   const chainSwapSigner = {
-    refundSignatureLock: jest.fn().mockImplementation((cb) => cb()),
+    refundSignatureLock: jest.fn().mockImplementation((_op, cb) => cb()),
   } as any as ChainSwapSigner;
 
   const eipSigner = {
-    refundSignatureLock: jest.fn().mockImplementation((cb) => cb()),
+    refundSignatureLock: jest.fn().mockImplementation((_op, cb) => cb()),
   } as any as EipSigner;
 
   const rateProvider = {

--- a/test/integration/wallet/ethereum/contracts/Commitments.spec.ts
+++ b/test/integration/wallet/ethereum/contracts/Commitments.spec.ts
@@ -837,8 +837,8 @@ describe('Commitments', () => {
         [contract],
         wallets,
       );
-      commitments.setRefundSignatureLock(async <T>(cb: () => Promise<T>) =>
-        cb(),
+      commitments.setRefundSignatureLock(
+        async <T>(_op: string, cb: () => Promise<T>) => cb(),
       );
 
       return commitments;

--- a/test/unit/InstrumentedLock.spec.ts
+++ b/test/unit/InstrumentedLock.spec.ts
@@ -1,0 +1,128 @@
+import InstrumentedLock from '../../lib/InstrumentedLock';
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+describe('InstrumentedLock', () => {
+  const locks: InstrumentedLock[] = [];
+
+  const newLock = (
+    name: string,
+    options?: ConstructorParameters<typeof InstrumentedLock>[1],
+  ) => {
+    const lock = new InstrumentedLock(name, options);
+    locks.push(lock);
+    return lock;
+  };
+
+  afterEach(() => {
+    locks.forEach((lock) => lock.destroy());
+    locks.length = 0;
+  });
+
+  test('should return the value of the callback', async () => {
+    const lock = newLock('test');
+    await expect(lock.acquire('key', 'op', async () => 42)).resolves.toEqual(
+      42,
+    );
+  });
+
+  test('should run tasks for the same key serially', async () => {
+    const lock = newLock('test');
+    const order: number[] = [];
+
+    const first = lock.acquire('key', 'first', async () => {
+      order.push(1);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      order.push(2);
+    });
+    const second = lock.acquire('key', 'second', async () => {
+      order.push(3);
+    });
+
+    await Promise.all([first, second]);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  test('should track the holder and waiters in the snapshot', async () => {
+    const lock = newLock('test');
+    const holder = deferred();
+
+    const held = lock.acquire('key', 'holder', () => holder.promise);
+    const waiter = lock.acquire('key', 'waiter', async () => {});
+
+    const entry = InstrumentedLock.snapshot().find(
+      (e) => e.name === 'test' && e.key === 'key',
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.op).toEqual('holder');
+    expect(entry!.pending).toEqual(1);
+    expect(entry!.holdAgeMs).toBeGreaterThanOrEqual(0);
+
+    holder.resolve();
+    await Promise.all([held, waiter]);
+
+    expect(lock.isBusy('key')).toEqual(false);
+  });
+
+  test('should reflect whether a key is busy', async () => {
+    const lock = newLock('test');
+    const holder = deferred();
+
+    expect(lock.isBusy('key')).toEqual(false);
+    const held = lock.acquire('key', 'holder', () => holder.promise);
+    expect(lock.isBusy('key')).toEqual(true);
+
+    holder.resolve();
+    await held;
+    expect(lock.isBusy('key')).toEqual(false);
+  });
+
+  test('should enrich the queue overflow error with the stuck holder', async () => {
+    const lock = newLock('eipSigner', { maxPending: 1 });
+    const holder = deferred();
+
+    const held = lock.acquire(
+      'refundSignature',
+      'holder',
+      () => holder.promise,
+    );
+    const waiter = lock.acquire('refundSignature', 'waiter', async () => {});
+
+    await expect(
+      lock.acquire('refundSignature', 'overflowed', async () => {}),
+    ).rejects.toThrow(
+      /^lock eipSigner\.refundSignature overflow \(op=overflowed\); holder=holder held for \d+ms, 1 pending$/,
+    );
+
+    const entry = InstrumentedLock.snapshot().find(
+      (e) => e.name === 'eipSigner' && e.key === 'refundSignature',
+    );
+    expect(entry!.rejections).toEqual(1);
+    expect(entry!.pending).toEqual(1);
+
+    holder.resolve();
+    await Promise.all([held, waiter]);
+  });
+
+  test('should not count an error thrown inside the callback as a rejection', async () => {
+    const lock = newLock('test');
+
+    await expect(
+      lock.acquire('key', 'op', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const entry = InstrumentedLock.snapshot().find(
+      (e) => e.name === 'test' && e.key === 'key',
+    );
+    expect(entry?.rejections ?? 0).toEqual(0);
+    expect(entry?.pending ?? 0).toEqual(0);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus now exposes lock metrics: pending queue depth, current holder age, and cumulative rejections
  * Lock overflow errors now include the current holder operation and hold duration for easier troubleshooting

* **Chores**
  * Internal locking updated to include operation labels to improve diagnostics and monitoring

* **Tests**
  * Added unit tests for lock instrumentation and behavior (acquisition order, busy state, snapshots, overflow handling)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->