### PR TITLE
feat: hold in invoice payment hook

### DIFF
--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -273,12 +273,6 @@ class EthereumNursery extends TypedEventEmitter<{
       );
 
       switch (action) {
-        case Action.Hold:
-          this.logger.warn(
-            `Holding lockup in ${this.ethereumManager.networkDetails.name} EtherSwap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
-          );
-          return;
-
         case Action.Reject:
           this.emit('lockup.failed', {
             swap,
@@ -428,12 +422,6 @@ class EthereumNursery extends TypedEventEmitter<{
       );
 
       switch (action) {
-        case Action.Hold:
-          this.logger.debug(
-            `Holding lockup in ${this.ethereumManager.networkDetails.name} ERC20Swap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
-          );
-          return;
-
         case Action.Reject:
           this.emit('lockup.failed', {
             swap,

--- a/lib/swap/NodeSwitch.ts
+++ b/lib/swap/NodeSwitch.ts
@@ -17,6 +17,8 @@ import {
 import Errors from './Errors';
 import InvoicePaymentHook, {
   InvoicePaymentHookAction,
+  type InvoicePaymentHookContinue,
+  type InvoicePaymentHookHold,
 } from './hooks/InvoicePaymentHook';
 
 type NodeAmountThreshold = {
@@ -53,24 +55,11 @@ type ReverseSwapNodeResolution =
       reason: string;
     };
 
-enum InvoicePaymentDecision {
-  Continue = 'continue',
-  Hold = 'hold',
-}
-
-type InvoicePaymentHookHold = {
-  action: InvoicePaymentDecision.Hold;
-};
-
-type InvoicePaymentHookContinue = {
-  action: InvoicePaymentDecision.Continue;
-  client?: LightningClient;
-  timePreference?: number;
-};
-
-type InvoicePaymentHookResult =
+type InvoicePaymentPreference =
   | InvoicePaymentHookHold
-  | InvoicePaymentHookContinue;
+  | (Omit<InvoicePaymentHookContinue, 'nodeId'> & {
+      client?: LightningClient;
+    });
 
 class NodeSwitch {
   public readonly clnAmountThreshold: {
@@ -339,19 +328,19 @@ class NodeSwitch {
     currency: Currency,
     swap: { id: string; invoice: string },
     decoded: DecodedInvoice,
-  ): Promise<InvoicePaymentHookResult | undefined> => {
+  ): Promise<InvoicePaymentPreference | undefined> => {
     const res = await this.paymentHook.hook(swap.id, swap.invoice, decoded);
     if (!res) return undefined;
 
     if (res.action === InvoicePaymentHookAction.Hold) {
-      return { action: InvoicePaymentDecision.Hold };
+      return { action: InvoicePaymentHookAction.Hold };
     }
 
     if (res.nodeId !== undefined) {
       const requestedClient = getLightningClientById(currency, res.nodeId);
       if (requestedClient && requestedClient.isConnected()) {
         return {
-          action: InvoicePaymentDecision.Continue,
+          action: InvoicePaymentHookAction.Continue,
           client: requestedClient,
           timePreference: res.timePreference,
         };
@@ -364,7 +353,7 @@ class NodeSwitch {
 
     if (res.timePreference !== undefined) {
       return {
-        action: InvoicePaymentDecision.Continue,
+        action: InvoicePaymentHookAction.Continue,
         timePreference: res.timePreference,
       };
     }
@@ -552,10 +541,4 @@ class NodeSwitch {
 }
 
 export default NodeSwitch;
-export type {
-  InvoicePaymentHookContinue,
-  InvoicePaymentHookHold,
-  InvoicePaymentHookResult,
-  NodeSwitchConfig,
-};
-export { InvoicePaymentDecision };
+export type { InvoicePaymentPreference, NodeSwitchConfig };

--- a/lib/swap/NodeSwitch.ts
+++ b/lib/swap/NodeSwitch.ts
@@ -15,7 +15,9 @@ import {
   getLightningClients,
 } from '../wallet/WalletManager';
 import Errors from './Errors';
-import InvoicePaymentHook from './hooks/InvoicePaymentHook';
+import InvoicePaymentHook, {
+  InvoicePaymentHookAction,
+} from './hooks/InvoicePaymentHook';
 
 type NodeAmountThreshold = {
   submarine: number;
@@ -50,6 +52,25 @@ type ReverseSwapNodeResolution =
         | ReverseSwapNodeResolutionStatus.Disconnected;
       reason: string;
     };
+
+enum InvoicePaymentDecision {
+  Continue = 'continue',
+  Hold = 'hold',
+}
+
+type InvoicePaymentHookHold = {
+  action: InvoicePaymentDecision.Hold;
+};
+
+type InvoicePaymentHookContinue = {
+  action: InvoicePaymentDecision.Continue;
+  client?: LightningClient;
+  timePreference?: number;
+};
+
+type InvoicePaymentHookResult =
+  | InvoicePaymentHookHold
+  | InvoicePaymentHookContinue;
 
 class NodeSwitch {
   public readonly clnAmountThreshold: {
@@ -318,16 +339,22 @@ class NodeSwitch {
     currency: Currency,
     swap: { id: string; invoice: string },
     decoded: DecodedInvoice,
-  ): Promise<
-    { client?: LightningClient; timePreference?: number } | undefined
-  > => {
+  ): Promise<InvoicePaymentHookResult | undefined> => {
     const res = await this.paymentHook.hook(swap.id, swap.invoice, decoded);
     if (!res) return undefined;
+
+    if (res.action === InvoicePaymentHookAction.Hold) {
+      return { action: InvoicePaymentDecision.Hold };
+    }
 
     if (res.nodeId !== undefined) {
       const requestedClient = getLightningClientById(currency, res.nodeId);
       if (requestedClient && requestedClient.isConnected()) {
-        return { client: requestedClient, timePreference: res.timePreference };
+        return {
+          action: InvoicePaymentDecision.Continue,
+          client: requestedClient,
+          timePreference: res.timePreference,
+        };
       }
 
       this.logger.warn(
@@ -336,7 +363,10 @@ class NodeSwitch {
     }
 
     if (res.timePreference !== undefined) {
-      return { timePreference: res.timePreference };
+      return {
+        action: InvoicePaymentDecision.Continue,
+        timePreference: res.timePreference,
+      };
     }
 
     return undefined;
@@ -522,4 +552,10 @@ class NodeSwitch {
 }
 
 export default NodeSwitch;
-export { NodeSwitchConfig };
+export type {
+  InvoicePaymentHookContinue,
+  InvoicePaymentHookHold,
+  InvoicePaymentHookResult,
+  NodeSwitchConfig,
+};
+export { InvoicePaymentDecision };

--- a/lib/swap/PaymentHandler.ts
+++ b/lib/swap/PaymentHandler.ts
@@ -36,12 +36,12 @@ import type { Currency } from '../wallet/WalletManager';
 import Errors from './Errors';
 import LightningNursery from './LightningNursery';
 import type NodeSwitch from './NodeSwitch';
+import type SwapNursery from './SwapNursery';
 import type {
   InvoicePaymentHookContinue,
   InvoicePaymentHookHold,
-} from './NodeSwitch';
-import { InvoicePaymentDecision } from './NodeSwitch';
-import type SwapNursery from './SwapNursery';
+} from './hooks/InvoicePaymentHook';
+import { InvoicePaymentHookAction } from './hooks/InvoicePaymentHook';
 
 type SwapNurseryEvents = {
   // UTXO based chains emit the "Transaction" object and Ethereum based ones just the transaction hash
@@ -97,9 +97,11 @@ type SwapNurseryEvents = {
   'invoice.settled': ReverseSwap;
 };
 
-type PreferredNode = InvoicePaymentHookHold | (InvoicePaymentHookContinue & {
-  client: LightningClient;
-});
+type PreferredNode =
+  | InvoicePaymentHookHold
+  | (Omit<InvoicePaymentHookContinue, 'nodeId'> & {
+      client: LightningClient;
+    });
 
 class PaymentHandler {
   private static readonly resetMissionControlInterval = 10 * 60 * 1000;
@@ -156,7 +158,7 @@ class PaymentHandler {
       swap,
       decoded,
     );
-    if (preferredNode.action === InvoicePaymentDecision.Hold) {
+    if (preferredNode.action === InvoicePaymentHookAction.Hold) {
       this.logger.debug(`Invoice payment of Swap ${swap.id} held by hook`);
       return undefined;
     }
@@ -401,13 +403,13 @@ class PaymentHandler {
       decoded,
     );
 
-    if (hookNode?.action === InvoicePaymentDecision.Hold) {
-      return { action: InvoicePaymentDecision.Hold };
+    if (hookNode?.action === InvoicePaymentHookAction.Hold) {
+      return { action: InvoicePaymentHookAction.Hold };
     }
 
     if (hookNode?.client) {
       return {
-        action: InvoicePaymentDecision.Continue,
+        action: InvoicePaymentHookAction.Continue,
         client: hookNode.client,
         timePreference: hookNode.timePreference,
       };
@@ -420,7 +422,7 @@ class PaymentHandler {
     );
 
     return {
-      action: InvoicePaymentDecision.Continue,
+      action: InvoicePaymentHookAction.Continue,
       client: fallbackClient,
       timePreference: hookNode?.timePreference,
     };

--- a/lib/swap/PaymentHandler.ts
+++ b/lib/swap/PaymentHandler.ts
@@ -36,6 +36,11 @@ import type { Currency } from '../wallet/WalletManager';
 import Errors from './Errors';
 import LightningNursery from './LightningNursery';
 import type NodeSwitch from './NodeSwitch';
+import type {
+  InvoicePaymentHookContinue,
+  InvoicePaymentHookHold,
+} from './NodeSwitch';
+import { InvoicePaymentDecision } from './NodeSwitch';
 import type SwapNursery from './SwapNursery';
 
 type SwapNurseryEvents = {
@@ -92,6 +97,10 @@ type SwapNurseryEvents = {
   'invoice.settled': ReverseSwap;
 };
 
+type PreferredNode = InvoicePaymentHookHold | (InvoicePaymentHookContinue & {
+  client: LightningClient;
+});
+
 class PaymentHandler {
   private static readonly resetMissionControlInterval = 10 * 60 * 1000;
   private static readonly errCltvTooSmall = 'CLTV limit too small';
@@ -147,6 +156,10 @@ class PaymentHandler {
       swap,
       decoded,
     );
+    if (preferredNode.action === InvoicePaymentDecision.Hold) {
+      this.logger.debug(`Invoice payment of Swap ${swap.id} held by hook`);
+      return undefined;
+    }
 
     const { node, paymentHash, payments } =
       await this.pendingPaymentTracker.getRelevantNode(
@@ -381,15 +394,20 @@ class PaymentHandler {
     lightningCurrency: Currency,
     swap: Swap,
     decoded: DecodedInvoice,
-  ): Promise<{ client: LightningClient; timePreference?: number }> => {
+  ): Promise<PreferredNode> => {
     const hookNode = await this.nodeSwitch.invoicePaymentHook(
       lightningCurrency,
       { id: swap.id, invoice: swap.invoice! },
       decoded,
     );
 
+    if (hookNode?.action === InvoicePaymentDecision.Hold) {
+      return { action: InvoicePaymentDecision.Hold };
+    }
+
     if (hookNode?.client) {
       return {
+        action: InvoicePaymentDecision.Continue,
         client: hookNode.client,
         timePreference: hookNode.timePreference,
       };
@@ -402,6 +420,7 @@ class PaymentHandler {
     );
 
     return {
+      action: InvoicePaymentDecision.Continue,
       client: fallbackClient,
       timePreference: hookNode?.timePreference,
     };

--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -218,15 +218,6 @@ class UtxoNursery extends TypedEventEmitter<{
       );
 
       switch (action) {
-        case Action.Hold:
-          this.logHoldingTransaction(
-            wallet.symbol,
-            swap,
-            transaction,
-            swapOutput,
-          );
-          return;
-
         case Action.Reject:
           this.emit('chainSwap.lockup.failed', {
             swap,
@@ -746,15 +737,6 @@ class UtxoNursery extends TypedEventEmitter<{
       );
 
       switch (action) {
-        case Action.Hold:
-          this.logHoldingTransaction(
-            wallet.symbol,
-            updatedSwap,
-            transaction,
-            swapOutput,
-          );
-          return;
-
         case Action.Reject:
           this.emit('swap.lockup.failed', {
             swap: updatedSwap,
@@ -866,18 +848,6 @@ class UtxoNursery extends TypedEventEmitter<{
   ) =>
     this.logger.verbose(
       `Found ${confirmed ? '' : 'un'}confirmed ${symbol} lockup transaction for ${swapTypeToPrettyString(swap.type)} Swap ${
-        swap.id
-      }: ${TxView.of(transaction).id}:${swapOutput.vout}`,
-    );
-
-  private logHoldingTransaction = (
-    symbol: string,
-    swap: Swap | ChainSwapInfo,
-    transaction: Transaction | LiquidTransaction,
-    swapOutput: NonNullable<ReturnType<typeof detectSwap>>,
-  ) =>
-    this.logger.warn(
-      `Holding ${symbol} lockup transaction for ${swapTypeToPrettyString(swap.type)} Swap ${
         swap.id
       }: ${TxView.of(transaction).id}:${swapOutput.vout}`,
     );

--- a/lib/swap/hooks/CreationHook.ts
+++ b/lib/swap/hooks/CreationHook.ts
@@ -8,7 +8,6 @@ import Hook from './Hook';
 const enum Action {
   Accept,
   Reject,
-  Hold,
 }
 
 type RequestParamsBase = {
@@ -106,13 +105,7 @@ class CreationHook extends Hook<
   protected parseGrpcAction = (res: boltzrpc.SwapCreationResponse): Action =>
     parseGrpcAction(this.logger, this.name, res.id, res.action);
 
-  private handleAction = (action: Action) => {
-    if (action === Action.Hold) {
-      this.logger.warn('Hold not implemented for swap creation hook');
-    }
-
-    return action !== Action.Reject;
-  };
+  private handleAction = (action: Action) => action !== Action.Reject;
 }
 
 const parseGrpcAction = (
@@ -127,8 +120,6 @@ const parseGrpcAction = (
     case boltzrpc.Action.REJECT:
       logger.warn(`Hook ${name} rejected for ${id}`);
       return Action.Reject;
-    case boltzrpc.Action.HOLD:
-      return Action.Hold;
     default:
       throw new Error(`unknown action: ${action}`);
   }

--- a/lib/swap/hooks/InvoicePaymentHook.ts
+++ b/lib/swap/hooks/InvoicePaymentHook.ts
@@ -4,23 +4,31 @@ import * as boltzrpc from '../../proto/boltzrpc';
 import type DecodedInvoice from '../../sidecar/DecodedInvoice';
 import Hook from './Hook';
 
-const enum InvoicePaymentHookAction {
+enum InvoicePaymentHookAction {
   Continue,
   Hold,
 }
 
-type HookResult = {
-  action: InvoicePaymentHookAction;
+type InvoicePaymentHookHold = {
+  action: InvoicePaymentHookAction.Hold;
+};
+
+type InvoicePaymentHookContinue = {
+  action: InvoicePaymentHookAction.Continue;
   nodeId?: string;
   timePreference?: number;
 };
 
-const defaultHookResult = {
+type InvoicePaymentHookResult =
+  | InvoicePaymentHookHold
+  | InvoicePaymentHookContinue;
+
+const defaultHookResult: InvoicePaymentHookResult = {
   action: InvoicePaymentHookAction.Continue,
 };
 
 class InvoicePaymentHook extends Hook<
-  HookResult | undefined,
+  InvoicePaymentHookResult | undefined,
   boltzrpc.InvoicePaymentHookRequest,
   boltzrpc.InvoicePaymentHookResponse
 > {
@@ -39,7 +47,7 @@ class InvoicePaymentHook extends Hook<
     swapId: string,
     invoice: string,
     decoded: DecodedInvoice,
-  ): Promise<HookResult | undefined> => {
+  ): Promise<InvoicePaymentHookResult | undefined> => {
     if (!this.isConnected()) {
       return undefined;
     }
@@ -56,7 +64,7 @@ class InvoicePaymentHook extends Hook<
     return res;
   };
 
-  private logHookResult = (swapId: string, res?: HookResult) => {
+  private logHookResult = (swapId: string, res?: InvoicePaymentHookResult) => {
     if (res === undefined) {
       this.logger.debug(
         `Invoice payment hook for ${swapId} returned no response`,
@@ -86,7 +94,7 @@ class InvoicePaymentHook extends Hook<
 
   protected parseGrpcAction = (
     res: boltzrpc.InvoicePaymentHookResponse,
-  ): HookResult | undefined => {
+  ): InvoicePaymentHookResult | undefined => {
     const action = this.parseHookAction(res);
     if (action === undefined) {
       return undefined;
@@ -122,7 +130,7 @@ class InvoicePaymentHook extends Hook<
   private parseHookAction = (
     res: boltzrpc.InvoicePaymentHookResponse,
   ): InvoicePaymentHookAction | undefined => {
-    switch (res.action ?? boltzrpc.InvoicePaymentHookAction.CONTINUE) {
+    switch (res.action ?? defaultHookResult.action) {
       case boltzrpc.InvoicePaymentHookAction.CONTINUE:
         return InvoicePaymentHookAction.Continue;
 
@@ -139,4 +147,9 @@ class InvoicePaymentHook extends Hook<
 }
 
 export default InvoicePaymentHook;
+export type {
+  InvoicePaymentHookContinue,
+  InvoicePaymentHookHold,
+  InvoicePaymentHookResult,
+};
 export { InvoicePaymentHookAction };

--- a/lib/swap/hooks/InvoicePaymentHook.ts
+++ b/lib/swap/hooks/InvoicePaymentHook.ts
@@ -1,12 +1,22 @@
 import type Logger from '../../Logger';
 import type NotificationClient from '../../notifications/NotificationClient';
-import type * as boltzrpc from '../../proto/boltzrpc';
+import * as boltzrpc from '../../proto/boltzrpc';
 import type DecodedInvoice from '../../sidecar/DecodedInvoice';
 import Hook from './Hook';
 
+const enum InvoicePaymentHookAction {
+  Continue,
+  Hold,
+}
+
 type HookResult = {
+  action: InvoicePaymentHookAction;
   nodeId?: string;
   timePreference?: number;
+};
+
+const defaultHookResult = {
+  action: InvoicePaymentHookAction.Continue,
 };
 
 class InvoicePaymentHook extends Hook<
@@ -15,7 +25,14 @@ class InvoicePaymentHook extends Hook<
   boltzrpc.InvoicePaymentHookResponse
 > {
   constructor(logger: Logger, notificationClient?: NotificationClient) {
-    super(logger, 'invoice payment', {}, {}, 60_000, notificationClient);
+    super(
+      logger,
+      'invoice payment',
+      defaultHookResult,
+      defaultHookResult,
+      60_000,
+      notificationClient,
+    );
   }
 
   public hook = async (
@@ -47,6 +64,11 @@ class InvoicePaymentHook extends Hook<
       return;
     }
 
+    if (res.action === InvoicePaymentHookAction.Hold) {
+      this.logger.debug(`Invoice payment hook for ${swapId} returned hold`);
+      return;
+    }
+
     const preferences: string[] = [];
 
     if (res.nodeId !== undefined) {
@@ -65,6 +87,17 @@ class InvoicePaymentHook extends Hook<
   protected parseGrpcAction = (
     res: boltzrpc.InvoicePaymentHookResponse,
   ): HookResult | undefined => {
+    const action = this.parseHookAction(res);
+    if (action === undefined) {
+      return undefined;
+    }
+
+    if (action === InvoicePaymentHookAction.Hold) {
+      return {
+        action,
+      };
+    }
+
     const nodeId = res.nodePubkey || undefined;
 
     if (res.timePreference !== undefined) {
@@ -77,13 +110,33 @@ class InvoicePaymentHook extends Hook<
       }
 
       return {
+        action,
         nodeId,
         timePreference,
       };
     }
 
-    return { nodeId };
+    return { action, nodeId };
+  };
+
+  private parseHookAction = (
+    res: boltzrpc.InvoicePaymentHookResponse,
+  ): InvoicePaymentHookAction | undefined => {
+    switch (res.action ?? boltzrpc.InvoicePaymentHookAction.CONTINUE) {
+      case boltzrpc.InvoicePaymentHookAction.CONTINUE:
+        return InvoicePaymentHookAction.Continue;
+
+      case boltzrpc.InvoicePaymentHookAction.HOLD:
+        return InvoicePaymentHookAction.Hold;
+
+      default:
+        this.logger.warn(
+          `Invoice payment hook for ${res.id} returned invalid action ${res.action}`,
+        );
+        return undefined;
+    }
   };
 }
 
 export default InvoicePaymentHook;
+export { InvoicePaymentHookAction };

--- a/lib/swap/hooks/TransactionHook.ts
+++ b/lib/swap/hooks/TransactionHook.ts
@@ -15,7 +15,7 @@ class TransactionHook extends Hook<
     super(
       logger,
       'transaction',
-      Action.Hold,
+      Action.Accept,
       Action.Accept,
       60_000,
       notificationClient,

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -425,7 +425,6 @@ message CalculateTransactionFeeResponse {
 enum Action {
   ACCEPT = 0;
   REJECT = 1;
-  HOLD = 2;
 }
 
 message SwapCreationResponse {

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -488,6 +488,11 @@ message InvoiceCreationHookRequest {
   optional string referral = 3;
 }
 
+enum InvoicePaymentHookAction {
+  CONTINUE = 0;
+  HOLD = 1;
+}
+
 message InvoicePaymentHookResponse {
   string id = 1;
 
@@ -497,6 +502,8 @@ message InvoicePaymentHookResponse {
   // Only applies to LND
   // -1 to optimize for fees, 1 to optimize for reliability; value between for a mix
   optional double time_preference = 3;
+
+  InvoicePaymentHookAction action = 4;
 }
 
 message InvoicePaymentHookRequest {

--- a/test/unit/swap/EthereumNursery.spec.ts
+++ b/test/unit/swap/EthereumNursery.spec.ts
@@ -621,57 +621,6 @@ describe('EthereumNursery', () => {
     transactionHook.hook = jest.fn().mockReturnValue(Action.Accept);
   });
 
-  test('should hold EtherSwap lockup transaction when action is Hold', async () => {
-    transactionHook.hook = jest.fn().mockReturnValue(Action.Hold);
-
-    let lockupEmitted = false;
-    let lockupFailed = false;
-
-    nursery.on('eth.lockup', () => {
-      lockupEmitted = true;
-    });
-
-    nursery.on('lockup.failed', () => {
-      lockupFailed = true;
-    });
-
-    mockGetSwapResult = {
-      pair: 'ETH/BTC',
-      expectedAmount: 10,
-      type: SwapType.Submarine,
-      orderSide: OrderSide.SELL,
-      timeoutBlockHeight: 11102219,
-      id: 'test-eth-hold-id',
-    };
-
-    await emitEthLockup({
-      transaction: exampleTransaction,
-      etherSwapValues: {
-        claimAddress: mockAddress,
-        amount: BigInt('100000000000'),
-        preimageHash: getHexString(examplePreimageHash),
-        timelock: mockGetSwapResult.timeoutBlockHeight,
-      } as any,
-    });
-
-    expect(mockGetSwap).toHaveBeenCalledTimes(1);
-    expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
-    expect(lockupEmitted).toEqual(false);
-    expect(lockupFailed).toEqual(false);
-
-    expect(transactionHook.hook).toHaveBeenCalledTimes(1);
-    expect(transactionHook.hook).toHaveBeenCalledWith(
-      mockGetSwapResult.id,
-      'Ethereum',
-      exampleTransaction.hash,
-      expect.any(Buffer),
-      true,
-      SwapType.Submarine,
-    );
-
-    transactionHook.hook = jest.fn().mockReturnValue(Action.Accept);
-  });
-
   test('should reject overpaid EtherSwap lockup transactions', async () => {
     mockGetSwapResult = {
       pair: 'ETH/BTC',
@@ -1092,58 +1041,6 @@ describe('EthereumNursery', () => {
     });
 
     await lockupPromise;
-
-    expect(transactionHook.hook).toHaveBeenCalledTimes(1);
-    expect(transactionHook.hook).toHaveBeenCalledWith(
-      mockGetSwapResult.id,
-      'USDT',
-      exampleTransaction.hash,
-      expect.any(Buffer),
-      true,
-      SwapType.Submarine,
-    );
-
-    transactionHook.hook = jest.fn().mockReturnValue(Action.Accept);
-  });
-
-  test('should hold ERC20Swap lockup transaction when action is Hold', async () => {
-    transactionHook.hook = jest.fn().mockReturnValue(Action.Hold);
-
-    let lockupEmitted = false;
-    let lockupFailed = false;
-
-    nursery.on('erc20.lockup', () => {
-      lockupEmitted = true;
-    });
-
-    nursery.on('lockup.failed', () => {
-      lockupFailed = true;
-    });
-
-    mockGetSwapResult = {
-      pair: 'BTC/USDT',
-      expectedAmount: 10,
-      orderSide: OrderSide.BUY,
-      type: SwapType.Submarine,
-      timeoutBlockHeight: 11102222,
-      id: 'test-erc20-hold-id',
-    };
-
-    await emitErc20Lockup({
-      transaction: exampleTransaction,
-      erc20SwapValues: {
-        claimAddress: mockAddress,
-        amount: BigInt('1000'),
-        tokenAddress: mockTokenAddress,
-        timelock: mockGetSwapResult.timeoutBlockHeight,
-        preimageHash: getHexString(examplePreimageHash),
-      } as any,
-    });
-
-    expect(mockGetSwap).toHaveBeenCalledTimes(1);
-    expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
-    expect(lockupEmitted).toEqual(false);
-    expect(lockupFailed).toEqual(false);
 
     expect(transactionHook.hook).toHaveBeenCalledTimes(1);
     expect(transactionHook.hook).toHaveBeenCalledWith(

--- a/test/unit/swap/NodeSwitch.spec.ts
+++ b/test/unit/swap/NodeSwitch.spec.ts
@@ -15,7 +15,6 @@ import type DecodedInvoice from '../../../lib/sidecar/DecodedInvoice';
 import { InvoiceType } from '../../../lib/sidecar/DecodedInvoice';
 import Errors from '../../../lib/swap/Errors';
 import NodeSwitch, {
-  InvoicePaymentDecision,
   ReverseSwapNodeResolutionStatus,
 } from '../../../lib/swap/NodeSwitch';
 import type InvoicePaymentHook from '../../../lib/swap/hooks/InvoicePaymentHook';
@@ -252,16 +251,16 @@ describe('NodeSwitch', () => {
 
   describe('invoicePaymentHook', () => {
     test.each`
-      hookResult                                       | testCurrency       | expected                                                                                      | description
-      ${{ nodeId: lndClient.id }}                      | ${currency}        | ${{ action: InvoicePaymentDecision.Continue, client: lndClient }}                              | ${'LND by nodeId'}
-      ${{ nodeId: lndClient.id, timePreference: 0.5 }} | ${currency}        | ${{ action: InvoicePaymentDecision.Continue, client: lndClient, timePreference: 0.5 }}         | ${'LND by nodeId with time preference'}
-      ${{ nodeId: clnClient.id }}                      | ${currency}        | ${{ action: InvoicePaymentDecision.Continue, client: clnClient }}                              | ${'CLN by nodeId'}
-      ${undefined}                                     | ${currency}        | ${undefined}                                                                                  | ${'undefined when hook returns undefined'}
-      ${{ action: InvoicePaymentHookAction.Hold }}      | ${currency}        | ${{ action: InvoicePaymentDecision.Hold }}                                                     | ${'hold when hook holds'}
-      ${{ nodeId: lndClient.id }}                      | ${clnOnlyCurrency} | ${undefined}                                                                                  | ${'undefined when hook returns LND but LND client is missing'}
-      ${{ nodeId: clnClient.id }}                      | ${lndOnlyCurrency} | ${undefined}                                                                                  | ${'undefined when hook returns CLN but CLN client is missing'}
-      ${{ timePreference: -1 }}                        | ${currency}        | ${{ action: InvoicePaymentDecision.Continue, timePreference: -1 }}                             | ${'time preference only without client'}
-      ${{ nodeId: lndClient.id, timePreference: 0.5 }} | ${clnOnlyCurrency} | ${{ action: InvoicePaymentDecision.Continue, timePreference: 0.5 }}                            | ${'time preference only when requested client missing'}
+      hookResult                                                                                  | testCurrency       | expected                                                                                 | description
+      ${{ action: InvoicePaymentHookAction.Continue, nodeId: lndClient.id }}                      | ${currency}        | ${{ action: InvoicePaymentHookAction.Continue, client: lndClient }}                      | ${'LND by nodeId'}
+      ${{ action: InvoicePaymentHookAction.Continue, nodeId: lndClient.id, timePreference: 0.5 }} | ${currency}        | ${{ action: InvoicePaymentHookAction.Continue, client: lndClient, timePreference: 0.5 }} | ${'LND by nodeId with time preference'}
+      ${{ action: InvoicePaymentHookAction.Continue, nodeId: clnClient.id }}                      | ${currency}        | ${{ action: InvoicePaymentHookAction.Continue, client: clnClient }}                      | ${'CLN by nodeId'}
+      ${undefined}                                                                                | ${currency}        | ${undefined}                                                                             | ${'undefined when hook returns undefined'}
+      ${{ action: InvoicePaymentHookAction.Hold }}                                                | ${currency}        | ${{ action: InvoicePaymentHookAction.Hold }}                                             | ${'hold when hook holds'}
+      ${{ action: InvoicePaymentHookAction.Continue, nodeId: lndClient.id }}                      | ${clnOnlyCurrency} | ${undefined}                                                                             | ${'undefined when hook returns LND but LND client is missing'}
+      ${{ action: InvoicePaymentHookAction.Continue, nodeId: clnClient.id }}                      | ${lndOnlyCurrency} | ${undefined}                                                                             | ${'undefined when hook returns CLN but CLN client is missing'}
+      ${{ action: InvoicePaymentHookAction.Continue, timePreference: -1 }}                        | ${currency}        | ${{ action: InvoicePaymentHookAction.Continue, timePreference: -1 }}                     | ${'time preference only without client'}
+      ${{ action: InvoicePaymentHookAction.Continue, nodeId: lndClient.id, timePreference: 0.5 }} | ${clnOnlyCurrency} | ${{ action: InvoicePaymentHookAction.Continue, timePreference: 0.5 }}                    | ${'time preference only when requested client missing'}
     `(
       'should return $description',
       async ({ hookResult, testCurrency, expected }) => {

--- a/test/unit/swap/NodeSwitch.spec.ts
+++ b/test/unit/swap/NodeSwitch.spec.ts
@@ -15,9 +15,11 @@ import type DecodedInvoice from '../../../lib/sidecar/DecodedInvoice';
 import { InvoiceType } from '../../../lib/sidecar/DecodedInvoice';
 import Errors from '../../../lib/swap/Errors';
 import NodeSwitch, {
+  InvoicePaymentDecision,
   ReverseSwapNodeResolutionStatus,
 } from '../../../lib/swap/NodeSwitch';
 import type InvoicePaymentHook from '../../../lib/swap/hooks/InvoicePaymentHook';
+import { InvoicePaymentHookAction } from '../../../lib/swap/hooks/InvoicePaymentHook';
 import type { Currency } from '../../../lib/wallet/WalletManager';
 
 describe('NodeSwitch', () => {
@@ -250,15 +252,16 @@ describe('NodeSwitch', () => {
 
   describe('invoicePaymentHook', () => {
     test.each`
-      hookResult                                       | testCurrency       | expected                                      | description
-      ${{ nodeId: lndClient.id }}                      | ${currency}        | ${{ client: lndClient }}                      | ${'LND by nodeId'}
-      ${{ nodeId: lndClient.id, timePreference: 0.5 }} | ${currency}        | ${{ client: lndClient, timePreference: 0.5 }} | ${'LND by nodeId with time preference'}
-      ${{ nodeId: clnClient.id }}                      | ${currency}        | ${{ client: clnClient }}                      | ${'CLN by nodeId'}
-      ${undefined}                                     | ${currency}        | ${undefined}                                  | ${'undefined when hook returns undefined'}
-      ${{ nodeId: lndClient.id }}                      | ${clnOnlyCurrency} | ${undefined}                                  | ${'undefined when hook returns LND but LND client is missing'}
-      ${{ nodeId: clnClient.id }}                      | ${lndOnlyCurrency} | ${undefined}                                  | ${'undefined when hook returns CLN but CLN client is missing'}
-      ${{ timePreference: -1 }}                        | ${currency}        | ${{ timePreference: -1 }}                     | ${'time preference only without client'}
-      ${{ nodeId: lndClient.id, timePreference: 0.5 }} | ${clnOnlyCurrency} | ${{ timePreference: 0.5 }}                    | ${'time preference only when requested client missing'}
+      hookResult                                       | testCurrency       | expected                                                                                      | description
+      ${{ nodeId: lndClient.id }}                      | ${currency}        | ${{ action: InvoicePaymentDecision.Continue, client: lndClient }}                              | ${'LND by nodeId'}
+      ${{ nodeId: lndClient.id, timePreference: 0.5 }} | ${currency}        | ${{ action: InvoicePaymentDecision.Continue, client: lndClient, timePreference: 0.5 }}         | ${'LND by nodeId with time preference'}
+      ${{ nodeId: clnClient.id }}                      | ${currency}        | ${{ action: InvoicePaymentDecision.Continue, client: clnClient }}                              | ${'CLN by nodeId'}
+      ${undefined}                                     | ${currency}        | ${undefined}                                                                                  | ${'undefined when hook returns undefined'}
+      ${{ action: InvoicePaymentHookAction.Hold }}      | ${currency}        | ${{ action: InvoicePaymentDecision.Hold }}                                                     | ${'hold when hook holds'}
+      ${{ nodeId: lndClient.id }}                      | ${clnOnlyCurrency} | ${undefined}                                                                                  | ${'undefined when hook returns LND but LND client is missing'}
+      ${{ nodeId: clnClient.id }}                      | ${lndOnlyCurrency} | ${undefined}                                                                                  | ${'undefined when hook returns CLN but CLN client is missing'}
+      ${{ timePreference: -1 }}                        | ${currency}        | ${{ action: InvoicePaymentDecision.Continue, timePreference: -1 }}                             | ${'time preference only without client'}
+      ${{ nodeId: lndClient.id, timePreference: 0.5 }} | ${clnOnlyCurrency} | ${{ action: InvoicePaymentDecision.Continue, timePreference: 0.5 }}                            | ${'time preference only when requested client missing'}
     `(
       'should return $description',
       async ({ hookResult, testCurrency, expected }) => {

--- a/test/unit/swap/PaymentHandler.spec.ts
+++ b/test/unit/swap/PaymentHandler.spec.ts
@@ -12,13 +12,15 @@ import TimeoutDeltaProvider from '../../../lib/service/TimeoutDeltaProvider';
 import type DecodedInvoiceSidecar from '../../../lib/sidecar/DecodedInvoice';
 import { InvoiceType } from '../../../lib/sidecar/DecodedInvoice';
 import type Sidecar from '../../../lib/sidecar/Sidecar';
-import NodeSwitch from '../../../lib/swap/NodeSwitch';
+import NodeSwitch, {
+  InvoicePaymentDecision,
+} from '../../../lib/swap/NodeSwitch';
 import PaymentHandler from '../../../lib/swap/PaymentHandler';
 import type { Currency } from '../../../lib/wallet/WalletManager';
 import { raceCall } from '../../Utils';
 
 jest.mock('../../../lib/swap/NodeSwitch', () => {
-  return jest.fn().mockImplementation(() => {
+  const nodeSwitch = jest.fn().mockImplementation(() => {
     return {
       getSwapNode: jest
         .fn()
@@ -27,6 +29,13 @@ jest.mock('../../../lib/swap/NodeSwitch', () => {
         ),
       invoicePaymentHook: jest.fn(),
     };
+  });
+
+  return Object.assign(nodeSwitch, {
+    InvoicePaymentDecision: {
+      Continue: 'continue',
+      Hold: 'hold',
+    },
   });
 });
 
@@ -327,11 +336,12 @@ describe('PaymentHandler', () => {
   });
 
   test.each`
-    hookNodeReturn                                   | getSwapNodeReturn       | expected                                                 | getSwapNodeCalled
-    ${{ client: 'hookClient' }}                      | ${{ node: 'swapNode' }} | ${{ client: 'hookClient' }}                              | ${false}
-    ${{ client: 'hookClient', timePreference: 0.5 }} | ${{ node: 'swapNode' }} | ${{ client: 'hookClient', timePreference: 0.5 }}         | ${false}
-    ${{ timePreference: 0.5 }}                       | ${{ node: 'swapNode' }} | ${{ client: { node: 'swapNode' }, timePreference: 0.5 }} | ${true}
-    ${undefined}                                     | ${{ node: 'swapNode' }} | ${{ client: { node: 'swapNode' } }}                      | ${true}
+    hookNodeReturn                                                                            | getSwapNodeReturn       | expected                                                                                     | getSwapNodeCalled
+    ${{ action: InvoicePaymentDecision.Continue, client: 'hookClient' }}                       | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Continue, client: 'hookClient' }}                         | ${false}
+    ${{ action: InvoicePaymentDecision.Continue, client: 'hookClient', timePreference: 0.5 }}  | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Continue, client: 'hookClient', timePreference: 0.5 }}    | ${false}
+    ${{ action: InvoicePaymentDecision.Hold }}                                                 | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Hold }}                                                   | ${false}
+    ${{ action: InvoicePaymentDecision.Continue, timePreference: 0.5 }}                        | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Continue, client: { node: 'swapNode' }, timePreference: 0.5 }} | ${true}
+    ${undefined}                                                                               | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Continue, client: { node: 'swapNode' } }}                 | ${true}
   `(
     'should get preferred node (hook: $hookNodeReturn, swap: $getSwapNodeReturn)',
     async ({
@@ -376,6 +386,25 @@ describe('PaymentHandler', () => {
       }
     },
   );
+
+  test('should not pay invoice when invoice payment hook holds', async () => {
+    (nodeSwitch.invoicePaymentHook as jest.Mock).mockResolvedValueOnce({
+      action: InvoicePaymentDecision.Hold,
+    });
+
+    const result = await handler.payInvoice(swap, undefined);
+
+    expect(result).toBeUndefined();
+    expect(nodeSwitch.invoicePaymentHook).toHaveBeenCalledTimes(1);
+    expect(
+      handler['pendingPaymentTracker'].getRelevantNode,
+    ).not.toHaveBeenCalled();
+    expect(
+      handler['selfPaymentClient'].handleSelfPayment,
+    ).not.toHaveBeenCalled();
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+    expect(swap.update).not.toHaveBeenCalled();
+  });
 
   describe('SelfPaymentClient', () => {
     beforeEach(() => {

--- a/test/unit/swap/PaymentHandler.spec.ts
+++ b/test/unit/swap/PaymentHandler.spec.ts
@@ -12,10 +12,9 @@ import TimeoutDeltaProvider from '../../../lib/service/TimeoutDeltaProvider';
 import type DecodedInvoiceSidecar from '../../../lib/sidecar/DecodedInvoice';
 import { InvoiceType } from '../../../lib/sidecar/DecodedInvoice';
 import type Sidecar from '../../../lib/sidecar/Sidecar';
-import NodeSwitch, {
-  InvoicePaymentDecision,
-} from '../../../lib/swap/NodeSwitch';
+import NodeSwitch from '../../../lib/swap/NodeSwitch';
 import PaymentHandler from '../../../lib/swap/PaymentHandler';
+import { InvoicePaymentHookAction } from '../../../lib/swap/hooks/InvoicePaymentHook';
 import type { Currency } from '../../../lib/wallet/WalletManager';
 import { raceCall } from '../../Utils';
 
@@ -31,12 +30,7 @@ jest.mock('../../../lib/swap/NodeSwitch', () => {
     };
   });
 
-  return Object.assign(nodeSwitch, {
-    InvoicePaymentDecision: {
-      Continue: 'continue',
-      Hold: 'hold',
-    },
-  });
+  return nodeSwitch;
 });
 
 const MockedNodeSwitch = <jest.Mock<NodeSwitch>>(<any>NodeSwitch);
@@ -336,12 +330,12 @@ describe('PaymentHandler', () => {
   });
 
   test.each`
-    hookNodeReturn                                                                            | getSwapNodeReturn       | expected                                                                                     | getSwapNodeCalled
-    ${{ action: InvoicePaymentDecision.Continue, client: 'hookClient' }}                       | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Continue, client: 'hookClient' }}                         | ${false}
-    ${{ action: InvoicePaymentDecision.Continue, client: 'hookClient', timePreference: 0.5 }}  | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Continue, client: 'hookClient', timePreference: 0.5 }}    | ${false}
-    ${{ action: InvoicePaymentDecision.Hold }}                                                 | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Hold }}                                                   | ${false}
-    ${{ action: InvoicePaymentDecision.Continue, timePreference: 0.5 }}                        | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Continue, client: { node: 'swapNode' }, timePreference: 0.5 }} | ${true}
-    ${undefined}                                                                               | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentDecision.Continue, client: { node: 'swapNode' } }}                 | ${true}
+    hookNodeReturn                                                                              | getSwapNodeReturn       | expected                                                                                            | getSwapNodeCalled
+    ${{ action: InvoicePaymentHookAction.Continue, client: 'hookClient' }}                      | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentHookAction.Continue, client: 'hookClient' }}                              | ${false}
+    ${{ action: InvoicePaymentHookAction.Continue, client: 'hookClient', timePreference: 0.5 }} | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentHookAction.Continue, client: 'hookClient', timePreference: 0.5 }}         | ${false}
+    ${{ action: InvoicePaymentHookAction.Hold }}                                                | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentHookAction.Hold }}                                                        | ${false}
+    ${{ action: InvoicePaymentHookAction.Continue, timePreference: 0.5 }}                       | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentHookAction.Continue, client: { node: 'swapNode' }, timePreference: 0.5 }} | ${true}
+    ${undefined}                                                                                | ${{ node: 'swapNode' }} | ${{ action: InvoicePaymentHookAction.Continue, client: { node: 'swapNode' } }}                      | ${true}
   `(
     'should get preferred node (hook: $hookNodeReturn, swap: $getSwapNodeReturn)',
     async ({
@@ -389,7 +383,7 @@ describe('PaymentHandler', () => {
 
   test('should not pay invoice when invoice payment hook holds', async () => {
     (nodeSwitch.invoicePaymentHook as jest.Mock).mockResolvedValueOnce({
-      action: InvoicePaymentDecision.Hold,
+      action: InvoicePaymentHookAction.Hold,
     });
 
     const result = await handler.payInvoice(swap, undefined);

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -222,6 +222,57 @@ describe('SwapNursery', () => {
     mockGetChainSwapResult = null;
   });
 
+  test('should retry settling swaps with pending invoices', async () => {
+    jest.useFakeTimers();
+
+    const pendingInvoiceSwap = {
+      id: 'pending-invoice-swap',
+      type: SwapType.Submarine,
+      pair: 'BTC/BTC',
+      orderSide: OrderSide.BUY,
+    } as any;
+    (SwapRepository.getSwaps as jest.Mock).mockResolvedValueOnce([
+      pendingInvoiceSwap,
+    ]);
+
+    const retryNursery = new SwapNursery(
+      mockLogger,
+      {} as any,
+      mockNotifications,
+      {} as any,
+      {} as any,
+      {} as any,
+      mockWalletManager,
+      {} as any,
+      1,
+      mockClaimer,
+      mockChainSwapSigner,
+      {} as any,
+      {} as any,
+    );
+    retryNursery.currencies = new Map([['BTC', mockCurrency]]);
+
+    const attemptSettleSwap = jest
+      .spyOn(retryNursery, 'attemptSettleSwap')
+      .mockResolvedValue(undefined);
+
+    await retryNursery.init([mockCurrency]);
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    expect(SwapRepository.getSwaps).toHaveBeenCalledWith({
+      status: {
+        [Op.in]: [SwapUpdateEvent.InvoicePending, SwapUpdateEvent.InvoicePaid],
+      },
+    });
+    expect(attemptSettleSwap).toHaveBeenCalledWith(
+      mockCurrency,
+      pendingInvoiceSwap,
+    );
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
   describe('signer lockup guards', () => {
     const createGuardedNursery = async (signer: Signer) => {
       const signerControlRegistry = SignerControlRegistry.getInstance();

--- a/test/unit/swap/UtxoNursery.spec.ts
+++ b/test/unit/swap/UtxoNursery.spec.ts
@@ -741,57 +741,6 @@ describe('UtxoNursery', () => {
     await failPromise;
   });
 
-  test('should hold transactions when action is Hold', async () => {
-    const checkSwapOutputs = nursery['checkOutputs'];
-
-    const transaction = parseTx(sampleTransactions.lockup);
-    transaction.updateInput(0, { sequence: 0xffffffff }, true);
-    transaction.updateInput(1, { sequence: 0xffffffff }, true);
-
-    mockGetSwapResult = {
-      id: 'hold',
-      acceptZeroConf: true,
-      redeemScript: sampleRedeemScript,
-      type: SwapType.Submarine,
-    };
-
-    mockGetRawTransactionVerboseResult = () => ({
-      confirmations: 1,
-    });
-
-    transactionHook.hook = jest.fn().mockReturnValue(Action.Hold);
-
-    const logHoldingSpy = jest.spyOn(nursery as any, 'logHoldingTransaction');
-
-    await checkSwapOutputs(
-      btcChainClient,
-      btcWallet,
-      transaction,
-      TransactionStatus.ZeroConfSafe,
-    );
-
-    expect(transactionHook.hook).toHaveBeenCalledTimes(1);
-    expect(transactionHook.hook).toHaveBeenCalledWith(
-      mockGetSwapResult.id,
-      btcWallet.symbol,
-      transaction.id,
-      Buffer.from(transaction.toBytes(true, true)),
-      false,
-      SwapType.Submarine,
-      0,
-    );
-    expect(logHoldingSpy).toHaveBeenCalledTimes(1);
-    expect(logHoldingSpy).toHaveBeenCalledWith(
-      btcWallet.symbol,
-      mockGetSwapResult,
-      transaction,
-      expect.anything(),
-    );
-
-    logHoldingSpy.mockRestore();
-    transactionHook.hook = jest.fn().mockReturnValue(true);
-  });
-
   test('should handle claimed Reverse Swaps', async () => {
     RefundTransactionRepository.getTransaction = jest
       .fn()

--- a/test/unit/swap/hooks/CreationHook.spec.ts
+++ b/test/unit/swap/hooks/CreationHook.spec.ts
@@ -79,10 +79,6 @@ describe('CreationHook', () => {
 
   describe('swapCreationHook', () => {
     test('should resolve accept action if stream is not connected', async () => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      hook['defaultAction'] = Action.Hold;
-
       expect(hook['stream']).toBeUndefined();
 
       await expect(
@@ -211,17 +207,8 @@ describe('CreationHook', () => {
   });
 
   describe('handleAction', () => {
-    beforeEach(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      hook['logger'] = {
-        warn: jest.fn(),
-      } as any;
-    });
-
     test.each([
       { action: Action.Accept, expected: true },
-      { action: Action.Hold, expected: true },
       { action: Action.Reject, expected: false },
     ])(
       'should return $expected when action is $action',
@@ -229,14 +216,6 @@ describe('CreationHook', () => {
         const result = hook['handleAction'](action);
 
         expect(result).toEqual(expected);
-
-        if (action === Action.Hold) {
-          expect(hook['logger'].warn).toHaveBeenCalledWith(
-            'Hold not implemented for swap creation hook',
-          );
-        } else {
-          expect(hook['logger'].warn).not.toHaveBeenCalled();
-        }
       },
     );
   });

--- a/test/unit/swap/hooks/InvoicePaymentHook.spec.ts
+++ b/test/unit/swap/hooks/InvoicePaymentHook.spec.ts
@@ -1,17 +1,38 @@
+import { status } from '@grpc/grpc-js';
 import Logger from '../../../../lib/Logger';
 import type NotificationClient from '../../../../lib/notifications/NotificationClient';
-import type * as boltzrpc from '../../../../lib/proto/boltzrpc';
+import * as boltzrpc from '../../../../lib/proto/boltzrpc';
 import type DecodedInvoice from '../../../../lib/sidecar/DecodedInvoice';
-import InvoicePaymentHook from '../../../../lib/swap/hooks/InvoicePaymentHook';
+import InvoicePaymentHook, {
+  InvoicePaymentHookAction,
+} from '../../../../lib/swap/hooks/InvoicePaymentHook';
 
 describe('InvoicePaymentHook', () => {
   let hook: InvoicePaymentHook;
 
+  let handlers: Record<string, (data?: any) => void>;
+  let stream: any;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
+
+    handlers = {};
+    stream = {
+      on: jest.fn().mockImplementation((event: string, handler: any) => {
+        handlers[event] = handler;
+      }),
+      end: jest.fn(),
+      write: jest.fn(),
+      removeAllListeners: jest.fn(),
+      emit: jest.fn(),
+    };
+
     hook = new InvoicePaymentHook(
       Logger.disabledLogger,
-      {} as unknown as NotificationClient,
+      {
+        sendMessage: jest.fn(),
+      } as unknown as NotificationClient,
     );
   });
 
@@ -27,6 +48,49 @@ describe('InvoicePaymentHook', () => {
       ).resolves.toBeUndefined();
       expect(mockSendHook).not.toHaveBeenCalled();
     });
+
+    test('should resolve continue action if hook is not resolved after timeout', async () => {
+      jest.useFakeTimers();
+
+      hook.connectToStream(stream);
+
+      const id = 'id';
+      const promise = hook.hook(id, 'invoice', {
+        rawRes: {},
+      } as unknown as DecodedInvoice);
+      expect(hook['pendingHooks'].has(id)).toEqual(true);
+
+      jest.runAllTimers();
+
+      await expect(promise).resolves.toEqual({
+        action: InvoicePaymentHookAction.Continue,
+      });
+      expect(hook['pendingHooks'].has(id)).toEqual(false);
+    });
+
+    test.each`
+      event      | payload
+      ${'end'}   | ${undefined}
+      ${'error'} | ${{ code: status.UNAVAILABLE, details: 'test' }}
+    `(
+      'should resolve pending hooks to continue action on $event',
+      async ({ event, payload }) => {
+        hook.connectToStream(stream);
+
+        const id = 'id';
+        const promise = hook.hook(id, 'invoice', {
+          rawRes: {},
+        } as unknown as DecodedInvoice);
+        expect(hook['pendingHooks'].has(id)).toEqual(true);
+
+        handlers[event](payload);
+
+        await expect(promise).resolves.toEqual({
+          action: InvoicePaymentHookAction.Continue,
+        });
+        expect(hook['pendingHooks'].has(id)).toEqual(false);
+      },
+    );
   });
 
   describe('parseGrpcAction', () => {
@@ -37,7 +101,34 @@ describe('InvoicePaymentHook', () => {
       } as boltzrpc.InvoicePaymentHookResponse;
 
       expect(hook['parseGrpcAction'](mockResponse)).toEqual({
+        action: InvoicePaymentHookAction.Continue,
         nodeId: undefined,
+      });
+    });
+
+    test('should return continue action when explicitly provided', () => {
+      const mockResponse = {
+        id: 'id',
+        nodePubkey: '',
+        action: boltzrpc.InvoicePaymentHookAction.CONTINUE,
+      } as boltzrpc.InvoicePaymentHookResponse;
+
+      expect(hook['parseGrpcAction'](mockResponse)).toEqual({
+        action: InvoicePaymentHookAction.Continue,
+        nodeId: undefined,
+      });
+    });
+
+    test('should return hold action without preferences', () => {
+      const mockResponse = {
+        id: 'id',
+        nodePubkey: 'ignored',
+        timePreference: -0.5,
+        action: boltzrpc.InvoicePaymentHookAction.HOLD,
+      } as boltzrpc.InvoicePaymentHookResponse;
+
+      expect(hook['parseGrpcAction'](mockResponse)).toEqual({
+        action: InvoicePaymentHookAction.Hold,
       });
     });
 
@@ -49,6 +140,7 @@ describe('InvoicePaymentHook', () => {
       } as boltzrpc.InvoicePaymentHookResponse;
 
       expect(hook['parseGrpcAction'](mockResponse)).toEqual({
+        action: InvoicePaymentHookAction.Continue,
         nodeId: undefined,
         timePreference: -0.5,
       });
@@ -61,6 +153,7 @@ describe('InvoicePaymentHook', () => {
       } as boltzrpc.InvoicePaymentHookResponse;
 
       expect(hook['parseGrpcAction'](mockResponse)).toEqual({
+        action: InvoicePaymentHookAction.Continue,
         nodeId: 'lnd-override',
       });
     });
@@ -73,6 +166,7 @@ describe('InvoicePaymentHook', () => {
       } as boltzrpc.InvoicePaymentHookResponse;
 
       expect(hook['parseGrpcAction'](mockResponse)).toEqual({
+        action: InvoicePaymentHookAction.Continue,
         nodeId: 'lnd-override',
         timePreference: 0.8,
       });
@@ -97,6 +191,7 @@ describe('InvoicePaymentHook', () => {
           } as boltzrpc.InvoicePaymentHookResponse;
 
           expect(hook['parseGrpcAction'](mockResponse)).toEqual({
+            action: InvoicePaymentHookAction.Continue,
             timePreference,
             nodeId: undefined,
           });

--- a/test/unit/swap/hooks/InvoicePaymentHook.spec.ts
+++ b/test/unit/swap/hooks/InvoicePaymentHook.spec.ts
@@ -28,12 +28,9 @@ describe('InvoicePaymentHook', () => {
       emit: jest.fn(),
     };
 
-    hook = new InvoicePaymentHook(
-      Logger.disabledLogger,
-      {
-        sendMessage: jest.fn(),
-      } as unknown as NotificationClient,
-    );
+    hook = new InvoicePaymentHook(Logger.disabledLogger, {
+      sendMessage: jest.fn(),
+    } as unknown as NotificationClient);
   });
 
   describe('hook', () => {

--- a/test/unit/swap/hooks/TransactionHook.spec.ts
+++ b/test/unit/swap/hooks/TransactionHook.spec.ts
@@ -1,0 +1,151 @@
+import { status } from '@grpc/grpc-js';
+import Logger from '../../../../lib/Logger';
+import { SwapType } from '../../../../lib/consts/Enums';
+import * as boltzrpc from '../../../../lib/proto/boltzrpc';
+import { Action } from '../../../../lib/swap/hooks/CreationHook';
+import TransactionHook from '../../../../lib/swap/hooks/TransactionHook';
+
+describe('TransactionHook', () => {
+  let hook: TransactionHook;
+
+  let handlers: Record<string, (data?: any) => void>;
+  let stream: any;
+
+  const request = {
+    swapId: 'swap-id',
+    symbol: 'BTC',
+    txId: 'tx-id',
+    tx: Buffer.from('tx'),
+    confirmed: true,
+    swapType: SwapType.Submarine,
+    vout: 1,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+
+    handlers = {};
+    stream = {
+      on: jest.fn().mockImplementation((event: string, handler: any) => {
+        handlers[event] = handler;
+      }),
+      end: jest.fn(),
+      write: jest.fn(),
+      removeAllListeners: jest.fn(),
+      emit: jest.fn(),
+    };
+
+    hook = new TransactionHook(Logger.disabledLogger);
+  });
+
+  describe('hook', () => {
+    test('should resolve accept action if stream is not connected', async () => {
+      await expect(
+        hook.hook(
+          request.swapId,
+          request.symbol,
+          request.txId,
+          request.tx,
+          request.confirmed,
+          request.swapType,
+          request.vout,
+        ),
+      ).resolves.toEqual(Action.Accept);
+
+      expect(stream.write).not.toHaveBeenCalled();
+    });
+
+    test('should send transaction hook request', async () => {
+      hook.connectToStream(stream);
+
+      const promise = hook.hook(
+        request.swapId,
+        request.symbol,
+        request.txId,
+        request.tx,
+        request.confirmed,
+        request.swapType,
+        request.vout,
+      );
+      hook['pendingHooks'].get(request.swapId)?.(Action.Accept);
+
+      await expect(promise).resolves.toEqual(Action.Accept);
+
+      expect(stream.write).toHaveBeenCalledTimes(1);
+      expect(stream.write).toHaveBeenCalledWith({
+        id: request.swapId,
+        symbol: request.symbol,
+        tx: request.tx,
+        txId: request.txId,
+        confirmed: request.confirmed,
+        swapType: boltzrpc.SwapType.SUBMARINE,
+        vout: request.vout.toString(),
+      } satisfies boltzrpc.TransactionHookRequest);
+    });
+
+    test('should resolve accept action if hook is not resolved after timeout', async () => {
+      jest.useFakeTimers();
+
+      hook.connectToStream(stream);
+
+      const promise = hook.hook(
+        request.swapId,
+        request.symbol,
+        request.txId,
+        request.tx,
+        request.confirmed,
+        request.swapType,
+        request.vout,
+      );
+      expect(hook['pendingHooks'].has(request.swapId)).toEqual(true);
+
+      jest.runAllTimers();
+
+      await expect(promise).resolves.toEqual(Action.Accept);
+      expect(hook['pendingHooks'].has(request.swapId)).toEqual(false);
+    });
+
+    test.each`
+      event      | payload
+      ${'end'}   | ${undefined}
+      ${'error'} | ${{ code: status.UNAVAILABLE, details: 'test' }}
+    `(
+      'should resolve pending hooks to accept action on $event',
+      async ({ event, payload }) => {
+        hook.connectToStream(stream);
+
+        const promise = hook.hook(
+          request.swapId,
+          request.symbol,
+          request.txId,
+          request.tx,
+          request.confirmed,
+          request.swapType,
+          request.vout,
+        );
+        expect(hook['pendingHooks'].has(request.swapId)).toEqual(true);
+
+        handlers[event](payload);
+
+        await expect(promise).resolves.toEqual(Action.Accept);
+        expect(hook['pendingHooks'].has(request.swapId)).toEqual(false);
+      },
+    );
+  });
+
+  describe('parseGrpcAction', () => {
+    test.each`
+      action                    | result
+      ${boltzrpc.Action.ACCEPT} | ${Action.Accept}
+      ${boltzrpc.Action.REJECT} | ${Action.Reject}
+    `('should parse action $action', ({ action, result }) => {
+      expect(
+        hook['parseGrpcAction']({
+          id: request.swapId,
+          action,
+        }),
+      ).toEqual(result);
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the intermediate "Hold" action from swap processing so lockup events are emitted immediately instead of being deferred.
  * Invoice payments now respect explicit Hold vs Continue results, so payments can be paused when a hold is returned.

* **Tests**
  * Updated and expanded unit tests to reflect Hold removal and to cover transaction hooks, invoice payment hooks, node selection, and swap retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->