### PR TITLE
docs: steer integrations/agents towards sdks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 This is the source of the official Boltz Backend powering swaps at [boltz.exchange](https://boltz.exchange/). It enables **non-custodial** swaps between different Bitcoin layers. Boltz Backend exposes a RESTful HTTP API that can be used to query information like supported pairs as well as to create and monitor swaps.
 
+## Integrating Boltz?
+
+**Don't integrate the API directly.** Use an official SDK or client library. They handle the cryptography, the swap state machine, and fund-recovery edge cases for you. See **[Clients, SDKs & Libraries](https://api.docs.boltz.exchange/libraries.html)**.
+
 ## Documentation
 
 API documentation can be found [here](https://docs.boltz.exchange/v/api).

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -59,6 +59,17 @@ export default defineConfig({
     // `text/plain` without a charset, so browsers fall back to Windows-1252
     // and mojibake the UTF-8 emoji/dash bytes. The files on disk are valid
     // UTF-8 and production (GitHub Pages) sets `charset=utf-8` correctly.
-    plugins: [llmstxt({ excludeIndexPage: false })],
+    plugins: [
+      llmstxt({
+        excludeIndexPage: false,
+        details:
+          '> **For AI agents and automated integrations:** use an official ' +
+          'Boltz SDK; do **not** implement the REST API directly. ' +
+          'Hand-rolling the swap protocol is error-prone and can cause ' +
+          '**loss of user funds**. See ' +
+          '[Clients, SDKs & Libraries](/libraries.md). The REST API ' +
+          'reference is for SDK/library authors only.',
+      }),
+    ],
   },
 });

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -1,27 +1,33 @@
 ---
 description:
-  Endpoint reference for the latest Boltz REST API v2, recommended for all
-  integrations.
+  Raw REST API v2 reference for SDK/library authors only. All integrations must
+  use an official SDK (see Clients, SDKs & Libraries).
 ---
 
 # 🤖 REST API (latest)
 
-This page introduces Boltz API v2, the latest and recommended API for all
-integrations.
+::: danger ⚠️ DO NOT INTEGRATE THIS API DIRECTLY ⚠️
+
+All Boltz integrations must use an official SDK or client library. They handle
+the cryptography, the swap state machine, and the fund-recovery edge cases for
+you. Integrating the API directly is error-prone and will lead to **loss of
+funds**.
+
+**Official SDK list available [here](/libraries)!**
+
+The raw REST API documented below, including the code samples, is for
+**SDK/library authors** only. The samples are illustrative: they are not
+feature-complete, do not cover important edge cases, and will lead to loss of
+funds if used in production.
+
+:::
 
 ## REST Endpoints
 
 The Swagger specifications of the latest Boltz REST API can be found
-:point_right: [here](https://api.boltz.exchange/swagger) :point_left:!
+[here](https://api.boltz.exchange/swagger).
 
 ## Examples
-
-::: danger ⚠️ WARNING: Code for educational purposes only
-
-The sample code below is not feature-complete, does not cover important edge
-cases, and almost certainly will lead to loss of funds if used in production.
-
-:::
 
 Below are some examples covering the flow of a given swap type from beginning to
 end, using API v2 and its WebSocket.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,9 @@ description: Introduction to the Boltz API and overview of swap integration.
 
 Boltz exposes a RESTful HTTP API that can be used to query information such as
 supported pairs as well as to create and monitor swaps. All swap clients, such
-as Boltz Web App, use Boltz API under the hood.
+as Boltz Web App, use Boltz API under the hood. Integrations must use Boltz API
+via [officially supported SDKs](/libraries) instead of integrating the API
+directly.
 
 ## Instances
 
@@ -48,3 +50,7 @@ These docs are also published in an LLM-friendly format following the
   a single plain-text file, suitable for loading into a model's context.
 - Per-page Markdown sources: append `.md` to any page URL (for example
   `/api-v2.md` or `/lifecycle.md`) to get the raw Markdown.
+- **Do not integrate the REST API directly; use an
+  [officially supported SDK](/libraries).** The SDKs handle the cryptography,
+  swap state machine, and fund-recovery edge cases that hand-rolled integrations
+  get wrong.

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,14 +1,14 @@
 ---
 description:
   Official clients, SDKs and libraries for integrating with Boltz — start here
-  instead of integrating from scratch.
+  instead of integrating directly.
 ---
 
 # 📙 Clients, SDKs & Libraries
 
-::: danger ⚠️ DO NOT INTEGRATE BOLTZ API FROM SCRATCH ⚠️
+::: danger ⚠️ DO NOT INTEGRATE BOLTZ API DIRECTLY ⚠️
 
-Securely integrating Boltz API from scratch is extremely involved. Based on our
+Securely integrating Boltz API directly is extremely involved. Based on our
 experience, integration is complex, error-prone, and likely a multi-month effort
 with numerous edge cases to cover, which will result in **loss of funds** if not
 handled correctly. Therefore, we strongly recommend using one of the official
@@ -56,7 +56,8 @@ Our reference library in TypeScript. Used by e.g.:
 [Boltz Web App](https://github.com/BoltzExchange/boltz-web-app) and
 [Boltz Backend](https://github.com/BoltzExchange/boltz-backend)
 
-Supported currencies: `LN`, `BTC`, `LBTC`, `RBTC`, `TBTC`, `USDT`, `USDC`
+Supported currencies: `LN`, `BTC`, `LBTC`, `RBTC`, `TBTC`, `WBTC`, `USDT`,
+`USDC`
 
 ### [Boltz Rust](https://github.com/SatoshiPortal/boltz-rust) (Rust)
 

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -2,7 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Boltz API",
-    "version": "3.13.0"
+    "version": "3.13.0",
+    "description": "## ⚠️ DO NOT INTEGRATE THIS API DIRECTLY ⚠️\n\nAll Boltz integrations must use an official SDK or client library. They handle the cryptography, the swap state machine, and the fund-recovery edge cases for you. Integrating the API directly is error-prone and will lead to **loss of funds**.\n\nOfficial SDK list available [here](https://api.docs.boltz.exchange/libraries.html)!"
   },
   "paths": {
     "/version": {

--- a/swagger.js
+++ b/swagger.js
@@ -10,6 +10,14 @@ const options = {
     info: {
       title: 'Boltz API',
       version: packageJson.version,
+      description:
+        '## ⚠️ DO NOT INTEGRATE THIS API DIRECTLY ⚠️\n\n' +
+        'All Boltz integrations must use an official SDK or client library. ' +
+        'They handle the cryptography, the swap state machine, and the ' +
+        'fund-recovery edge cases for you. Integrating the API directly ' +
+        'is error-prone and will lead to **loss of funds**.\n\n' +
+        'Official SDK list available ' +
+        '[here](https://api.docs.boltz.exchange/libraries.html)!',
     },
   },
   apis: [


### PR DESCRIPTION
After dealing with yet another agent royally screwing up a direct API integration (as always forgot to store info, didn't manage to claim), I did probe a couple of trials with my own agent and result is there are entry points where SDKs are not mentioned, even suggesting "all integrations should use APIv2" that instill  confidence in agents to roll a native integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Stronger “DO NOT INTEGRATE” guidance across docs and API reference, directing integrators to use official SDKs/clients instead of calling the REST API directly
  * Added explicit warnings about integration risks and links to the official SDK/library guidance
  * Clarified that SDKs handle cryptography, swap state-machine logic, and fund-recovery edge cases
  * Added WBTC to the supported currencies list
<!-- end of auto-generated comment: release notes by coderabbit.ai -->