### PR TITLE
feat: alert on claim fails

### DIFF
--- a/lib/notifications/NotificationProvider.ts
+++ b/lib/notifications/NotificationProvider.ts
@@ -302,6 +302,22 @@ class NotificationProvider {
       );
     });
 
+    this.service.eventHandler.on(
+      'claim.failure',
+      async ({ swap, symbol, error }) => {
+        const { base, quote } = splitPairId(swap.pair);
+        const truncatedError =
+          error.length > 200 ? error.substring(0, 200) + '...' : error;
+
+        const message =
+          `${Emojis.RotatingLight} **Claim failure for ${symbol}** ${Emojis.RotatingLight}\n` +
+          `${await getBasicSwapInfo(swap.type, swap, base, quote)}\n` +
+          `Error: ${truncatedError}`;
+
+        await this.client.sendMessage(message, true, true);
+      },
+    );
+
     this.service.swapManager.deferredClaimer.on(
       'batch.claim.failure',
       async ({ symbol, error }) => {

--- a/lib/service/EventHandler.ts
+++ b/lib/service/EventHandler.ts
@@ -44,6 +44,11 @@ class EventHandler extends TypedEventEmitter<{
     swap: AnySwap;
     reason: string;
   };
+  'claim.failure': {
+    swap: AnySwap;
+    symbol: string;
+    error: string;
+  };
   'channel.backup': {
     currency: string;
     channelBackup: string;
@@ -203,6 +208,14 @@ class EventHandler extends TypedEventEmitter<{
         status: {
           status: SwapUpdateEvent.TransactionClaimPending,
         },
+      });
+    });
+
+    this.nursery.on('claim.failure', ({ swap, symbol, error }) => {
+      this.emit('claim.failure', {
+        swap,
+        symbol,
+        error,
       });
     });
 

--- a/lib/swap/PaymentHandler.ts
+++ b/lib/swap/PaymentHandler.ts
@@ -66,6 +66,11 @@ type SwapNurseryEvents = {
   'invoice.failedToPay': Swap;
   'invoice.paid': Swap;
   'claim.pending': Swap | ChainSwapInfo;
+  'claim.failure': {
+    swap: Swap | ChainSwapInfo;
+    symbol: string;
+    error: string;
+  };
   claim: {
     swap: Swap | ChainSwapInfo;
   };

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -1790,6 +1790,22 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     };
   };
 
+  private emitClaimFailure = (
+    swap: Swap | ChainSwapInfo,
+    symbol: string,
+    error: unknown,
+  ) => {
+    const formattedError = formatError(error);
+    this.logger.error(
+      `Claim of ${symbol} for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} failed: ${formattedError}`,
+    );
+    this.emit('claim.failure', {
+      swap,
+      symbol,
+      error: formattedError,
+    });
+  };
+
   private claimUtxo = async (
     swap: Swap | ChainSwapInfo,
     chainClient: IChainClient,
@@ -1802,44 +1818,52 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       return;
     }
 
