### PR TITLE
chore: lower arbitrum event rescan interval and add logging

### DIFF
--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -32,6 +32,7 @@ import SwapRepository from '../db/repositories/SwapRepository';
 import type Wallet from '../wallet/Wallet';
 import type WalletManager from '../wallet/WalletManager';
 import type EthereumManager from '../wallet/ethereum/EthereumManager';
+import type { ContractEventSource } from '../wallet/ethereum/contracts/ContractEventHandler';
 import type ERC20WalletProvider from '../wallet/providers/ERC20WalletProvider';
 import Errors from './Errors';
 import EthereumTransactionConfirmationTracker from './EthereumConfirmationTracker';
@@ -160,6 +161,7 @@ class EthereumNursery extends TypedEventEmitter<{
     transaction: Transaction | TransactionResponse,
     etherSwapValues: EtherSwapValues,
     options?: UserLockupTransactionOptions,
+    source?: ContractEventSource,
   ) => {
     if (
       this.getSwapReceivingCurrency(swap) !==
@@ -169,7 +171,7 @@ class EthereumNursery extends TypedEventEmitter<{
     }
 
     this.logger.debug(
-      `Found lockup in ${this.ethereumManager.networkDetails.name} EtherSwap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
+      `Found lockup in ${this.ethereumManager.networkDetails.name} EtherSwap contract${this.formatEventSource(source)} for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
     );
 
     const lockupAmount = Number(etherSwapValues.amount / etherDecimals);
@@ -294,6 +296,7 @@ class EthereumNursery extends TypedEventEmitter<{
     transaction: Transaction | TransactionResponse,
     erc20SwapValues: ERC20SwapValues,
     options?: UserLockupTransactionOptions,
+    source?: ContractEventSource,
   ) => {
     const wallet = this.walletManager.wallets.get(
       this.getSwapReceivingCurrency(swap),
@@ -305,7 +308,7 @@ class EthereumNursery extends TypedEventEmitter<{
     const erc20Wallet = wallet.walletProvider as ERC20WalletProvider;
 
     this.logger.debug(
-      `Found lockup in ${this.ethereumManager.networkDetails.name} ERC20Swap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
+      `Found lockup in ${this.ethereumManager.networkDetails.name} ERC20Swap contract${this.formatEventSource(source)} for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
     );
 
     const lockupAmount = erc20Wallet.normalizeTokenAmount(
@@ -441,7 +444,7 @@ class EthereumNursery extends TypedEventEmitter<{
   private listenEtherSwap = () => {
     this.ethereumManager.contractEventHandler.on(
       'eth.lockup',
-      async ({ transaction, etherSwapValues }) => {
+      async ({ source, transaction, etherSwapValues }) => {
         const swaps = await Promise.all([
           SwapRepository.getSwap({
             preimageHash: getHexString(etherSwapValues.preimageHash),
@@ -459,14 +462,20 @@ class EthereumNursery extends TypedEventEmitter<{
         ]);
 
         for (const swap of swaps.filter((s) => s !== null)) {
-          await this.checkEtherSwapLockup(swap!, transaction, etherSwapValues);
+          await this.checkEtherSwapLockup(
+            swap!,
+            transaction,
+            etherSwapValues,
+            undefined,
+            source,
+          );
         }
       },
     );
 
     this.ethereumManager.contractEventHandler.on(
       'eth.claim',
-      async ({ transactionHash, preimageHash, preimage }) => {
+      async ({ source, transactionHash, preimageHash, preimage }) => {
         const swaps = await Promise.all([
           ReverseSwapRepository.getReverseSwap({
             preimageHash: getHexString(preimageHash),
@@ -490,7 +499,7 @@ class EthereumNursery extends TypedEventEmitter<{
           }
 
           this.logger.debug(
-            `Found claim in ${this.ethereumManager.networkDetails.name} EtherSwap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
+            `Found claim in ${this.ethereumManager.networkDetails.name} EtherSwap contract${this.formatEventSource(source)} for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
           );
 
           this.emit('claim', {
@@ -513,7 +522,7 @@ class EthereumNursery extends TypedEventEmitter<{
   private listenERC20Swap = () => {
     this.ethereumManager.contractEventHandler.on(
       'erc20.lockup',
-      async ({ transaction, erc20SwapValues }) => {
+      async ({ source, transaction, erc20SwapValues }) => {
         const swaps = await Promise.all([
           SwapRepository.getSwap({
             preimageHash: getHexString(erc20SwapValues.preimageHash),
@@ -531,14 +540,20 @@ class EthereumNursery extends TypedEventEmitter<{
         ]);
 
         for (const swap of swaps.filter((s) => s !== null)) {
-          await this.checkErc20SwapLockup(swap!, transaction, erc20SwapValues);
+          await this.checkErc20SwapLockup(
+            swap!,
+            transaction,
+            erc20SwapValues,
+            undefined,
+            source,
+          );
         }
       },
     );
 
     this.ethereumManager.contractEventHandler.on(
       'erc20.claim',
-      async ({ transactionHash, preimageHash, preimage }) => {
+      async ({ source, transactionHash, preimageHash, preimage }) => {
         const swaps: (ReverseSwap | ChainSwapInfo | null)[] = await Promise.all(
           [
             ReverseSwapRepository.getReverseSwap({
@@ -564,7 +579,7 @@ class EthereumNursery extends TypedEventEmitter<{
           }
 
           this.logger.debug(
-            `Found claim in ${this.ethereumManager.networkDetails.name} ERC20Swap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
+            `Found claim in ${this.ethereumManager.networkDetails.name} ERC20Swap contract${this.formatEventSource(source)} for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
           );
 
           this.emit('claim', {
@@ -739,6 +754,9 @@ class EthereumNursery extends TypedEventEmitter<{
       ? sendingWallet.symbol === this.ethereumManager.networkDetails.symbol
       : sendingWallet.type === CurrencyType.ERC20;
   };
+
+  private formatEventSource = (source?: ContractEventSource) =>
+    source === undefined ? '' : ` via ${source}`;
 
   /**
    * Returns a wallet in case there is one with the symbol, and it is an Ethereum one

--- a/lib/wallet/ethereum/WebSocketProvider.ts
+++ b/lib/wallet/ethereum/WebSocketProvider.ts
@@ -48,6 +48,9 @@ class ReconnectingWebSocket
     if (this.ws?.readyState !== WebSocket.OPEN) {
       throw new Error('WebSocket is not connected');
     }
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} send: ${this.formatFrame(payload)}`,
+    );
     this.ws.send(payload);
   };
 
@@ -73,6 +76,9 @@ class ReconnectingWebSocket
     const isReconnecting = this.reconnectAttempts > 0;
 
     try {
+      this.logger.debug(
+        `${this.symbol} WebSocket ${this.name} opening connection${isReconnecting ? ` after ${this.reconnectAttempts} reconnect attempt(s)` : ''}`,
+      );
       this.ws = new WebSocket(this.endpoint);
 
       this.ws.onopen = (event) => {
@@ -93,6 +99,9 @@ class ReconnectingWebSocket
       };
 
       this.ws.onmessage = (event) => {
+        this.logger.debug(
+          `${this.symbol} WebSocket ${this.name} recv: ${this.formatFrame(event.data)}`,
+        );
         if (this.onmessage) {
           this.onmessage(event);
         }
@@ -146,6 +155,37 @@ class ReconnectingWebSocket
       this.connect();
     }, ReconnectingWebSocket.reconnectDelay);
   };
+
+  private formatFrame = (payload: unknown): string => {
+    const data = this.frameToString(payload);
+    const bytes = Buffer.byteLength(data);
+
+    return `${this.truncate(data)}; bytes=${bytes}`;
+  };
+
+  private frameToString = (payload: unknown): string => {
+    if (typeof payload === 'string') {
+      return payload;
+    }
+    if (Buffer.isBuffer(payload)) {
+      return payload.toString();
+    }
+    if (payload instanceof ArrayBuffer) {
+      return Buffer.from(payload).toString();
+    }
+    if (ArrayBuffer.isView(payload)) {
+      return Buffer.from(
+        payload.buffer,
+        payload.byteOffset,
+        payload.byteLength,
+      ).toString();
+    }
+
+    return String(payload);
+  };
+
+  private truncate = (value: string) =>
+    value.length > 1_000 ? `${value.slice(0, 1_000)}...` : value;
 }
 
 class WebSocketProvider extends EthersWebSocketProvider {

--- a/lib/wallet/ethereum/WebSocketProvider.ts
+++ b/lib/wallet/ethereum/WebSocketProvider.ts
@@ -76,10 +76,14 @@ class ReconnectingWebSocket
       this.ws = new WebSocket(this.endpoint);
 
       this.ws.onopen = (event) => {
+        const reconnectAttempts = this.reconnectAttempts;
         this.reconnectAttempts = 0;
         this.logger.info(`${this.symbol} WebSocket ${this.name} connected`);
 
         if (isReconnecting) {
+          this.logger.debug(
+            `${this.symbol} WebSocket ${this.name} reconnected after ${reconnectAttempts} attempt(s)`,
+          );
           this.emit('reconnected', undefined);
         }
 
@@ -151,7 +155,12 @@ class WebSocketProvider extends EthersWebSocketProvider {
   private registeredOnceListeners = new Map<ProviderEvent, Set<Listener>>();
   private onceWrappedListeners = new Map<Listener, Listener>();
 
-  constructor(logger: Logger, symbol: string, name: string, endpoint: string) {
+  constructor(
+    private readonly logger: Logger,
+    private readonly symbol: string,
+    private readonly name: string,
+    endpoint: string,
+  ) {
     const ws = new ReconnectingWebSocket(endpoint, logger, symbol, name);
 
     super(ws, undefined, {
@@ -172,6 +181,9 @@ class WebSocketProvider extends EthersWebSocketProvider {
     this.registeredListeners.get(event)!.add(listener);
 
     await super.on(event, listener);
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} registered listener for ${this.formatProviderEvent(event)} (${this.countRegisteredListeners(this.registeredListeners)} persistent, ${this.countRegisteredListeners(this.registeredOnceListeners)} once)`,
+    );
     return this;
   }
 
@@ -192,6 +204,9 @@ class WebSocketProvider extends EthersWebSocketProvider {
     this.onceWrappedListeners.set(listener, wrappedListener);
 
     await super.once(event, wrappedListener);
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} registered once listener for ${this.formatProviderEvent(event)} (${this.countRegisteredListeners(this.registeredListeners)} persistent, ${this.countRegisteredListeners(this.registeredOnceListeners)} once)`,
+    );
     return this;
   }
 
@@ -259,6 +274,17 @@ class WebSocketProvider extends EthersWebSocketProvider {
   }
 
   private reregisterListeners = async (): Promise<void> => {
+    const persistentListeners = this.countRegisteredListeners(
+      this.registeredListeners,
+    );
+    const onceListeners = this.countRegisteredListeners(
+      this.registeredOnceListeners,
+    );
+
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} re-registering ${persistentListeners} persistent listener(s) and ${onceListeners} once listener(s) after reconnect`,
+    );
+
     await super.removeAllListeners();
 
     for (const [event, listenerSet] of this.registeredListeners) {
@@ -281,6 +307,31 @@ class WebSocketProvider extends EthersWebSocketProvider {
     }
 
     this.resume();
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} re-registered ${persistentListeners} persistent listener(s) and ${onceListeners} once listener(s) after reconnect`,
+    );
+  };
+
+  private countRegisteredListeners = (
+    listeners: Map<ProviderEvent, Set<Listener>>,
+  ) =>
+    Array.from(listeners.values()).reduce(
+      (sum, listenerSet) => sum + listenerSet.size,
+      0,
+    );
+
+  private formatProviderEvent = (event: ProviderEvent): string => {
+    if (typeof event === 'string') {
+      return event;
+    }
+
+    try {
+      return JSON.stringify(event, (_, value) =>
+        typeof value === 'bigint' ? value.toString() : value,
+      );
+    } catch {
+      return String(event);
+    }
   };
 }
 

--- a/lib/wallet/ethereum/WebSocketProvider.ts
+++ b/lib/wallet/ethereum/WebSocketProvider.ts
@@ -221,9 +221,6 @@ class WebSocketProvider extends EthersWebSocketProvider {
     this.registeredListeners.get(event)!.add(listener);
 
     await super.on(event, listener);
-    this.logger.debug(
-      `${this.symbol} WebSocket ${this.name} registered listener for ${this.formatProviderEvent(event)} (${this.countRegisteredListeners(this.registeredListeners)} persistent, ${this.countRegisteredListeners(this.registeredOnceListeners)} once)`,
-    );
     return this;
   }
 
@@ -244,9 +241,6 @@ class WebSocketProvider extends EthersWebSocketProvider {
     this.onceWrappedListeners.set(listener, wrappedListener);
 
     await super.once(event, wrappedListener);
-    this.logger.debug(
-      `${this.symbol} WebSocket ${this.name} registered once listener for ${this.formatProviderEvent(event)} (${this.countRegisteredListeners(this.registeredListeners)} persistent, ${this.countRegisteredListeners(this.registeredOnceListeners)} once)`,
-    );
     return this;
   }
 
@@ -314,17 +308,6 @@ class WebSocketProvider extends EthersWebSocketProvider {
   }
 
   private reregisterListeners = async (): Promise<void> => {
-    const persistentListeners = this.countRegisteredListeners(
-      this.registeredListeners,
-    );
-    const onceListeners = this.countRegisteredListeners(
-      this.registeredOnceListeners,
-    );
-
-    this.logger.debug(
-      `${this.symbol} WebSocket ${this.name} re-registering ${persistentListeners} persistent listener(s) and ${onceListeners} once listener(s) after reconnect`,
-    );
-
     await super.removeAllListeners();
 
     for (const [event, listenerSet] of this.registeredListeners) {
@@ -347,31 +330,6 @@ class WebSocketProvider extends EthersWebSocketProvider {
     }
 
     this.resume();
-    this.logger.debug(
-      `${this.symbol} WebSocket ${this.name} re-registered ${persistentListeners} persistent listener(s) and ${onceListeners} once listener(s) after reconnect`,
-    );
-  };
-
-  private countRegisteredListeners = (
-    listeners: Map<ProviderEvent, Set<Listener>>,
-  ) =>
-    Array.from(listeners.values()).reduce(
-      (sum, listenerSet) => sum + listenerSet.size,
-      0,
-    );
-
-  private formatProviderEvent = (event: ProviderEvent): string => {
-    if (typeof event === 'string') {
-      return event;
-    }
-
-    try {
-      return JSON.stringify(event, (_, value) =>
-        typeof value === 'bigint' ? value.toString() : value,
-      );
-    } catch {
-      return String(event);
-    }
   };
 }
 

--- a/lib/wallet/ethereum/WebSocketProvider.ts
+++ b/lib/wallet/ethereum/WebSocketProvider.ts
@@ -48,9 +48,6 @@ class ReconnectingWebSocket
     if (this.ws?.readyState !== WebSocket.OPEN) {
       throw new Error('WebSocket is not connected');
     }
-    this.logger.debug(
-      `${this.symbol} WebSocket ${this.name} send: ${this.formatFrame(payload)}`,
-    );
     this.ws.send(payload);
   };
 
@@ -99,9 +96,6 @@ class ReconnectingWebSocket
       };
 
       this.ws.onmessage = (event) => {
-        this.logger.debug(
-          `${this.symbol} WebSocket ${this.name} recv: ${this.formatFrame(event.data)}`,
-        );
         if (this.onmessage) {
           this.onmessage(event);
         }
@@ -155,37 +149,6 @@ class ReconnectingWebSocket
       this.connect();
     }, ReconnectingWebSocket.reconnectDelay);
   };
-
-  private formatFrame = (payload: unknown): string => {
-    const data = this.frameToString(payload);
-    const bytes = Buffer.byteLength(data);
-
-    return `${this.truncate(data)}; bytes=${bytes}`;
-  };
-
-  private frameToString = (payload: unknown): string => {
-    if (typeof payload === 'string') {
-      return payload;
-    }
-    if (Buffer.isBuffer(payload)) {
-      return payload.toString();
-    }
-    if (payload instanceof ArrayBuffer) {
-      return Buffer.from(payload).toString();
-    }
-    if (ArrayBuffer.isView(payload)) {
-      return Buffer.from(
-        payload.buffer,
-        payload.byteOffset,
-        payload.byteLength,
-      ).toString();
-    }
-
-    return String(payload);
-  };
-
-  private truncate = (value: string) =>
-    value.length > 1_000 ? `${value.slice(0, 1_000)}...` : value;
 }
 
 class WebSocketProvider extends EthersWebSocketProvider {
@@ -195,7 +158,12 @@ class WebSocketProvider extends EthersWebSocketProvider {
   private registeredOnceListeners = new Map<ProviderEvent, Set<Listener>>();
   private onceWrappedListeners = new Map<Listener, Listener>();
 
-  constructor(logger: Logger, symbol: string, name: string, endpoint: string) {
+  constructor(
+    private readonly logger: Logger,
+    private readonly symbol: string,
+    private readonly name: string,
+    endpoint: string,
+  ) {
     const ws = new ReconnectingWebSocket(endpoint, logger, symbol, name);
 
     super(ws, undefined, {
@@ -216,6 +184,9 @@ class WebSocketProvider extends EthersWebSocketProvider {
     this.registeredListeners.get(event)!.add(listener);
 
     await super.on(event, listener);
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} registered listener for ${this.formatProviderEvent(event)} (${this.countRegisteredListeners(this.registeredListeners)} persistent, ${this.countRegisteredListeners(this.registeredOnceListeners)} once)`,
+    );
     return this;
   }
 
@@ -236,6 +207,9 @@ class WebSocketProvider extends EthersWebSocketProvider {
     this.onceWrappedListeners.set(listener, wrappedListener);
 
     await super.once(event, wrappedListener);
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} registered once listener for ${this.formatProviderEvent(event)} (${this.countRegisteredListeners(this.registeredListeners)} persistent, ${this.countRegisteredListeners(this.registeredOnceListeners)} once)`,
+    );
     return this;
   }
 
@@ -303,6 +277,17 @@ class WebSocketProvider extends EthersWebSocketProvider {
   }
 
   private reregisterListeners = async (): Promise<void> => {
+    const persistentListeners = this.countRegisteredListeners(
+      this.registeredListeners,
+    );
+    const onceListeners = this.countRegisteredListeners(
+      this.registeredOnceListeners,
+    );
+
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} re-registering ${persistentListeners} persistent listener(s) and ${onceListeners} once listener(s) after reconnect`,
+    );
+
     await super.removeAllListeners();
 
     for (const [event, listenerSet] of this.registeredListeners) {
@@ -325,6 +310,31 @@ class WebSocketProvider extends EthersWebSocketProvider {
     }
 
     this.resume();
+    this.logger.debug(
+      `${this.symbol} WebSocket ${this.name} re-registered ${persistentListeners} persistent listener(s) and ${onceListeners} once listener(s) after reconnect`,
+    );
+  };
+
+  private countRegisteredListeners = (
+    listeners: Map<ProviderEvent, Set<Listener>>,
+  ) =>
+    Array.from(listeners.values()).reduce(
+      (sum, listenerSet) => sum + listenerSet.size,
+      0,
+    );
+
+  private formatProviderEvent = (event: ProviderEvent): string => {
+    if (typeof event === 'string') {
+      return event;
+    }
+
+    try {
+      return JSON.stringify(event, (_, value) =>
+        typeof value === 'bigint' ? value.toString() : value,
+      );
+    } catch {
+      return String(event);
+    }
   };
 }
 

--- a/lib/wallet/ethereum/WebSocketProvider.ts
+++ b/lib/wallet/ethereum/WebSocketProvider.ts
@@ -195,12 +195,7 @@ class WebSocketProvider extends EthersWebSocketProvider {
   private registeredOnceListeners = new Map<ProviderEvent, Set<Listener>>();
   private onceWrappedListeners = new Map<Listener, Listener>();
 
-  constructor(
-    private readonly logger: Logger,
-    private readonly symbol: string,
-    private readonly name: string,
-    endpoint: string,
-  ) {
+  constructor(logger: Logger, symbol: string, name: string, endpoint: string) {
     const ws = new ReconnectingWebSocket(endpoint, logger, symbol, name);
 
     super(ws, undefined, {

--- a/lib/wallet/ethereum/contracts/ContractEventHandler.ts
+++ b/lib/wallet/ethereum/contracts/ContractEventHandler.ts
@@ -17,11 +17,13 @@ import { formatERC20SwapValues, formatEtherSwapValues } from './ContractUtils';
 type Events = {
   // EtherSwap contract events
   'eth.lockup': {
+    source?: ContractEventSource;
     version: bigint;
     transaction: Transaction | TransactionResponse;
     etherSwapValues: EtherSwapValues;
   };
   'eth.claim': {
+    source?: ContractEventSource;
     version: bigint;
     transactionHash: string;
     preimageHash: Buffer;
@@ -30,11 +32,13 @@ type Events = {
 
   // ERC20Swap contract events
   'erc20.lockup': {
+    source?: ContractEventSource;
     version: bigint;
     transaction: Transaction | TransactionResponse;
     erc20SwapValues: ERC20SwapValues;
   };
   'erc20.claim': {
+    source?: ContractEventSource;
     version: bigint;
     transactionHash: string;
     preimageHash: Buffer;
@@ -42,9 +46,12 @@ type Events = {
   };
 };
 
+type ContractEventSource = 'live' | 'manual' | 'rescan';
+type ContractName = 'ERC20Swap' | 'EtherSwap';
+type ContractEventName = 'Claim' | 'Lockup';
+
 class ContractEventHandler extends TypedEventEmitter<Events> {
-  // Check for missed events every 5 minutes
-  private static readonly missedEventsCheckInterval = 1_000 * 60 * 5;
+  private static readonly missedEventsCheckInterval = 1_000 * 60;
 
   private version!: bigint;
 
@@ -107,22 +114,56 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
   public rescan = async (
     startHeight: number,
     endHeight?: number,
+    source: ContractEventSource = 'rescan',
   ): Promise<void> => {
-    const [etherLockups, etherClaims] = await Promise.all([
-      this.etherSwap.queryFilter(
-        this.etherSwap.filters.Lockup(),
-        startHeight,
-        endHeight,
-      ),
-      this.etherSwap.queryFilter(
-        this.etherSwap.filters.Claim(),
-        startHeight,
-        endHeight,
-      ),
-    ]);
+    const [etherLockups, etherClaims, erc20Lockups, erc20Claims] =
+      await Promise.all([
+        this.etherSwap.queryFilter(
+          this.etherSwap.filters.Lockup(),
+          startHeight,
+          endHeight,
+        ),
+        this.etherSwap.queryFilter(
+          this.etherSwap.filters.Claim(),
+          startHeight,
+          endHeight,
+        ),
+        this.erc20Swap.queryFilter(
+          this.erc20Swap.filters.Lockup(),
+          startHeight,
+          endHeight,
+        ),
+        this.erc20Swap.queryFilter(
+          this.erc20Swap.filters.Claim(),
+          startHeight,
+          endHeight,
+        ),
+      ]);
+
+    const totalEvents =
+      etherLockups.length +
+      etherClaims.length +
+      erc20Lockups.length +
+      erc20Claims.length;
+
+    if (totalEvents > 0) {
+      this.logger.debug(
+        `${this.networkDetails.name} contracts v${this.version} found ${totalEvents} event(s) via ${source} from block ${startHeight} to ${endHeight ?? 'latest'}: eth.lockup=${etherLockups.length}, eth.claim=${etherClaims.length}, erc20.lockup=${erc20Lockups.length}, erc20.claim=${erc20Claims.length}`,
+      );
+    }
 
     for (const event of etherLockups) {
+      this.logContractEvent(
+        source,
+        'EtherSwap',
+        'Lockup',
+        event.transactionHash,
+        event.blockNumber,
+        event.index,
+        parseBuffer(event.topics[1]),
+      );
       this.emit('eth.lockup', {
+        source,
         version: this.version,
         transaction: await event.getTransaction(),
         etherSwapValues: formatEtherSwapValues(event.args!),
@@ -130,29 +171,37 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
     }
 
     for (const event of etherClaims) {
+      const preimageHash = parseBuffer(event.topics[1]);
+      this.logContractEvent(
+        source,
+        'EtherSwap',
+        'Claim',
+        event.transactionHash,
+        event.blockNumber,
+        event.index,
+        preimageHash,
+      );
       this.emit('eth.claim', {
+        source,
         version: this.version,
         transactionHash: event.transactionHash,
-        preimageHash: parseBuffer(event.topics[1]),
+        preimageHash,
         preimage: parseBuffer(event.args!.preimage),
       });
     }
 
-    const [erc20Lockups, erc20Claims] = await Promise.all([
-      this.erc20Swap.queryFilter(
-        this.erc20Swap.filters.Lockup(),
-        startHeight,
-        endHeight,
-      ),
-      this.erc20Swap.queryFilter(
-        this.erc20Swap.filters.Claim(),
-        startHeight,
-        endHeight,
-      ),
-    ]);
-
     for (const event of erc20Lockups) {
+      this.logContractEvent(
+        source,
+        'ERC20Swap',
+        'Lockup',
+        event.transactionHash,
+        event.blockNumber,
+        event.index,
+        parseBuffer(event.topics[1]),
+      );
       this.emit('erc20.lockup', {
+        source,
         version: this.version,
         transaction: await event.getTransaction(),
         erc20SwapValues: formatERC20SwapValues(event.args!),
@@ -160,10 +209,21 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
     }
 
     for (const event of erc20Claims) {
+      const preimageHash = parseBuffer(event.topics[1]);
+      this.logContractEvent(
+        source,
+        'ERC20Swap',
+        'Claim',
+        event.transactionHash,
+        event.blockNumber,
+        event.index,
+        preimageHash,
+      );
       this.emit('erc20.claim', {
+        source,
         version: this.version,
         transactionHash: event.transactionHash,
-        preimageHash: parseBuffer(event.topics[1]),
+        preimageHash,
         preimage: parseBuffer(event.args!.preimage),
       });
     }
@@ -177,7 +237,7 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
 
     // Rescan from the block before to the one after the transaction
     // Just easier than trying to filter events from the tx itself
-    await this.rescan(tx.blockNumber - 1, tx.blockNumber + 1);
+    await this.rescan(tx.blockNumber - 1, tx.blockNumber + 1, 'manual');
   };
 
   public checkMissedEvents = async () => {
@@ -192,15 +252,16 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
         this.missedEventsCheckPending = false;
 
         const startHeight = this.rescanLastHeight;
-        this.logger.debug(
-          `Checking for missed events of ${this.networkDetails.name} contracts v${this.version} from block ${startHeight}`,
-        );
-
         const currentHeight = Math.max(
           await this.provider.getBlockNumber(),
           startHeight,
         );
-        await this.rescan(startHeight, currentHeight);
+
+        this.logger.debug(
+          `Checking for missed events of ${this.networkDetails.name} contracts v${this.version} from block ${startHeight} to ${currentHeight}`,
+        );
+
+        await this.rescan(startHeight, currentHeight, 'rescan');
         this.rescanLastHeight = currentHeight;
       }
     })().finally(() => {
@@ -209,6 +270,22 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
 
     return this.missedEventsCheckPromise;
   };
+
+  private logContractEvent = (
+    source: ContractEventSource,
+    contract: ContractName,
+    eventName: ContractEventName,
+    transactionHash: string,
+    blockNumber: number,
+    logIndex: number,
+    preimageHash: Buffer,
+  ) => {
+    this.logger.debug(
+      `${this.networkDetails.name} contracts v${this.version} ${contract} ${eventName} event via ${source}: tx=${transactionHash}, block=${blockNumber}, logIndex=${logIndex}, preimageHash=${ContractEventHandler.formatHex(preimageHash)}`,
+    );
+  };
+
+  private static formatHex = (value: Buffer) => `0x${value.toString('hex')}`;
 
   private subscribeContractEvents = async () => {
     await this.etherSwap.on(
@@ -221,7 +298,17 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
         timelock: bigint,
         event: ContractEventPayload,
       ) => {
+        this.logContractEvent(
+          'live',
+          'EtherSwap',
+          'Lockup',
+          event.log.transactionHash,
+          event.log.blockNumber,
+          event.log.index,
+          parseBuffer(preimageHash),
+        );
         this.emit('eth.lockup', {
+          source: 'live',
           version: this.version,
           transaction: await event.log.getTransaction(),
           etherSwapValues: {
@@ -238,7 +325,17 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
     await this.etherSwap.on(
       'Claim' as any,
       (preimageHash: string, preimage: string, event: ContractEventPayload) => {
+        this.logContractEvent(
+          'live',
+          'EtherSwap',
+          'Claim',
+          event.log.transactionHash,
+          event.log.blockNumber,
+          event.log.index,
+          parseBuffer(preimageHash),
+        );
         this.emit('eth.claim', {
+          source: 'live',
           version: this.version,
           transactionHash: event.log.transactionHash,
           preimageHash: parseBuffer(preimageHash),
@@ -258,7 +355,17 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
         timelock: bigint,
         event: ContractEventPayload,
       ) => {
+        this.logContractEvent(
+          'live',
+          'ERC20Swap',
+          'Lockup',
+          event.log.transactionHash,
+          event.log.blockNumber,
+          event.log.index,
+          parseBuffer(preimageHash),
+        );
         this.emit('erc20.lockup', {
+          source: 'live',
           version: this.version,
           transaction: await event.log.getTransaction(),
           erc20SwapValues: {
@@ -276,7 +383,17 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
     await this.erc20Swap.on(
       'Claim' as any,
       (preimageHash: string, preimage: string, event: ContractEventPayload) => {
+        this.logContractEvent(
+          'live',
+          'ERC20Swap',
+          'Claim',
+          event.log.transactionHash,
+          event.log.blockNumber,
+          event.log.index,
+          parseBuffer(preimageHash),
+        );
         this.emit('erc20.claim', {
+          source: 'live',
           version: this.version,
           transactionHash: event.log.transactionHash,
           preimageHash: parseBuffer(preimageHash),
@@ -288,4 +405,4 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
 }
 
 export default ContractEventHandler;
-export { Events };
+export { type ContractEventSource, Events };

--- a/test/integration/service/TimeoutDeltaProvider.spec.ts
+++ b/test/integration/service/TimeoutDeltaProvider.spec.ts
@@ -153,7 +153,7 @@ describe('TimeoutDeltaProvider', () => {
         OrderSide.SELL,
         SwapType.Submarine,
         SwapVersion.Legacy,
-        await createInvoice(18),
+        await createInvoice(24),
       ),
     ).resolves.toEqual([
       timeoutDelta.swapMinimal / TimeoutDeltaProvider.blockTimes.get(base)!,

--- a/test/unit/wallet/ethereum/contracts/ContractEventHandler.spec.ts
+++ b/test/unit/wallet/ethereum/contracts/ContractEventHandler.spec.ts
@@ -61,11 +61,11 @@ describe('ContractEventHandler missed event checks', () => {
     await Promise.all([firstCheck, secondCheck, thirdCheck]);
 
     expect(rescan).toHaveBeenCalledTimes(2);
-    expect(rescan).toHaveBeenNthCalledWith(1, 100, 101);
-    expect(rescan).toHaveBeenNthCalledWith(2, 101, 105);
+    expect(rescan).toHaveBeenNthCalledWith(1, 100, 101, 'rescan');
+    expect(rescan).toHaveBeenNthCalledWith(2, 101, 105, 'rescan');
     expect(mockLogger.debug).toHaveBeenNthCalledWith(
       2,
-      'Checking for missed events of Arbitrum contracts v6 from block 101',
+      'Checking for missed events of Arbitrum contracts v6 from block 101 to 105',
     );
 
     handler.destroy();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap and contract events now include an event-source (live, manual, rescan) so logs and emitted events show origin; swap/claim logging reflects source.
  * Rescan now queries all event types in parallel and logs a summary.

* **Performance**
  * Missed-event polling shortened from 5 minutes to 1 minute for faster detection.

* **Improvements**
  * Websocket/debug logging improved with clearer reconnect and listener summaries.

* **Tests**
  * Unit tests updated to assert rescan source and adjusted debug expectations.

* **Chores**
  * Updated regtest pointer to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->