### PR TITLE
chore: bump LND to v0.21.0-beta

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -37,7 +37,7 @@ NODE_VERSION = BuildArgument(
 
 GOLANG_VERSION = BuildArgument(
     name="GOLANG_VERSION",
-    value="1.26.2-trixie",
+    value="1.26.4-trixie",
 )
 
 BITCOIN_VERSION = "31.0"
@@ -45,9 +45,9 @@ LITECOIN_VERSION = "0.21.4"
 ELEMENTS_VERSION = "23.3.3"
 GETH_VERSION = "1.17.2"
 
-C_LIGHTNING_VERSION = "26.06"
+C_LIGHTNING_VERSION = "26.06.1"
 ECLAIR_VERSION = "0.14.0"
-LND_VERSION = "0.20.1-beta"
+LND_VERSION = "0.21.0-beta"
 
 BITCOIN_BUILD_ARG = BuildArgument(
     name="BITCOIN_VERSION",

--- a/lib/VersionCheck.ts
+++ b/lib/VersionCheck.ts
@@ -82,7 +82,7 @@ class VersionCheck {
     },
     [ClnClient.serviceName]: {
       minimal: '26.04',
-      maximal: '26.06',
+      maximal: '26.06.1',
     },
     [ClnClient.serviceNameHold]: {
       minimal: '0.3.0',
@@ -90,7 +90,7 @@ class VersionCheck {
     },
     [LndClient.serviceName]: {
       minimal: '0.19.0',
-      maximal: '0.20.1',
+      maximal: '0.21.0',
     },
   };
 

--- a/lib/lightning/LightningClient.ts
+++ b/lib/lightning/LightningClient.ts
@@ -148,7 +148,6 @@ interface LightningClient extends BalancerFetcher, BaseClient<EventTypes> {
   sendPayment(
     invoice: string,
     cltvDelta?: number,
-    outgoingChannelId?: string,
     maxPaymentFeeRatio?: number,
     timePreference?: number,
   ): Promise<PaymentResponse>;

--- a/lib/lightning/LndClient.ts
+++ b/lib/lightning/LndClient.ts
@@ -401,13 +401,11 @@ class LndClient extends BaseClient<EventTypes> implements LightningClient {
    *
    * @param invoice an invoice for a payment within the Lightning Network
    * @param cltvDelta CLTV delta limit for the payment
-   * @param outgoingChannelId channel through which the invoice should be paid
    * @param maxPaymentFeeRatio max payment fee ratio to override the default of the client
    */
   public sendPayment = async (
     invoice: string,
     cltvDelta?: number,
-    outgoingChannelId?: string,
     maxPaymentFeeRatio?: number,
     timePreference?: number,
   ): Promise<PaymentResponse> => {
@@ -423,9 +421,6 @@ class LndClient extends BaseClient<EventTypes> implements LightningClient {
         ),
         paymentRequest: invoice,
         cltvLimit: cltvDelta ?? 0,
-        outgoingChanId: outgoingChannelId
-          ? toOptionalProtoInt(Number.parseInt(outgoingChannelId, 10))
-          : undefined,
       });
 
       const stream = this.router!.sendPaymentV2(request, this.meta);

--- a/lib/lightning/PendingPaymentTracker.ts
+++ b/lib/lightning/PendingPaymentTracker.ts
@@ -154,7 +154,6 @@ class PendingPaymentTracker {
     paymentHash: string,
     payments: LightningPayment[],
     cltvLimit?: number,
-    outgoingChannelId?: string,
     timePreference?: number,
   ): Promise<PaymentResponse | undefined> => {
     for (const status of [
@@ -204,7 +203,6 @@ class PendingPaymentTracker {
       lightningClient,
       paymentHash,
       cltvLimit,
-      outgoingChannelId,
       timePreference,
     );
   };
@@ -249,7 +247,6 @@ class PendingPaymentTracker {
     lightningClient: LightningClient,
     preimageHash: string,
     cltvLimit?: number,
-    outgoingChannelId?: string,
     timePreference?: number,
   ) => {
     await LightningPaymentRepository.create({
@@ -267,7 +264,6 @@ class PendingPaymentTracker {
       paymentPromise = lightningClient.sendPayment(
         swap.invoice!,
         cltvLimit,
-        outgoingChannelId,
         referral?.maxRoutingFeeRatio(swap.pair),
         timePreference,
       );

--- a/lib/lightning/cln/ClnClient.ts
+++ b/lib/lightning/cln/ClnClient.ts
@@ -549,11 +549,9 @@ class ClnClient
     return routes;
   };
 
-  // TODO: support for setting outgoing channel id
   public sendPayment = async (
     invoice: string,
     cltvDelta?: number,
-    _?: string,
     maxPaymentFeeRatio?: number,
   ): Promise<PaymentResponse> => {
     try {

--- a/lib/service/cooperative/ChainSwapSigner.ts
+++ b/lib/service/cooperative/ChainSwapSigner.ts
@@ -49,7 +49,6 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
   private attemptSettleSwap!: (
     currency: Currency,
     swap: Swap | ChainSwapInfo,
-    outgoingChannelId?: string,
     preimage?: Buffer,
   ) => Promise<void>;
 
@@ -351,7 +350,6 @@ class ChainSwapSigner extends CoopSignerBase<{ claim: ChainSwapInfo }> {
             await this.attemptSettleSwap(
               this.currencies.get(swap.receivingData.symbol)!,
               swap,
-              undefined,
               preimage,
             );
           }

--- a/lib/swap/PaymentHandler.ts
+++ b/lib/swap/PaymentHandler.ts
@@ -123,10 +123,7 @@ class PaymentHandler {
     this.selfPaymentClient = new SelfPaymentClient(this.logger, swapNursery);
   }
 
-  public payInvoice = async (
-    swap: Swap,
-    outgoingChannelId?: string,
-  ): Promise<Buffer | undefined> => {
+  public payInvoice = async (swap: Swap): Promise<Buffer | undefined> => {
     this.logger.verbose(`Paying invoice of Swap ${swap.id}`);
 
     if (swap.status !== SwapUpdateEvent.InvoicePending) {
@@ -219,7 +216,6 @@ class PaymentHandler {
         paymentHash,
         payments,
         cltvLimit,
-        outgoingChannelId,
         preferredNode?.timePreference,
       );
 
@@ -227,7 +223,7 @@ class PaymentHandler {
         return await this.settleInvoice(swap, payResponse);
       }
     } catch (error) {
-      return this.handlePaymentFailure(swap, node, error, outgoingChannelId);
+      return this.handlePaymentFailure(swap, node, error);
     }
 
     return undefined;
@@ -237,15 +233,9 @@ class PaymentHandler {
     swap: Swap,
     lightningClient: LightningClient,
     error: unknown,
-    outgoingChannelId?: string,
   ): Promise<Buffer | undefined> => {
     if (lightningClient instanceof LndClient) {
-      return this.handleLndPaymentFailure(
-        swap,
-        lightningClient,
-        error,
-        outgoingChannelId,
-      );
+      return this.handleLndPaymentFailure(swap, lightningClient, error);
     } else if (lightningClient instanceof ClnClient) {
       return this.handleClnPaymentFailure(swap, error);
     }
@@ -257,16 +247,11 @@ class PaymentHandler {
     swap: Swap,
     lndClient: LndClient,
     error: unknown,
-    outgoingChannelId?: string,
   ): Promise<Buffer | undefined> => {
     const errorMessage =
       typeof error === 'number'
         ? LndClient.formatPaymentFailureReason(error as any)
         : formatError(error);
-
-    if (outgoingChannelId !== undefined) {
-      throw errorMessage;
-    }
 
     if (
       errorMessage === PaymentHandler.errCltvTooSmall ||

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -826,7 +826,6 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
           await this.attemptSettleSwap(
             this.currencies.get(swap.receivingData.symbol)!,
             swap,
-            undefined,
             preimage,
           );
           await this.chainSwapSigner.removeFromClaimable(swap.id);
@@ -970,13 +969,12 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
   public attemptSettleSwap = async (
     currency: Currency,
     swap: Swap | ChainSwapInfo,
-    outgoingChannelId?: string,
     preimage?: Buffer,
   ): Promise<void> => {
     let payRes: PaidSwapInvoice | undefined;
 
     if (swap.type === SwapType.Submarine) {
-      payRes = await this.payInvoice(swap as Swap, outgoingChannelId);
+      payRes = await this.payInvoice(swap as Swap);
     } else {
       payRes = { preimage: preimage! };
     }
@@ -1452,7 +1450,6 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
             await this.attemptSettleSwap(
               this.currencies.get(chainSwap.receivingData.symbol)!,
               chainSwap,
-              undefined,
               preimage,
             );
           }
@@ -1781,12 +1778,8 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
   private payInvoice = async (
     swap: Swap,
-    outgoingChannelId?: string,
   ): Promise<PaidSwapInvoice | undefined> => {
-    const preimage = await this.paymentHandler.payInvoice(
-      swap,
-      outgoingChannelId,
-    );
+    const preimage = await this.paymentHandler.payInvoice(swap);
 
     if (preimage === undefined) {
       return undefined;

--- a/proto/lnd/router.proto
+++ b/proto/lnd/router.proto
@@ -27,7 +27,7 @@ option go_package = "github.com/lightningnetwork/lnd/lnrpc/routerrpc";
 // Router is a service that offers advanced interaction with the router
 // subsystem of the daemon.
 service Router {
-    /*
+    /* lncli: `sendpayment`
     SendPaymentV2 attempts to route a payment described by the passed
     PaymentRequest to the final destination. The call returns a stream of
     payment updates. When using this RPC, make sure to set a fee limit, as the
@@ -53,24 +53,13 @@ service Router {
     */
     rpc TrackPayments (TrackPaymentsRequest) returns (stream lnrpc.Payment);
 
-    /*
+    /* lncli: `estimateroutefee`
     EstimateRouteFee allows callers to obtain a lower bound w.r.t how much it
     may cost to send an HTLC to the target end destination.
     */
     rpc EstimateRouteFee (RouteFeeRequest) returns (RouteFeeResponse);
 
-    /*
-    Deprecated, use SendToRouteV2. SendToRoute attempts to make a payment via
-    the specified route. This method differs from SendPayment in that it
-    allows users to specify a full route manually. This can be used for
-    things like rebalancing, and atomic swaps. It differs from the newer
-    SendToRouteV2 in that it doesn't return the full HTLC information.
-    */
-    rpc SendToRoute (SendToRouteRequest) returns (SendToRouteResponse) {
-        option deprecated = true;
-    }
-
-    /*
+    /* lncli: `sendtoroute`
     SendToRouteV2 attempts to make a payment via the specified route. This
     method differs from SendPayment in that it allows users to specify a full
     route manually. This can be used for things like rebalancing, and atomic
@@ -141,23 +130,6 @@ service Router {
     rpc SubscribeHtlcEvents (SubscribeHtlcEventsRequest)
         returns (stream HtlcEvent);
 
-    /*
-    Deprecated, use SendPaymentV2. SendPayment attempts to route a payment
-    described by the passed PaymentRequest to the final destination. The call
-    returns a stream of payment status updates.
-    */
-    rpc SendPayment (SendPaymentRequest) returns (stream PaymentStatus) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use TrackPaymentV2. TrackPayment returns an update stream for
-    the payment identified by the payment hash.
-    */
-    rpc TrackPayment (TrackPaymentRequest) returns (stream PaymentStatus) {
-        option deprecated = true;
-    }
-
     /**
     HtlcInterceptor dispatches a bi-directional streaming RPC in which
     Forwarded HTLC requests are sent to the client and the client responds with
@@ -202,6 +174,18 @@ service Router {
     */
     rpc XFindBaseLocalChanAlias (FindBaseAliasRequest)
         returns (FindBaseAliasResponse);
+
+    /* lncli: `deletefwdhistory`
+    DeleteForwardingHistory allows the caller to delete forwarding history
+    events with a timestamp at or before a specified time. This is useful
+    for implementing data retention policies for privacy purposes. The call
+    deletes events in batches and returns statistics including the total number
+    of events deleted and the aggregate fees earned from those events. The
+    deletion is performed in a transaction-safe manner with configurable batch
+    sizes to avoid holding large database locks.
+    */
+    rpc DeleteForwardingHistory (DeleteForwardingHistoryRequest)
+        returns (DeleteForwardingHistoryResponse);
 }
 
 message SendPaymentRequest {
@@ -252,12 +236,7 @@ message SendPaymentRequest {
     */
     int64 fee_limit_sat = 7;
 
-    /*
-    Deprecated, use outgoing_chan_ids. The channel id of the channel that must
-    be taken to the first hop. If zero, any channel may be used (unless
-    outgoing_chan_ids are set).
-    */
-    uint64 outgoing_chan_id = 8 [jstype = JS_STRING, deprecated = true];
+    reserved 8;
 
     /*
     An optional maximum total time lock for the route. This should not
@@ -477,14 +456,6 @@ message SendToRouteRequest {
     base64.
     */
     map<uint64, bytes> first_hop_custom_records = 4;
-}
-
-message SendToRouteResponse {
-    // The preimage obtained by making the payment.
-    bytes preimage = 1;
-
-    // The failure message in case the payment failed.
-    lnrpc.Failure failure = 2;
 }
 
 message ResetMissionControlRequest {
@@ -911,62 +882,11 @@ enum FailureDetail {
     INVALID_KEYSEND = 20;
     MPP_IN_PROGRESS = 21;
     CIRCULAR_ROUTE = 22;
-}
-
-enum PaymentState {
-    /*
-    Payment is still in flight.
-    */
-    IN_FLIGHT = 0;
-
-    /*
-    Payment completed successfully.
-    */
-    SUCCEEDED = 1;
-
-    /*
-    There are more routes to try, but the payment timeout was exceeded.
-    */
-    FAILED_TIMEOUT = 2;
-
-    /*
-    All possible routes were tried and failed permanently. Or were no
-    routes to the destination at all.
-    */
-    FAILED_NO_ROUTE = 3;
-
-    /*
-    A non-recoverable error has occurred.
-    */
-    FAILED_ERROR = 4;
-
-    /*
-    Payment details incorrect (unknown hash, invalid amt or
-    invalid final cltv delta)
-    */
-    FAILED_INCORRECT_PAYMENT_DETAILS = 5;
-
-    /*
-    Insufficient local balance.
-    */
-    FAILED_INSUFFICIENT_BALANCE = 6;
-}
-
-message PaymentStatus {
-    // Current state the payment is in.
-    PaymentState state = 1;
-
-    /*
-    The pre-image of the payment when state is SUCCEEDED.
-    */
-    bytes preimage = 2;
-
-    reserved 3;
-
-    /*
-    The HTLCs made in attempt to settle the payment [EXPERIMENTAL].
-    */
-    repeated lnrpc.HTLCAttempt htlcs = 4;
+    INVOICE_ALREADY_SETTLED = 23;
+    HTLC_INVOICE_TYPE_MISMATCH = 24;
+    AMP_ERROR = 25;
+    AMP_RECONSTRUCTION = 26;
+    EXTERNAL_VALIDATION_FAILED = 27;
 }
 
 message CircuitKey {
@@ -1133,4 +1053,36 @@ message FindBaseAliasRequest {
 message FindBaseAliasResponse {
     // The base scid that resulted from the base scid look up.
     uint64 base = 1;
+}
+
+message DeleteForwardingHistoryRequest {
+    // Specify the cutoff time for deletion using one of the following options.
+    // Events with a timestamp at or before the cutoff are deleted.
+    oneof time_spec {
+        // Absolute Unix timestamp (seconds). Events at or before this time
+        // are deleted.
+        uint64 delete_before_time = 1;
+
+        // Relative duration string indicating how far back to delete, e.g.
+        // "-30d" deletes events at or before 30 days ago.
+        // Standard Go: "-24h", "-1.5h"
+        // Custom units: "-1d", "-1w", "-1M", "-1y"
+        // Supported: ns, us/µs, ms, s, m, h, d (days), w (weeks),
+        // M (months=30.44d), y (years=365.25d).
+        // Use negative values to specify time in the past.
+        string delete_before_duration = 2;
+    }
+}
+
+message DeleteForwardingHistoryResponse {
+    // Number of forwarding events deleted.
+    uint64 events_deleted = 1;
+
+    // Total fees earned from deleted events (in millisatoshis).
+    // This is the sum of (amt_in - amt_out) for all deleted events, which
+    // can be used for accounting purposes.
+    int64 total_fee_msat = 2;
+
+    // Status message.
+    string status = 3;
 }

--- a/proto/lnd/rpc.proto
+++ b/proto/lnd/rpc.proto
@@ -262,47 +262,6 @@ service Lightning {
     */
     rpc AbandonChannel (AbandonChannelRequest) returns (AbandonChannelResponse);
 
-    /* lncli: `sendpayment`
-    Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a
-    bi-directional streaming RPC for sending payments through the Lightning
-    Network. A single RPC invocation creates a persistent bi-directional
-    stream allowing clients to rapidly send payments through the Lightning
-    Network with a single persistent connection.
-    */
-    rpc SendPayment (stream SendRequest) returns (stream SendResponse) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use routerrpc.SendPaymentV2. SendPaymentSync is the synchronous
-    non-streaming version of SendPayment. This RPC is intended to be consumed by
-    clients of the REST proxy. Additionally, this RPC expects the destination's
-    public key and the payment hash (if any) to be encoded as hex strings.
-    */
-    rpc SendPaymentSync (SendRequest) returns (SendResponse) {
-        option deprecated = true;
-    }
-
-    /* lncli: `sendtoroute`
-    Deprecated, use routerrpc.SendToRouteV2. SendToRoute is a bi-directional
-    streaming RPC for sending payment through the Lightning Network. This
-    method differs from SendPayment in that it allows users to specify a full
-    route manually. This can be used for things like rebalancing, and atomic
-    swaps.
-    */
-    rpc SendToRoute (stream SendToRouteRequest) returns (stream SendResponse) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use routerrpc.SendToRouteV2. SendToRouteSync is a synchronous
-    version of SendToRoute. It Will block until the payment either fails or
-    succeeds.
-    */
-    rpc SendToRouteSync (SendToRouteRequest) returns (SendResponse) {
-        option deprecated = true;
-    }
-
     /* lncli: `addinvoice`
     AddInvoice attempts to add a new invoice to the invoice database. Any
     duplicated invoices are rejected, therefore all invoices *must* have a
@@ -597,6 +556,18 @@ service Lightning {
     rpc SubscribeCustomMessages (SubscribeCustomMessagesRequest)
         returns (stream CustomMessage);
 
+    /* lncli: `sendonion`
+    SendOnionMessage sends an onion message to a peer.
+    */
+    rpc SendOnionMessage (SendOnionMessageRequest)
+        returns (SendOnionMessageResponse);
+
+    /* lncli: `subscribeonion`
+    SubscribeOnionMessages subscribes to a stream of incoming onion messages.
+    */
+    rpc SubscribeOnionMessages (SubscribeOnionMessagesRequest)
+        returns (stream OnionMessageUpdate);
+
     /* lncli: `listaliases`
     ListAliases returns the set of all aliases that have ever existed with
     their confirmed SCID (if it exists) and/or the base SCID (in the case of
@@ -642,7 +613,8 @@ message CustomMessage {
 }
 
 message SendCustomMessageRequest {
-    // Peer to send the message to
+    // Peer to which the message will be sent. Represented as a byte-encoded
+    // public key
     bytes peer = 1;
 
     // Message type. This value needs to be in the custom range (>= 32768).
@@ -657,6 +629,67 @@ message SendCustomMessageRequest {
 
 message SendCustomMessageResponse {
     // The status of the send operation.
+    string status = 1;
+}
+
+message SubscribeOnionMessagesRequest {
+}
+
+message OnionMessageUpdate {
+    // Peer from which this message originates. Represented as a byte-encoded
+    // public key.
+    bytes peer = 1;
+
+    // PathKey is used to derive the blinded node id by tweaking the hop's
+    // static public key. The hop uses the corresponding blinded private key
+    // together with the sender's ephemeral key to perform ECDH and obtain the
+    // shared secret for decrypting the onion payload. Separately, for
+    // decrypting `encrypted_recipient_data`, the recipient performs ECDH
+    // between its static node private key and the path_key to derive the
+    // decryption key.
+    bytes path_key = 2;
+
+    // Serialized Sphinx onion packet (BOLT 4) containing the layered, per-hop
+    // encrypted payloads and routing instructions used to forward this message
+    // along its designated path.
+    bytes onion = 3;
+
+    // reply_path is the blinded path that should be used when replying to a
+    // received message.
+    BlindedPath reply_path = 4;
+
+    // encrypted_recipient_data is the encrypted data that contains the
+    // forwarding information for an onion message. It contains either
+    // next_node_id or short_channel_id for each non-final node. It MAY contain
+    // the path_id for the final node.
+    bytes encrypted_recipient_data = 5;
+
+    // Custom onion message tlv records. These are customized fields that are
+    // not defined by LND and cannot be extracted.
+    map<uint64, bytes> custom_records = 6;
+}
+
+message SendOnionMessageRequest {
+    // Peer to send the message to
+    bytes peer = 1;
+
+    // PathKey is used to derive the blinded node id by tweaking the hop's
+    // static public key. The hop uses the corresponding blinded private key
+    // together with the sender's ephemeral key to perform ECDH and obtain the
+    // shared secret for decrypting the onion payload. Separately, for
+    // decrypting `encrypted_recipient_data`, the recipient performs ECDH
+    // between its static node private key and the path_key to derive the
+    // decryption key.
+    bytes path_key = 2;
+
+    // Serialized Sphinx onion packet (BOLT 4) containing the layered, per-hop
+    // encrypted payloads and routing instructions used to forward this message
+    // along its designated path.
+    bytes onion = 3;
+}
+
+message SendOnionMessageResponse {
+    // The status of the onion message send operation.
     string status = 1;
 }
 
@@ -820,139 +853,6 @@ message FeeLimit {
         // The fee limit expressed as a percentage of the payment amount.
         int64 percent = 2;
     }
-}
-
-message SendRequest {
-    /*
-    The identity pubkey of the payment recipient. When using REST, this field
-    must be encoded as base64.
-    */
-    bytes dest = 1;
-
-    /*
-    The hex-encoded identity pubkey of the payment recipient. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string dest_string = 2 [deprecated = true];
-
-    /*
-    The amount to send expressed in satoshis.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt = 3;
-
-    /*
-    The amount to send expressed in millisatoshis.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt_msat = 12;
-
-    /*
-    The hash to use within the payment's HTLC. When using REST, this field
-    must be encoded as base64.
-    */
-    bytes payment_hash = 4;
-
-    /*
-    The hex-encoded hash to use within the payment's HTLC. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string payment_hash_string = 5 [deprecated = true];
-
-    /*
-    A bare-bones invoice for a payment within the Lightning Network. With the
-    details of the invoice, the sender has all the data necessary to send a
-    payment to the recipient.
-    */
-    string payment_request = 6;
-
-    /*
-    The CLTV delta from the current height that should be used to set the
-    timelock for the final hop.
-    */
-    int32 final_cltv_delta = 7;
-
-    /*
-    The maximum number of satoshis that will be paid as a fee of the payment.
-    This value can be represented either as a percentage of the amount being
-    sent, or as a fixed amount of the maximum fee the user is willing the pay to
-    send the payment. If not specified, lnd will use a default value of 100%
-    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
-    */
-    FeeLimit fee_limit = 8;
-
-    /*
-    The channel id of the channel that must be taken to the first hop. If zero,
-    any channel may be used.
-    */
-    uint64 outgoing_chan_id = 9 [jstype = JS_STRING];
-
-    /*
-    The pubkey of the last hop of the route. If empty, any hop may be used.
-    */
-    bytes last_hop_pubkey = 13;
-
-    /*
-    An optional maximum total time lock for the route. This should not exceed
-    lnd's `--max-cltv-expiry` setting. If zero, then the value of
-    `--max-cltv-expiry` is enforced.
-    */
-    uint32 cltv_limit = 10;
-
-    /*
-    An optional field that can be used to pass an arbitrary set of TLV records
-    to a peer which understands the new records. This can be used to pass
-    application specific data during the payment attempt. Record types are
-    required to be in the custom range >= 65536. When using REST, the values
-    must be encoded as base64.
-    */
-    map<uint64, bytes> dest_custom_records = 11;
-
-    // If set, circular payments to self are permitted.
-    bool allow_self_payment = 14;
-
-    /*
-    Features assumed to be supported by the final node. All transitive feature
-    dependencies must also be set properly. For a given feature bit pair, either
-    optional or remote may be set, but not both. If this field is nil or empty,
-    the router will try to load destination features from the graph as a
-    fallback.
-    */
-    repeated FeatureBit dest_features = 15;
-
-    /*
-    The payment address of the generated invoice.  This is also called
-    payment secret in specifications (e.g. BOLT 11).
-    */
-    bytes payment_addr = 16;
-}
-
-message SendResponse {
-    string payment_error = 1;
-    bytes payment_preimage = 2;
-    Route payment_route = 3;
-    bytes payment_hash = 4;
-}
-
-message SendToRouteRequest {
-    /*
-    The payment hash to use for the HTLC. When using REST, this field must be
-    encoded as base64.
-    */
-    bytes payment_hash = 1;
-
-    /*
-    An optional hex-encoded payment hash to be used for the HTLC. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string payment_hash_string = 2 [deprecated = true];
-
-    reserved 3;
-
-    // Route that should be used to attempt to complete the payment.
-    Route route = 4;
 }
 
 message ChannelAcceptRequest {
@@ -1159,6 +1059,9 @@ message EstimateFeeRequest {
 
     // The strategy to use for selecting coins during fees estimation.
     CoinSelectionStrategy coin_selection_strategy = 5;
+
+    // A list of selected inputs for the transaction.
+    repeated OutPoint inputs = 6;
 }
 
 message EstimateFeeResponse {
@@ -1171,6 +1074,9 @@ message EstimateFeeResponse {
 
     // The fee rate in satoshi/vbyte.
     uint64 sat_per_vbyte = 3;
+
+    // A list of selected inputs for the transaction the estimate is for.
+    repeated OutPoint inputs = 4;
 }
 
 message SendManyRequest {
@@ -1399,6 +1305,11 @@ message HTLC {
 }
 
 enum CommitmentType {
+    // Allow multiple enum names to map to the same numeric value so the
+    // taproot channel types can expose short, canonical aliases without
+    // breaking on-wire compatibility with the historic names.
+    option allow_alias = true;
+
     /*
     Returned when the commitment type isn't known or unavailable.
     */
@@ -1435,8 +1346,25 @@ enum CommitmentType {
     SCRIPT_ENFORCED_LEASE = 4;
 
     /*
-    A channel that uses musig2 for the funding output, and the new tapscript
-    features where relevant.
+    The production taproot channel type that uses musig2 for the funding
+    output and the new tapscript features, with final scripts and feature
+    bits 80/81. This is the recommended taproot variant; new integrations
+    should select this enum value.
+    */
+    TAPROOT = 7;
+
+    /*
+    Deprecated alias for TAPROOT, preserved so existing clients that select
+    the production taproot channel type by its historic name continue to
+    compile and serialize against the same wire value.
+    */
+    SIMPLE_TAPROOT_FINAL = 7;
+
+    /*
+    A legacy taproot channel type that uses musig2 for the funding output and
+    the new tapscript features, but with development scripts and the staging
+    feature bits. Retained for compatibility with peers that have not upgraded
+    to TAPROOT; new integrations should prefer TAPROOT.
     */
     SIMPLE_TAPROOT = 5;
 
@@ -1978,6 +1906,13 @@ message PeerEvent {
 
 message GetInfoRequest {
 }
+enum GraphCacheStatus {
+    GRAPH_CACHE_STATUS_DISABLED = 0;
+    GRAPH_CACHE_STATUS_LOADING = 1;
+    GRAPH_CACHE_STATUS_LOADED = 2;
+    GRAPH_CACHE_STATUS_FAILED = 3;
+}
+
 message GetInfoResponse {
     // The version of the LND software that the node is running.
     string version = 14;
@@ -2052,9 +1987,19 @@ message GetInfoResponse {
 
     // Indicates whether final htlc resolutions are stored on disk.
     bool store_final_htlc_resolutions = 22;
+
+    // Whether the wallet is fully synced to the best chain. This indicates the
+    // wallet's internal sync state with the backing chain source.
+    bool wallet_synced = 23;
+
+    // The current status of the in-memory graph cache.
+    GraphCacheStatus graph_cache_status = 24;
 }
 
 message GetDebugInfoRequest {
+    // If set to true, the log file content will be included in the response.
+    // By default, only the config information is returned.
+    bool include_log = 1;
 }
 
 message GetDebugInfoResponse {
@@ -2890,6 +2835,24 @@ message PendingChannelsResponse {
         // The raw hex encoded bytes of the closing transaction. Included if
         // include_raw_tx in the request is true.
         string closing_tx_hex = 5;
+
+        /*
+        Remaining number of confirmations until the channel closure is
+        considered final and removed from waiting close. Channel closes
+        require multiple confirmations for reorg protection — the exact
+        number scales with channel capacity. A closing transaction that
+        gets reorganized out of the chain resets this counter. When the
+        closing transaction is not yet confirmed, this value equals the
+        total number of confirmations required.
+        */
+        uint32 blocks_til_close_confirmed = 6;
+
+        /*
+        The block height at which the closing transaction was first confirmed.
+        This will be zero if the closing transaction has not yet confirmed, or
+        if this information is not available for older channels.
+        */
+        uint32 close_height = 7;
     }
 
     message Commitments {
@@ -2994,6 +2957,10 @@ message PendingChannelsResponse {
 message ChannelEventSubscription {
 }
 
+message ChannelCommitUpdate {
+    Channel channel = 1;
+}
+
 message ChannelEventUpdate {
     oneof channel {
         Channel open_channel = 1;
@@ -3003,6 +2970,7 @@ message ChannelEventUpdate {
         PendingUpdate pending_open_channel = 6;
         ChannelPoint fully_resolved_channel = 7;
         ChannelPoint channel_funding_timeout = 8;
+        ChannelCommitUpdate updated_channel = 9;
     }
 
     enum UpdateType {
@@ -3013,6 +2981,7 @@ message ChannelEventUpdate {
         PENDING_OPEN_CHANNEL = 4;
         FULLY_RESOLVED_CHANNEL = 5;
         CHANNEL_FUNDING_TIMEOUT = 6;
+        CHANNEL_UPDATE = 7;
     }
 
     UpdateType type = 5;
@@ -3186,11 +3155,7 @@ message QueryRoutesRequest {
     */
     map<uint64, bytes> dest_custom_records = 13;
 
-    /*
-    Deprecated, use outgoing_chan_ids. The channel id of the channel that must
-    be taken to the first hop. If zero, any channel may be used.
-    */
-    uint64 outgoing_chan_id = 14 [jstype = JS_STRING, deprecated = true];
+    reserved 14;
 
     /*
     The pubkey of the last hop of the route. If empty, any hop may be used.
@@ -4461,6 +4426,10 @@ message ListPaymentsRequest {
     // If set, returns all payments with a creation date less than or equal to
     // it. Measured in seconds since the unix epoch.
     uint64 creation_date_end = 7;
+
+    // If set, omit hop-level route data for HTLC attempts to reduce query
+    // cost and response size.
+    bool omit_hops = 8;
 }
 
 message ListPaymentsResponse {

--- a/test/integration/service/TimeoutDeltaProvider.spec.ts
+++ b/test/integration/service/TimeoutDeltaProvider.spec.ts
@@ -153,7 +153,7 @@ describe('TimeoutDeltaProvider', () => {
         OrderSide.SELL,
         SwapType.Submarine,
         SwapVersion.Legacy,
-        await createInvoice(18),
+        await createInvoice(24),
       ),
     ).resolves.toEqual([
       timeoutDelta.swapMinimal / TimeoutDeltaProvider.blockTimes.get(base)!,

--- a/test/integration/service/cooperative/ChainSwapSigner.spec.ts
+++ b/test/integration/service/cooperative/ChainSwapSigner.spec.ts
@@ -885,7 +885,6 @@ describe('ChainSwapSigner', () => {
       expect(attemptSettle).toHaveBeenCalledWith(
         undefined,
         chainSwapInfo,
-        undefined,
         preimage,
       );
     });

--- a/test/unit/lightning/PendingPaymentTracker.spec.ts
+++ b/test/unit/lightning/PendingPaymentTracker.spec.ts
@@ -150,7 +150,6 @@ describe('PendingPaymentTracker', () => {
       expect(lightningClient.sendPayment).toHaveBeenCalledWith(
         swap.invoice,
         undefined,
-        undefined,
         0.01,
         undefined,
       );
@@ -182,7 +181,6 @@ describe('PendingPaymentTracker', () => {
         undefined,
         undefined,
         undefined,
-        undefined,
       );
     });
 
@@ -205,7 +203,6 @@ describe('PendingPaymentTracker', () => {
       expect(lightningClient.sendPayment).toHaveBeenCalledTimes(1);
       expect(lightningClient.sendPayment).toHaveBeenCalledWith(
         swap.invoice,
-        undefined,
         undefined,
         undefined,
         undefined,

--- a/test/unit/swap/PaymentHandler.spec.ts
+++ b/test/unit/swap/PaymentHandler.spec.ts
@@ -111,17 +111,8 @@ describe('PaymentHandler', () => {
       sendPayment: jest
         .fn()
         .mockImplementation(
-          (
-            _: LightningClient,
-            invoice: string,
-            cltvLimit?: number,
-            outgoingChannelId?: string,
-          ) => {
-            return btcLndClient.sendPayment(
-              invoice,
-              cltvLimit,
-              outgoingChannelId,
-            );
+          (_: LightningClient, invoice: string, cltvLimit?: number) => {
+            return btcLndClient.sendPayment(invoice, cltvLimit);
           },
         ),
       getRelevantNode: jest
@@ -168,9 +159,7 @@ describe('PaymentHandler', () => {
       status: Payment_PaymentStatus.IN_FLIGHT,
     };
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
 
     expect(mockedEmit).not.toHaveBeenCalled();
     expect(btcLndClient.trackPayment).toHaveBeenCalledTimes(1);
@@ -184,9 +173,7 @@ describe('PaymentHandler', () => {
       Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
     ]);
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
 
     expect(
       handler['selfPaymentClient'].handleSelfPayment,
@@ -211,9 +198,7 @@ describe('PaymentHandler', () => {
     ]);
     relevantPayments = [{} as any];
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
 
     expect(
       handler['selfPaymentClient'].handleSelfPayment,
@@ -240,9 +225,7 @@ describe('PaymentHandler', () => {
       status: Payment_PaymentStatus.FAILED,
     };
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
 
     expect(mockedEmit).not.toHaveBeenCalled();
     expect(btcLndClient.resetMissionControl).not.toHaveBeenCalled();
@@ -263,9 +246,7 @@ describe('PaymentHandler', () => {
     expect(btcLndClient.resetMissionControl).not.toHaveBeenCalled();
     expect(btcLndClient.trackPayment).not.toHaveBeenCalled();
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
     expect(swap.update).toHaveBeenCalledTimes(1);
     expect(swap.update).toHaveBeenCalledWith({
       failureReason: 'invoice could not be paid',
@@ -284,9 +265,7 @@ describe('PaymentHandler', () => {
     expect(btcLndClient.resetMissionControl).not.toHaveBeenCalled();
     expect(btcLndClient.trackPayment).not.toHaveBeenCalled();
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
     expect(swap.update).toHaveBeenCalledTimes(1);
     expect(swap.update).toHaveBeenCalledWith({
       failureReason: 'invoice could not be paid',
@@ -301,9 +280,7 @@ describe('PaymentHandler', () => {
       status: Payment_PaymentStatus.FAILED,
     };
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
 
     expect(btcLndClient.resetMissionControl).toHaveBeenCalledTimes(1);
     expect(handler['lastResetMissionControl']).not.toBeUndefined();
@@ -312,9 +289,7 @@ describe('PaymentHandler', () => {
     // Reset MC not called
     const lastCallBefore = handler['lastResetMissionControl'];
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
     expect(btcLndClient.resetMissionControl).toHaveBeenCalledTimes(1);
     expect(handler['lastResetMissionControl']).toEqual(lastCallBefore);
 
@@ -322,9 +297,7 @@ describe('PaymentHandler', () => {
     jest.useFakeTimers();
     jest.advanceTimersByTime(PaymentHandler['resetMissionControlInterval'] + 1);
 
-    await expect(handler.payInvoice(swap, undefined)).resolves.toEqual(
-      undefined,
-    );
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
     expect(btcLndClient.resetMissionControl).toHaveBeenCalledTimes(2);
     expect(handler['lastResetMissionControl']! - Date.now()).toBeLessThan(1000);
   });
@@ -386,7 +359,7 @@ describe('PaymentHandler', () => {
       action: InvoicePaymentHookAction.Hold,
     });
 
-    const result = await handler.payInvoice(swap, undefined);
+    const result = await handler.payInvoice(swap);
 
     expect(result).toBeUndefined();
     expect(nodeSwitch.invoicePaymentHook).toHaveBeenCalledTimes(1);
@@ -426,7 +399,7 @@ describe('PaymentHandler', () => {
       const settleInvoiceSpy = jest.spyOn(handler as any, 'settleInvoice');
       settleInvoiceSpy.mockResolvedValue(mockPaymentResponse.preimage);
 
-      const result = await handler.payInvoice(swap, undefined);
+      const result = await handler.payInvoice(swap);
 
       expect(result).toEqual(mockPaymentResponse.preimage);
       expect(
@@ -450,7 +423,7 @@ describe('PaymentHandler', () => {
 
       const settleInvoiceSpy = jest.spyOn(handler as any, 'settleInvoice');
 
-      const result = await handler.payInvoice(swap, undefined);
+      const result = await handler.payInvoice(swap);
 
       expect(result).toBeUndefined();
       expect(
@@ -468,7 +441,7 @@ describe('PaymentHandler', () => {
           result: undefined,
         });
 
-      const result = await handler.payInvoice(swap, undefined);
+      const result = await handler.payInvoice(swap);
 
       expect(
         handler['selfPaymentClient'].handleSelfPayment,
@@ -491,7 +464,7 @@ describe('PaymentHandler', () => {
       const abandonSwapSpy = jest.spyOn(handler as any, 'abandonSwap');
       abandonSwapSpy.mockResolvedValue(undefined);
 
-      const result = await handler.payInvoice(swap, undefined);
+      const result = await handler.payInvoice(swap);
 
       expect(result).toBeUndefined();
       expect(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for LND onion messaging API

* **Bug Fixes & Improvements**
  * Updated payment routing logic to improve fee management

* **Chores**
  * Upgraded Go to 1.26.4, C-Lightning to 26.06.1, and LND to 0.21.0-beta
  * Updated supported version bounds for CLN and LND clients
  * Removed deprecated LND payment APIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->