-    const claimTransaction = constructClaimTransaction(
-      wallet,
-      [
-        constructClaimDetails(
-          this.swapOutputType,
-          wallet,
+    try {
+      const claimTransaction = constructClaimTransaction(
+        wallet,
+        [
+          constructClaimDetails(
+            this.swapOutputType,
+            wallet,
+            swap.type === SwapType.Submarine
+              ? (swap as Swap)
+              : (swap as ChainSwapInfo).receivingData,
+            transaction,
+            preimage,
+          ),
+        ] as ClaimDetails[] | LiquidClaimDetails[],
+        await wallet.getAddress(TransactionLabelRepository.claimLabel(swap)),
+        await chainClient.estimateFee(),
+      );
+
+      const claimTransactionFee = await calculateTransactionFee(
+        chainClient,
+        claimTransaction,
+      );
+
+      await chainClient.sendRawTransaction(TxView.of(claimTransaction).hex);
+
+      this.logger.info(
+        `Claimed ${wallet.symbol} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in: ${TxView.of(claimTransaction).id}`,
+      );
+
+      this.emit('claim', {
+        swap:
           swap.type === SwapType.Submarine
-            ? (swap as Swap)
-            : (swap as ChainSwapInfo).receivingData,
-          transaction,
-          preimage,
-        ),
-      ] as ClaimDetails[] | LiquidClaimDetails[],
-      await wallet.getAddress(TransactionLabelRepository.claimLabel(swap)),
-      await chainClient.estimateFee(),
-    );
-
-    const claimTransactionFee = await calculateTransactionFee(
-      chainClient,
-      claimTransaction,
-    );
-
-    await chainClient.sendRawTransaction(TxView.of(claimTransaction).hex);
-
-    this.logger.info(
-      `Claimed ${wallet.symbol} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in: ${TxView.of(claimTransaction).id}`,
-    );
-
-    this.emit('claim', {
-      swap:
-        swap.type === SwapType.Submarine
-          ? await SwapRepository.setMinerFee(swap as Swap, claimTransactionFee)
-          : await ChainSwapRepository.setClaimMinerFee(
-              swap as ChainSwapInfo,
-              preimage,
-              claimTransactionFee,
-            ),
-    });
+            ? await SwapRepository.setMinerFee(
+                swap as Swap,
+                claimTransactionFee,
+              )
+            : await ChainSwapRepository.setClaimMinerFee(
+                swap as ChainSwapInfo,
+                preimage,
+                claimTransactionFee,
+              ),
+      });
+    } catch (error) {
+      this.emitClaimFailure(swap, wallet.symbol, error);
+      throw error;
+    }
   };
 
   private claimVtxo = async (
@@ -1847,36 +1871,41 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     arkClient: ArkClient,
     preimage: Buffer,
   ) => {
-    const txId =
-      swap.type === SwapType.Submarine
-        ? (swap as Swap).lockupTransactionId
-        : (swap as ChainSwapInfo).receivingData.transactionId;
-    const vout =
-      swap.type === SwapType.Submarine
-        ? (swap as Swap).lockupTransactionVout
-        : (swap as ChainSwapInfo).receivingData.transactionVout;
-
-    const claimTransaction = await arkClient.claimVHtlc(
-      preimage,
-      getHexBuffer(swap.theirRefundPublicKey!),
-      arkClient.pubkey,
-      { txId: txId!, vout: vout! },
-      TransactionLabelRepository.claimLabel(swap),
-    );
-    this.logger.info(
-      `Claimed ${arkClient.symbol} vHTLC of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in: ${claimTransaction}`,
-    );
-
-    this.emit('claim', {
-      swap:
+    try {
+      const txId =
         swap.type === SwapType.Submarine
-          ? await SwapRepository.setMinerFee(swap as Swap, 0)
-          : await ChainSwapRepository.setClaimMinerFee(
-              swap as ChainSwapInfo,
-              preimage,
-              0,
-            ),
-    });
+          ? (swap as Swap).lockupTransactionId
+          : (swap as ChainSwapInfo).receivingData.transactionId;
+      const vout =
+        swap.type === SwapType.Submarine
+          ? (swap as Swap).lockupTransactionVout
+          : (swap as ChainSwapInfo).receivingData.transactionVout;
+
+      const claimTransaction = await arkClient.claimVHtlc(
+        preimage,
+        getHexBuffer(swap.theirRefundPublicKey!),
+        arkClient.pubkey,
+        { txId: txId!, vout: vout! },
+        TransactionLabelRepository.claimLabel(swap),
+      );
+      this.logger.info(
+        `Claimed ${arkClient.symbol} vHTLC of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in: ${claimTransaction}`,
+      );
+
+      this.emit('claim', {
+        swap:
+          swap.type === SwapType.Submarine
+            ? await SwapRepository.setMinerFee(swap as Swap, 0)
+            : await ChainSwapRepository.setClaimMinerFee(
+                swap as ChainSwapInfo,
+                preimage,
+                0,
+              ),
+      });
+    } catch (error) {
+      this.emitClaimFailure(swap, arkClient.symbol, error);
+      throw error;
+    }
   };
 
   private claimEther = async (
@@ -1886,28 +1915,34 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     etherSwapValues: EtherSwapValues,
     preimage: Buffer,
   ) => {
-    const contractTransaction = await contracts.contractHandler.claimEther(
-      swap,
-      preimage,
-      etherSwapValues.amount,
-      etherSwapValues.refundAddress,
-      etherSwapValues.timelock,
-    );
+    try {
+      const contractTransaction = await contracts.contractHandler.claimEther(
+        swap,
+        preimage,
+        etherSwapValues.amount,
+        etherSwapValues.refundAddress,
+        etherSwapValues.timelock,
+      );
 
-    this.logger.info(
-      `Claimed ${manager.networkDetails.name} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in: ${contractTransaction.hash}`,
-    );
-    const transactionFee = calculateEthereumTransactionFee(contractTransaction);
-    this.emit('claim', {
-      swap:
-        swap.type === SwapType.Submarine
-          ? await SwapRepository.setMinerFee(swap as Swap, transactionFee)
-          : await ChainSwapRepository.setClaimMinerFee(
-              swap as ChainSwapInfo,
-              preimage,
-              transactionFee,
-            ),
-    });
+      this.logger.info(
+        `Claimed ${manager.networkDetails.name} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in: ${contractTransaction.hash}`,
+      );
+      const transactionFee =
+        calculateEthereumTransactionFee(contractTransaction);
+      this.emit('claim', {
+        swap:
+          swap.type === SwapType.Submarine
+            ? await SwapRepository.setMinerFee(swap as Swap, transactionFee)
+            : await ChainSwapRepository.setClaimMinerFee(
+                swap as ChainSwapInfo,
+                preimage,
+                transactionFee,
+              ),
+      });
+    } catch (error) {
+      this.emitClaimFailure(swap, manager.networkDetails.symbol, error);
+      throw error;
+    }
   };
 
   private claimERC20 = async (
@@ -1921,29 +1956,35 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
     const wallet = this.walletManager.wallets.get(chainCurrency)!;
 
-    const contractTransaction = await contractHandler.claimToken(
-      swap,
-      wallet.walletProvider as ERC20WalletProvider,
-      preimage,
-      erc20SwapValues.amount,
-      erc20SwapValues.refundAddress,
-      erc20SwapValues.timelock,
-    );
+    try {
+      const contractTransaction = await contractHandler.claimToken(
+        swap,
+        wallet.walletProvider as ERC20WalletProvider,
+        preimage,
+        erc20SwapValues.amount,
+        erc20SwapValues.refundAddress,
+        erc20SwapValues.timelock,
+      );
 
-    this.logger.info(
-      `Claimed ${chainCurrency} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in: ${contractTransaction.hash}`,
-    );
-    const transactionFee = calculateEthereumTransactionFee(contractTransaction);
-    this.emit('claim', {
-      swap:
-        swap.type === SwapType.Submarine
-          ? await SwapRepository.setMinerFee(swap as Swap, transactionFee)
-          : await ChainSwapRepository.setClaimMinerFee(
-              swap as ChainSwapInfo,
-              preimage,
-              transactionFee,
-            ),
-    });
+      this.logger.info(
+        `Claimed ${chainCurrency} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} in: ${contractTransaction.hash}`,
+      );
+      const transactionFee =
+        calculateEthereumTransactionFee(contractTransaction);
+      this.emit('claim', {
+        swap:
+          swap.type === SwapType.Submarine
+            ? await SwapRepository.setMinerFee(swap as Swap, transactionFee)
+            : await ChainSwapRepository.setClaimMinerFee(
+                swap as ChainSwapInfo,
+                preimage,
+                transactionFee,
+              ),
+      });
+    } catch (error) {
+      this.emitClaimFailure(swap, chainCurrency, error);
+      throw error;
+    }
   };
 
   private handleSwapSendFailed = async (

--- a/test/unit/notifications/NotificationProvider.spec.ts
+++ b/test/unit/notifications/NotificationProvider.spec.ts
@@ -22,9 +22,15 @@ type failureCallback = (args: {
   swap: Swap | ReverseSwap;
   reason: string;
 }) => void;
+type claimFailureCallback = (args: {
+  swap: Swap | ReverseSwap;
+  symbol: string;
+  error: string;
+}) => void;
 
 let emitSwapSuccess: successCallback;
 let emitSwapFailure: failureCallback;
+let emitClaimFailure: claimFailureCallback;
 let emitZeroConfDisabled: (symbol: string) => void;
 let emitBatchClaimFailure: (args: { symbol: string; error: string }) => void;
 
@@ -47,8 +53,10 @@ jest.mock('../../../lib/service/Service', () => {
         on: (event: string, callback: any) => {
           if (event === 'swap.success') {
             emitSwapSuccess = callback;
-          } else {
+          } else if (event === 'swap.failure') {
             emitSwapFailure = callback;
+          } else if (event === 'claim.failure') {
+            emitClaimFailure = callback;
           }
         },
       },
@@ -331,6 +339,29 @@ describe('NotificationProvider', () => {
     );
   });
 
+  test('should send notification on immediate claim failure', async () => {
+    const symbol = 'L-BTC';
+    const error = 'bad-txns-in-ne-out';
+
+    emitClaimFailure({ swap, symbol, error });
+    await wait(5);
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      `${Emojis.RotatingLight} **Claim failure for ${symbol}** ${Emojis.RotatingLight}\n` +
+        `ID: ${swap.id}\n` +
+        `Pair: ${swap.pair}\n` +
+        'Order side: buy\n' +
+        `Onchain amount: ${satoshisToSatcomma(swap.onchainAmount!)} BTC\n` +
+        `Lightning amount: ${satoshisToSatcomma(
+          bolt11.decode(swap.invoice!).satoshis!,
+        )} LTC\n` +
+        `Error: ${error}`,
+      true,
+      true,
+    );
+  });
+
   test('should truncate long error messages in batch claim failures', async () => {
     const symbol = 'L-BTC';
     const longError = 'a'.repeat(250);
@@ -342,6 +373,30 @@ describe('NotificationProvider', () => {
     const expectedError = longError.substring(0, 200) + '...';
     expect(mockSendMessage).toHaveBeenCalledWith(
       `${Emojis.RotatingLight} **Batch claim failure for ${symbol}** ${Emojis.RotatingLight}\n` +
+        `Error: ${expectedError}`,
+      true,
+      true,
+    );
+  });
+
+  test('should truncate long error messages in immediate claim failures', async () => {
+    const symbol = 'L-BTC';
+    const longError = 'a'.repeat(250);
+    const expectedError = longError.substring(0, 200) + '...';
+
+    emitClaimFailure({ swap, symbol, error: longError });
+    await wait(5);
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      `${Emojis.RotatingLight} **Claim failure for ${symbol}** ${Emojis.RotatingLight}\n` +
+        `ID: ${swap.id}\n` +
+        `Pair: ${swap.pair}\n` +
+        'Order side: buy\n' +
+        `Onchain amount: ${satoshisToSatcomma(swap.onchainAmount!)} BTC\n` +
+        `Lightning amount: ${satoshisToSatcomma(
+          bolt11.decode(swap.invoice!).satoshis!,
+        )} LTC\n` +
         `Error: ${expectedError}`,
       true,
       true,

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -1277,6 +1277,53 @@ describe('SwapNursery', () => {
     });
   });
 
+  describe('claimUtxo', () => {
+    beforeEach(() => {
+      (swapNursery as any).claimer = {
+        deferClaim: jest.fn().mockResolvedValue(false),
+      };
+      jest.spyOn(swapNursery, 'emit');
+    });
+
+    test('should emit claim.failure with the wallet symbol and rethrow when the claim fails', async () => {
+      const swap = {
+        id: 'submarine-utxo-swap',
+        type: SwapType.Submarine,
+        pair: 'BTC/BTC',
+        orderSide: OrderSide.BUY,
+      } as any;
+      const wallet = {
+        symbol: 'BTC',
+        getAddress: jest.fn().mockResolvedValue('bcrt1qaddress'),
+      } as any;
+      const chainClient = {
+        symbol: 'BTC',
+        estimateFee: jest.fn().mockRejectedValue(new Error('estimate failed')),
+        sendRawTransaction: jest.fn(),
+      } as any;
+
+      await expect(
+        (swapNursery as any).claimUtxo(
+          swap,
+          chainClient,
+          wallet,
+          {} as any,
+          Buffer.from('preimage'),
+        ),
+      ).rejects.toThrow();
+
+      expect(swapNursery.emit).toHaveBeenCalledWith('claim.failure', {
+        swap,
+        symbol: 'BTC',
+        error: expect.any(String),
+      });
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'claim',
+        expect.anything(),
+      );
+    });
+  });
+
   describe('claimVtxo', () => {
     const mockArkClient = {
       claimVHtlc: jest.fn().mockResolvedValue('ark-claim-tx'),
@@ -1349,6 +1396,141 @@ describe('SwapNursery', () => {
         swap,
         Buffer.from('preimage'),
         0,
+      );
+    });
+
+    test('should emit claim.failure and rethrow when the claim fails', async () => {
+      const error = new Error('vHTLC claim failed');
+      const failingArkClient = {
+        ...mockArkClient,
+        claimVHtlc: jest.fn().mockRejectedValue(error),
+      };
+      const swap = {
+        id: 'submarine-ark-swap',
+        type: SwapType.Submarine,
+        theirRefundPublicKey: '02'.repeat(33),
+        lockupTransactionId: 'submarine-lockup-tx',
+        lockupTransactionVout: 4,
+      } as any;
+
+      await expect(
+        (swapNursery as any).claimVtxo(
+          swap,
+          failingArkClient,
+          Buffer.from('preimage'),
+        ),
+      ).rejects.toThrow(error);
+
+      expect(swapNursery.emit).toHaveBeenCalledWith('claim.failure', {
+        swap,
+        symbol: 'ARK',
+        error: error.message,
+      });
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'claim',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('claimEther', () => {
+    const buildManager = () =>
+      ({
+        networkDetails: { name: 'Rootstock', symbol: 'RBTC' },
+      }) as any;
+
+    const swap = {
+      id: 'submarine-ether-swap',
+      type: SwapType.Submarine,
+      pair: 'BTC/RBTC',
+      orderSide: OrderSide.BUY,
+    } as any;
+
+    const etherSwapValues = {
+      amount: 1n,
+      refundAddress: '0xboltz',
+      timelock: 1,
+    } as any;
+
+    beforeEach(() => {
+      jest.spyOn(swapNursery, 'emit');
+    });
+
+    test('should emit claim.failure with the network symbol and rethrow when the claim fails', async () => {
+      const error = new Error('claimEther reverted');
+      const contracts = {
+        contractHandler: {
+          claimEther: jest.fn().mockRejectedValue(error),
+        },
+      } as any;
+
+      await expect(
+        (swapNursery as any).claimEther(
+          buildManager(),
+          contracts,
+          swap,
+          etherSwapValues,
+          Buffer.from('preimage'),
+        ),
+      ).rejects.toThrow(error);
+
+      expect(swapNursery.emit).toHaveBeenCalledWith('claim.failure', {
+        swap,
+        symbol: 'RBTC',
+        error: error.message,
+      });
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'claim',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('claimERC20', () => {
+    const swap = {
+      id: 'submarine-erc20-swap',
+      type: SwapType.Submarine,
+      pair: 'BTC/USDT',
+      orderSide: OrderSide.BUY,
+    } as any;
+
+    const erc20SwapValues = {
+      amount: 1n,
+      refundAddress: '0xboltz',
+      timelock: 1,
+    } as any;
+
+    beforeEach(() => {
+      (swapNursery as any).walletManager = {
+        ethereumManagers: [],
+        wallets: new Map([['USDT', { walletProvider: {} }]]),
+      };
+      jest.spyOn(swapNursery, 'emit');
+    });
+
+    test('should emit claim.failure with the chain currency and rethrow when the claim fails', async () => {
+      const error = new Error('claimToken reverted');
+      const contractHandler = {
+        claimToken: jest.fn().mockRejectedValue(error),
+      } as any;
+
+      await expect(
+        (swapNursery as any).claimERC20(
+          contractHandler,
+          swap,
+          erc20SwapValues,
+          Buffer.from('preimage'),
+        ),
+      ).rejects.toThrow(error);
+
+      expect(swapNursery.emit).toHaveBeenCalledWith('claim.failure', {
+        swap,
+        symbol: 'USDT',
+        error: error.message,
+      });
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'claim',
+        expect.anything(),
       );
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added immediate “claim failure” notifications for all supported swap types, including swap identifiers and concise error details (errors are truncated to 200 characters when needed).
  * Standardized claim-failure events so notification delivery is triggered reliably whenever claim operations fail.

* **Tests**
  * Expanded unit test coverage to verify notification message formatting, error truncation behavior, and that success events are not emitted on claim failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->