### PR TITLE
feat: send gRPC hook

### DIFF
--- a/boltzr-cli/src/grpc/mod.rs
+++ b/boltzr-cli/src/grpc/mod.rs
@@ -11,6 +11,7 @@ mod boltzr {
     tonic::include_proto!("boltzr");
 }
 
+#[allow(clippy::enum_variant_names)]
 mod boltz_rpc {
     tonic::include_proto!("boltzrpc");
 }

--- a/docs/boltz.conf
+++ b/docs/boltz.conf
@@ -510,6 +510,12 @@ cltvDelta = 20  # CLTV delta for Lightning invoices (blocks)
 
 # paymentTimeoutMinutes = 60
 
+# Fallback action of the send approval hook when the approver does not respond
+# or is not connected: "accept" (default), "reject" to fail closed, or "hold" to
+# pause the send and keep retrying until an approver responds
+# [swap.sendApproval]
+# defaultAction = "accept"
+
 # =============================================================================
 # Routing Fee Configuration
 # =============================================================================

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -15,6 +15,7 @@ import type { Config as RoutingFeeConfig } from './lightning/RoutingFee';
 import type { ClnConfig } from './lightning/cln/Types';
 import type { SidecarConfig } from './sidecar/Sidecar';
 import type { NodeSwitchConfig } from './swap/NodeSwitch';
+import type { SendApprovalDefaultAction } from './swap/hooks/SendApprovalHook';
 
 type EmailConfig = {
   enabled: boolean;
@@ -190,6 +191,10 @@ type SwapConfig = {
   overpayment?: OverPaymentConfig;
 
   paymentTimeoutMinutes?: number;
+
+  sendApproval?: {
+    defaultAction?: SendApprovalDefaultAction;
+  };
 };
 
 type ConfigType = {

--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -26,6 +26,7 @@ import RefundTransaction from './models/RefundTransaction';
 import ReverseRoutingHint from './models/ReverseRoutingHint';
 import ReverseSwap from './models/ReverseSwap';
 import ScriptPubKey from './models/ScriptPubKey';
+import SendApprovalHold from './models/SendApprovalHold';
 import Swap from './models/Swap';
 import SwapMetadata from './models/SwapMetadata';
 import TransactionLabel from './models/TransactionLabel';
@@ -128,6 +129,7 @@ class Database {
       RefundTransaction.sync(),
       ClaimTransaction.sync(),
       ScriptPubKey.sync(),
+      SendApprovalHold.sync(),
     ]);
   };
 
@@ -175,6 +177,7 @@ class Database {
     Commitment.load(Database.sequelize);
     JwtToken.load(Database.sequelize);
     SwapMetadata.load(Database.sequelize);
+    SendApprovalHold.load(Database.sequelize);
 
     TransactionLabelRepository.setLogger(this.logger);
   };

--- a/lib/db/models/SendApprovalHold.ts
+++ b/lib/db/models/SendApprovalHold.ts
@@ -1,0 +1,44 @@
+import type { Sequelize } from 'sequelize';
+import { DataTypes, Model } from 'sequelize';
+import { SwapType } from '../../consts/Enums';
+
+type SendApprovalHoldType = {
+  swapId: string;
+  type: SwapType;
+};
+
+class SendApprovalHold extends Model implements SendApprovalHoldType {
+  declare swapId: string;
+  declare type: SwapType;
+
+  declare createdAt: Date;
+  declare updatedAt: Date;
+
+  public static load = (sequelize: Sequelize) => {
+    SendApprovalHold.init(
+      {
+        swapId: {
+          type: new DataTypes.STRING(255),
+          allowNull: false,
+          primaryKey: true,
+        },
+        type: {
+          type: new DataTypes.INTEGER(),
+          allowNull: false,
+          validate: {
+            isIn: [
+              Object.values(SwapType).filter((val) => typeof val === 'number'),
+            ],
+          },
+        },
+      },
+      {
+        sequelize,
+        tableName: 'send_approval_holds',
+      },
+    );
+  };
+}
+
+export default SendApprovalHold;
+export { SendApprovalHoldType };

--- a/lib/db/repositories/SendApprovalHoldRepository.ts
+++ b/lib/db/repositories/SendApprovalHoldRepository.ts
@@ -1,0 +1,26 @@
+import type { SendApprovalHoldType } from '../models/SendApprovalHold';
+import SendApprovalHold from '../models/SendApprovalHold';
+
+class SendApprovalHoldRepository {
+  public static create = async (
+    hold: SendApprovalHoldType,
+  ): Promise<SendApprovalHold> => {
+    const [sendApprovalHold] = await SendApprovalHold.findOrCreate({
+      where: { swapId: hold.swapId },
+      defaults: hold,
+    });
+
+    return sendApprovalHold;
+  };
+
+  public static getAll = (): Promise<SendApprovalHold[]> =>
+    SendApprovalHold.findAll();
+
+  public static exists = async (swapId: string): Promise<boolean> =>
+    (await SendApprovalHold.findByPk(swapId)) !== null;
+
+  public static remove = (swapId: string): Promise<number> =>
+    SendApprovalHold.destroy({ where: { swapId } });
+}
+
+export default SendApprovalHoldRepository;

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -59,6 +59,7 @@ class GrpcServer {
       swapCreationHook: grpcService.swapCreationHook,
       invoiceCreationHook: grpcService.invoiceCreationHook,
       transactionHook: grpcService.transactionHook,
+      sendApprovalHook: grpcService.sendApprovalHook,
       invoicePaymentHook: grpcService.invoicePaymentHook,
       getReferrals: grpcService.getReferrals,
       setReferral: grpcService.setReferral,

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -580,6 +580,15 @@ class GrpcService {
     this.service.swapManager.nursery.transactionHook.connectToStream(call);
   };
 
+  public sendApprovalHook = (
+    call: ServerDuplexStream<
+      boltzrpc.SendApprovalHookResponse,
+      boltzrpc.SendApprovalHookRequest
+    >,
+  ) => {
+    this.service.swapManager.nursery.sendApprovalHook.connectToStream(call);
+  };
+
   public invoicePaymentHook = (
     call: ServerDuplexStream<
       boltzrpc.InvoicePaymentHookResponse,

--- a/lib/lightning/PendingPaymentTracker.ts
+++ b/lib/lightning/PendingPaymentTracker.ts
@@ -108,6 +108,7 @@ class PendingPaymentTracker {
     paymentHash: string;
     node: LightningClient;
     payments: LightningPayment[];
+    existingRelevantAction: LightningPayment | undefined;
   }> => {
     const paymentHash = getHexString(
       (await this.sidecar.decodeInvoiceOrOffer(swap.invoice!)).paymentHash!,
@@ -127,6 +128,7 @@ class PendingPaymentTracker {
         payments,
         paymentHash,
         node: preferredNode,
+        existingRelevantAction,
       };
     }
 
@@ -145,6 +147,7 @@ class PendingPaymentTracker {
       payments,
       paymentHash,
       node: node || preferredNode,
+      existingRelevantAction,
     };
   };
 

--- a/lib/swap/PaymentHandler.ts
+++ b/lib/swap/PaymentHandler.ts
@@ -17,6 +17,7 @@ import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
 import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
 import SwapRepository from '../db/repositories/SwapRepository';
+import { msatToSat } from '../lightning/ChannelUtils';
 import type {
   LightningClient,
   PaymentResponse,
@@ -36,12 +37,18 @@ import type { Currency } from '../wallet/WalletManager';
 import Errors from './Errors';
 import LightningNursery from './LightningNursery';
 import type NodeSwitch from './NodeSwitch';
+import {
+  persistSendApprovalDecision,
+  resolveSendApprovalDecision,
+} from './SendApprovalGuard';
 import type SwapNursery from './SwapNursery';
 import type {
   InvoicePaymentHookContinue,
   InvoicePaymentHookHold,
 } from './hooks/InvoicePaymentHook';
 import { InvoicePaymentHookAction } from './hooks/InvoicePaymentHook';
+import { SendApprovalAction } from './hooks/SendApprovalHook';
+import type SendApprovalHook from './hooks/SendApprovalHook';
 
 type SwapNurseryEvents = {
   // UTXO based chains emit the "Transaction" object and Ethereum based ones just the transaction hash
@@ -119,6 +126,7 @@ class PaymentHandler {
     private readonly timeoutDeltaProvider: TimeoutDeltaProvider,
     private readonly pendingPaymentTracker: PendingPaymentTracker,
     private readonly swapNursery: SwapNursery,
+    private readonly sendApprovalHook: SendApprovalHook,
   ) {
     this.selfPaymentClient = new SelfPaymentClient(this.logger, swapNursery);
   }
@@ -160,7 +168,7 @@ class PaymentHandler {
       return undefined;
     }
 
-    const { node, paymentHash, payments } =
+    const { node, paymentHash, payments, existingRelevantAction } =
       await this.pendingPaymentTracker.getRelevantNode(
         lightningCurrency,
         swap,
@@ -193,13 +201,40 @@ class PaymentHandler {
       return undefined;
     }
 
-    if (isSubmarineInvoicePaymentSignerDisabled && payments.length === 0) {
+    if (
+      isSubmarineInvoicePaymentSignerDisabled &&
+      existingRelevantAction === undefined
+    ) {
       const errorMessage = disabledSignerMessage(
         Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
       );
       this.logPaymentFailure(swap, errorMessage);
       await this.abandonSwap(swap, errorMessage);
       return undefined;
+    }
+
+    if (existingRelevantAction === undefined) {
+      const sendApproval = await resolveSendApprovalDecision(
+        this.sendApprovalHook,
+        swap.id,
+        swap.pair,
+        lightningSymbol,
+        msatToSat(decoded.amountMsat),
+      );
+      if (
+        !(await persistSendApprovalDecision(swap.id, swap.type, sendApproval))
+      ) {
+        this.logger.verbose(
+          `Holding invoice payment of Swap ${swap.id} per send approval hook`,
+        );
+        return undefined;
+      }
+      if (sendApproval === SendApprovalAction.Reject) {
+        const errorMessage = Errors.HOOK_REJECTED().message;
+        this.logPaymentFailure(swap, errorMessage);
+        await this.abandonSwap(swap, errorMessage);
+        return undefined;
+      }
     }
 
     try {

--- a/lib/swap/SendApprovalGuard.ts
+++ b/lib/swap/SendApprovalGuard.ts
@@ -1,0 +1,40 @@
+import type { SwapType } from '../consts/Enums';
+import SendApprovalHoldRepository from '../db/repositories/SendApprovalHoldRepository';
+import type SendApprovalHook from './hooks/SendApprovalHook';
+import { SendApprovalAction } from './hooks/SendApprovalHook';
+
+// Ask the send approval hook for a decision. When the swap is already held, keep
+// holding on a non-resolution (hook not connected, timed out or disconnected) so
+// only a real approver response can release it.
+const resolveSendApprovalDecision = async (
+  hook: SendApprovalHook,
+  swapId: string,
+  pair: string,
+  symbol: string,
+  amount: number,
+): Promise<SendApprovalAction> => {
+  const fallback = (await SendApprovalHoldRepository.exists(swapId))
+    ? SendApprovalAction.Hold
+    : undefined;
+
+  return hook.hook(swapId, pair, symbol, amount, fallback);
+};
+
+// Persist the decision: a Hold creates the hold row and returns false (the send
+// must keep holding); anything else removes the row and returns true (the send
+// may proceed)
+const persistSendApprovalDecision = async (
+  swapId: string,
+  type: SwapType,
+  action: SendApprovalAction,
+): Promise<boolean> => {
+  if (action === SendApprovalAction.Hold) {
+    await SendApprovalHoldRepository.create({ swapId, type });
+    return false;
+  }
+
+  await SendApprovalHoldRepository.remove(swapId);
+  return true;
+};
+
+export { resolveSendApprovalDecision, persistSendApprovalDecision };

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -250,6 +250,7 @@ class SwapManager {
       lockupTransactionTracker,
       overpaymentProtector,
       swapConfig.paymentTimeoutMinutes,
+      swapConfig.sendApproval?.defaultAction,
     );
 
     this.renegotiator = new Renegotiator(

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -55,11 +55,13 @@ import type {
 } from '../consts/Types';
 import { RefundStatus } from '../db/models/RefundTransaction';
 import type ReverseSwap from '../db/models/ReverseSwap';
+import type SendApprovalHold from '../db/models/SendApprovalHold';
 import type Swap from '../db/models/Swap';
 import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../db/repositories/ChainSwapRepository';
 import RefundTransactionRepository from '../db/repositories/RefundTransactionRepository';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
+import SendApprovalHoldRepository from '../db/repositories/SendApprovalHoldRepository';
 import SwapRepository from '../db/repositories/SwapRepository';
 import TransactionLabelRepository from '../db/repositories/TransactionLabelRepository';
 import WrappedSwapRepository from '../db/repositories/WrappedSwapRepository';
@@ -99,8 +101,13 @@ import type OverpaymentProtector from './OverpaymentProtector';
 import type { SwapNurseryEvents } from './PaymentHandler';
 import PaymentHandler from './PaymentHandler';
 import RefundWatcher from './RefundWatcher';
+import {
+  persistSendApprovalDecision,
+  resolveSendApprovalDecision,
+} from './SendApprovalGuard';
 import type SwapOutputType from './SwapOutputType';
 import UtxoNursery from './UtxoNursery';
+import SendApprovalHook, { SendApprovalAction } from './hooks/SendApprovalHook';
 import TransactionHook from './hooks/TransactionHook';
 
 type PaidSwapInvoice = {
@@ -110,6 +117,11 @@ type PaidSwapInvoice = {
 class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
   // Constants
   public static reverseSwapMempoolEta = 2;
+  private static readonly actionableChainSwapLockupStatuses = [
+    SwapUpdateEvent.SwapCreated,
+    SwapUpdateEvent.TransactionMempool,
+    SwapUpdateEvent.TransactionConfirmed,
+  ];
 
   // Nurseries
   public readonly arkNursery: ArkNursery;
@@ -134,10 +146,20 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
   public static readonly chainSwapLock = 'chainSwap';
   public static readonly reverseSwapLock = 'reverseSwap';
 
+  // The full three-way mapping is intentional: the two-way call sites only ever
+  // pass the two types they can encounter, and this agrees with them on those
+  private static readonly lockForSwapType = (type: SwapType): string =>
+    type === SwapType.Submarine
+      ? SwapNursery.swapLock
+      : type === SwapType.ReverseSubmarine
+        ? SwapNursery.reverseSwapLock
+        : SwapNursery.chainSwapLock;
+
   private static retryLock = 'retry';
   private static readonly refundTransactionUpdateTimeout = 1_000;
 
   public readonly transactionHook: TransactionHook;
+  public readonly sendApprovalHook: SendApprovalHook;
 
   constructor(
     private logger: Logger,
@@ -154,12 +176,18 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     lockupTransactionTracker: LockupTransactionTracker,
     overpaymentProtector: OverpaymentProtector,
     paymentTimeoutMinutes?: number,
+    sendApprovalDefaultAction?: string,
   ) {
     super();
 
     this.logger.info(`Setting Swap retry interval to ${retryInterval} seconds`);
 
     this.transactionHook = new TransactionHook(this.logger, notifications);
+    this.sendApprovalHook = new SendApprovalHook(
+      this.logger,
+      notifications,
+      sendApprovalDefaultAction,
+    );
 
     this.arkNursery = new ArkNursery(this.logger, overpaymentProtector);
     this.utxoNursery = new UtxoNursery(
@@ -196,6 +224,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       timeoutDeltaProvider,
       this.pendingPaymentTracker,
       this,
+      this.sendApprovalHook,
     );
     this.lightningNursery = new LightningNursery(
       this.logger,
@@ -462,9 +491,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
     this.utxoNursery.on('server.lockup.confirmed', async (data) => {
       await this.lock.acquire(
-        data.swap.type === SwapType.ReverseSubmarine
-          ? SwapNursery.reverseSwapLock
-          : SwapNursery.chainSwapLock,
+        SwapNursery.lockForSwapType(data.swap.type),
         'server.lockup.confirmed',
         async () => {
           let swap: typeof data.swap | null;
@@ -529,80 +556,17 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     });
 
     this.lightningNursery.on('invoice.paid', async ({ id }) => {
-      await this.lock.acquire(
-        SwapNursery.reverseSwapLock,
-        'invoice.paid',
-        async () => {
-          const reverseSwap = await ReverseSwapRepository.getReverseSwap({
-            id,
-          });
-          if (reverseSwap === null || reverseSwap === undefined) {
-            this.logger.warn(`Could not find Reverse Swap with id: ${id}`);
-            return;
-          }
-
-          if (
-            ![
-              SwapUpdateEvent.SwapCreated,
-              SwapUpdateEvent.MinerFeePaid,
-            ].includes(reverseSwap.status as SwapUpdateEvent)
-          ) {
-            return;
-          }
-
-          const { base, quote } = splitPairId(reverseSwap.pair);
-          const chainSymbol = getChainCurrency(
-            base,
-            quote,
-            reverseSwap.orderSide,
-            true,
-          );
-          const lightningSymbol = getLightningCurrency(
-            base,
-            quote,
-            reverseSwap.orderSide,
-            true,
-          );
-          const chainCurrency = this.currencies.get(chainSymbol)!;
-          const resolved = NodeSwitch.tryResolveReverseSwapNode(
-            this.currencies.get(lightningSymbol)!,
-            reverseSwap,
-          );
-          if (resolved.status !== ReverseSwapNodeResolutionStatus.Resolved) {
-            this.logger.warn(
-              `Skipping lockup of Reverse Swap ${reverseSwap.id}: ${resolved.reason}`,
-            );
-            return;
-          }
-          const lightningClient = resolved.lightningClient;
-
-          const wallet = this.walletManager.wallets.get(chainSymbol)!;
-
-          switch (chainCurrency.type) {
-            case CurrencyType.BitcoinLike:
-            case CurrencyType.Liquid:
-              await this.lockupUtxo(
-                reverseSwap,
-                chainCurrency.chainClient!,
-                wallet,
-                lightningClient,
-              );
-              break;
-
-            case CurrencyType.Ether:
-              await this.lockupEther(reverseSwap, wallet, lightningClient);
-              break;
-
-            case CurrencyType.ERC20:
-              await this.lockupERC20(reverseSwap, wallet, lightningClient);
-              break;
-
-            case CurrencyType.Ark:
-              await this.lockupVtxo(reverseSwap, wallet, lightningClient);
-              break;
-          }
+      await this.withSendApproval<ReverseSwap>({
+        id,
+        symbolFor: (swap) => {
+          const { base, quote } = splitPairId(swap.pair);
+          return getChainCurrency(base, quote, swap.orderSide, true);
         },
-      );
+        lock: SwapNursery.reverseSwapLock,
+        lockReason: 'invoice.paid',
+        loadEligible: () => this.loadEligibleReverseSwap(id),
+        proceed: (swap, approval) => this.lockupReverseSwap(swap, approval),
+      });
     });
 
     this.utxoNursery.on(
@@ -761,24 +725,16 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       transaction: Transaction | LiquidTransaction | string,
       confirmed: boolean,
     ) => {
-      await this.lock.acquire(
-        SwapNursery.chainSwapLock,
-        'chainSwap.lockup',
-        async () => {
-          const fetchedSwap = await this.getChainSwapForLockup(swap);
-          if (fetchedSwap === undefined || fetchedSwap === null) {
-            return;
-          }
-
-          this.emit('transaction', {
-            confirmed,
-            transaction,
-            swap: fetchedSwap,
-          });
-
-          await this.handleChainSwapLockup(fetchedSwap);
-        },
-      );
+      await this.withSendApproval<ChainSwapInfo>({
+        id: swap.id,
+        symbolFor: (fetchedSwap) => fetchedSwap.sendingData.symbol,
+        lock: SwapNursery.chainSwapLock,
+        lockReason: 'chainSwap.lockup',
+        loadEligible: () => this.getChainSwapForLockup(swap),
+        emitTransaction: { transaction, confirmed },
+        proceed: (fetchedSwap, approval) =>
+          this.handleChainSwapLockup(fetchedSwap, approval),
+      });
     };
 
     this.utxoNursery.on(
@@ -961,6 +917,8 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
               await this.attemptSettleSwap(chainCurrency, pendingInvoiceSwap);
             }
           });
+
+          await this.retryHeldSendApprovals();
         });
       }, this.retryInterval * 1000);
     }
@@ -1166,26 +1124,34 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     }
   };
 
-  private handleChainSwapLockup = async (swap: ChainSwapInfo) => {
+  private handleChainSwapLockup = async (
+    swap: ChainSwapInfo,
+    approval: SendApprovalAction,
+  ) => {
     const sendingCurrency = this.currencies.get(swap.sendingData.symbol)!;
     const wallet = this.walletManager.wallets.get(swap.sendingData.symbol)!;
 
     switch (sendingCurrency.type) {
       case CurrencyType.BitcoinLike:
       case CurrencyType.Liquid:
-        await this.lockupUtxo(swap, sendingCurrency.chainClient!, wallet);
+        await this.lockupUtxo(
+          swap,
+          sendingCurrency.chainClient!,
+          wallet,
+          approval,
+        );
         break;
 
       case CurrencyType.Ether:
-        await this.lockupEther(swap, wallet);
+        await this.lockupEther(swap, wallet, approval);
         break;
 
       case CurrencyType.ERC20:
-        await this.lockupERC20(swap, wallet);
+        await this.lockupERC20(swap, wallet, approval);
         break;
 
       case CurrencyType.Ark:
-        await this.lockupVtxo(swap, wallet);
+        await this.lockupVtxo(swap, wallet, approval);
         break;
     }
   };
@@ -1231,6 +1197,24 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       return undefined;
     }
 
+    if (FinalChainSwapEvents.includes(fetchedSwap.status as SwapUpdateEvent)) {
+      this.logger.warn(
+        `Prevented ${swapTypeToPrettyString(fetchedSwap.type)} Swap ${fetchedSwap.id} from sending a lockup transaction because it has final status ${fetchedSwap.status}`,
+      );
+      return undefined;
+    }
+
+    if (
+      !SwapNursery.actionableChainSwapLockupStatuses.includes(
+        fetchedSwap.status as SwapUpdateEvent,
+      )
+    ) {
+      this.logger.warn(
+        `Prevented ${swapTypeToPrettyString(fetchedSwap.type)} Swap ${fetchedSwap.id} from sending a lockup transaction because it has non-actionable status ${fetchedSwap.status}`,
+      );
+      return undefined;
+    }
+
     if (fetchedSwap.createdRefundSignature) {
       this.logger.warn(
         `Prevented ${swapTypeToPrettyString(fetchedSwap.type)} Swap ${fetchedSwap.id} from sending a lockup transaction because it already signed a refund`,
@@ -1265,9 +1249,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
     ethereumNursery.on('lockup.failed', async ({ swap, reason }) => {
       await this.lock.acquire(
-        swap.type === SwapType.Submarine
-          ? SwapNursery.swapLock
-          : SwapNursery.chainSwapLock,
+        SwapNursery.lockForSwapType(swap.type),
         'lockup.failed',
         async () => {
           await this.lockupFailed(swap, reason);
@@ -1279,65 +1261,59 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       swap: Swap | ChainSwapInfo,
       transactionHash: string,
     ) => {
-      await this.lock.acquire(
-        swap.type === SwapType.Submarine
-          ? SwapNursery.swapLock
-          : SwapNursery.chainSwapLock,
-        'lockup',
-        async () => {
-          let updatedSwap: typeof swap | undefined;
-          if (swap.type === SwapType.Submarine) {
-            updatedSwap = (await SwapRepository.getSwap({
-              id: swap.id,
-            }))!;
-          } else {
-            updatedSwap = await this.getChainSwapForLockup(
-              swap as ChainSwapInfo,
-            );
-          }
+      if (swap.type === SwapType.Chain) {
+        await this.withSendApproval<ChainSwapInfo>({
+          id: swap.id,
+          symbolFor: (fetchedSwap) => fetchedSwap.sendingData.symbol,
+          lock: SwapNursery.chainSwapLock,
+          lockReason: 'lockup',
+          loadEligible: () => this.getChainSwapForLockup(swap as ChainSwapInfo),
+          emitTransaction: { confirmed: true, transaction: transactionHash },
+          proceed: (fetchedSwap, approval) =>
+            this.handleChainSwapLockup(fetchedSwap, approval),
+        });
+        return;
+      }
 
-          if (updatedSwap === undefined || updatedSwap === null) {
-            return;
-          }
+      await this.lock.acquire(SwapNursery.swapLock, 'lockup', async () => {
+        const updatedSwap = await SwapRepository.getSwap({ id: swap.id });
+        if (updatedSwap === null || updatedSwap === undefined) {
+          return;
+        }
 
-          if (updatedSwap.status === SwapUpdateEvent.TransactionLockupFailed) {
+        if (updatedSwap.status === SwapUpdateEvent.TransactionLockupFailed) {
+          this.logger.warn(
+            `Lockup already failed for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
+          );
+          return;
+        }
+
+        this.emit('transaction', {
+          swap: updatedSwap,
+          confirmed: true,
+          transaction: transactionHash,
+        });
+
+        if (updatedSwap.invoice) {
+          const { base, quote } = splitPairId(updatedSwap.pair);
+
+          if (updatedSwap.createdRefundSignature) {
             this.logger.warn(
-              `Lockup already failed for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
+              `Prevented ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} from paying an invoice because it already signed a refund`,
             );
             return;
           }
 
-          this.emit('transaction', {
-            swap: updatedSwap,
-            confirmed: true,
-            transaction: transactionHash,
-          });
-
-          if (updatedSwap.type === SwapType.Chain) {
-            await this.handleChainSwapLockup(updatedSwap as ChainSwapInfo);
-          } else {
-            if ((updatedSwap as Swap).invoice) {
-              const { base, quote } = splitPairId(updatedSwap.pair);
-
-              if (updatedSwap.createdRefundSignature) {
-                this.logger.warn(
-                  `Prevented ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} from paying an invoice because it already signed a refund`,
-                );
-                return;
-              }
-
-              await this.attemptSettleSwap(
-                this.currencies.get(
-                  getChainCurrency(base, quote, updatedSwap.orderSide, false),
-                )!,
-                updatedSwap as Swap,
-              );
-            } else {
-              await this.setSwapRate(updatedSwap as Swap);
-            }
-          }
-        },
-      );
+          await this.attemptSettleSwap(
+            this.currencies.get(
+              getChainCurrency(base, quote, updatedSwap.orderSide, false),
+            )!,
+            updatedSwap,
+          );
+        } else {
+          await this.setSwapRate(updatedSwap);
+        }
+      });
     };
 
     ethereumNursery.on('eth.lockup', async ({ swap, transactionHash }) => {
@@ -1421,9 +1397,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       'lockup.confirmed',
       async ({ swap, transactionHash }) => {
         await this.lock.acquire(
-          swap.type === SwapType.ReverseSubmarine
-            ? SwapNursery.reverseSwapLock
-            : SwapNursery.chainSwapLock,
+          SwapNursery.lockForSwapType(swap.type),
           'lockup.confirmed',
           async () => {
             this.emit('transaction', {
@@ -1438,9 +1412,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
     ethereumNursery.on('claim', async ({ swap, preimage }) => {
       await this.lock.acquire(
-        swap.type === SwapType.ReverseSubmarine
-          ? SwapNursery.reverseSwapLock
-          : SwapNursery.chainSwapLock,
+        SwapNursery.lockForSwapType(swap.type),
         'claim',
         async () => {
           if (swap.type === SwapType.ReverseSubmarine) {
@@ -1501,14 +1473,267 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     }
   };
 
+  private lockupAmount = (swap: ReverseSwap | ChainSwapInfo): number =>
+    swap.type === SwapType.ReverseSubmarine
+      ? (swap as ReverseSwap).onchainAmount
+      : (swap as ChainSwapInfo).sendingData.expectedAmount;
+
+  private readonly pendingSendApprovals = new Map<
+    string,
+    Promise<SendApprovalAction>
+  >();
+
+  private resolveSendApproval = (
+    swap: ReverseSwap | ChainSwapInfo,
+    symbol: string,
+  ): Promise<SendApprovalAction> => {
+    const existing = this.pendingSendApprovals.get(swap.id);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const approval = resolveSendApprovalDecision(
+      this.sendApprovalHook,
+      swap.id,
+      swap.pair,
+      symbol,
+      this.lockupAmount(swap),
+    );
+    approval.catch(() => this.pendingSendApprovals.delete(swap.id));
+
+    this.pendingSendApprovals.set(swap.id, approval);
+    return approval;
+  };
+
+  private assertSendApproved = (action: SendApprovalAction) => {
+    if (action !== SendApprovalAction.Accept) {
+      throw new Error(Errors.HOOK_REJECTED().message);
+    }
+  };
+
+  private handleSendApproval = async (
+    swap: ReverseSwap | ChainSwapInfo,
+    approval: SendApprovalAction,
+  ): Promise<boolean> => {
+    const mayProceed = await persistSendApprovalDecision(
+      swap.id,
+      swap.type,
+      approval,
+    );
+    this.pendingSendApprovals.delete(swap.id);
+    if (!mayProceed) {
+      this.logger.verbose(
+        `Holding lockup of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} per send approval hook`,
+      );
+    }
+
+    return mayProceed;
+  };
+
+  private loadEligibleReverseSwap = async (
+    id: string,
+  ): Promise<ReverseSwap | undefined> => {
+    const reverseSwap = await ReverseSwapRepository.getReverseSwap({ id });
+    if (reverseSwap === null || reverseSwap === undefined) {
+      this.logger.warn(`Could not find Reverse Swap with id: ${id}`);
+      return undefined;
+    }
+
+    if (
+      ![SwapUpdateEvent.SwapCreated, SwapUpdateEvent.MinerFeePaid].includes(
+        reverseSwap.status as SwapUpdateEvent,
+      )
+    ) {
+      return undefined;
+    }
+
+    return reverseSwap;
+  };
+
+  // Shared skeleton for every outgoing send: load the eligible swap, resolve the
+  // approval outside the lock, then re-load inside the lock before emitting,
+  // persisting the decision and proceeding. A swap that is no longer eligible
+  // drops any held row (at either the outer or inner check)
+  private withSendApproval = async <T extends ReverseSwap | ChainSwapInfo>({
+    id,
+    symbolFor,
+    lock,
+    lockReason,
+    loadEligible,
+    emitTransaction,
+    proceed,
+  }: {
+    id: string;
+    symbolFor: (swap: T) => string;
+    lock: string;
+    lockReason: string;
+    loadEligible: () => Promise<T | undefined>;
+    emitTransaction?: {
+      transaction: Transaction | LiquidTransaction | string;
+      confirmed: boolean;
+    };
+    proceed: (swap: T, approval: SendApprovalAction) => Promise<void>;
+  }) => {
+    const eligible = await loadEligible();
+    if (eligible === undefined) {
+      await SendApprovalHoldRepository.remove(id);
+      return;
+    }
+
+    const approval = await this.resolveSendApproval(
+      eligible,
+      symbolFor(eligible),
+    );
+
+    try {
+      await this.lock.acquire(lock, lockReason, async () => {
+        const fresh = await loadEligible();
+        if (fresh === undefined) {
+          await SendApprovalHoldRepository.remove(id);
+          return;
+        }
+
+        if (emitTransaction !== undefined) {
+          this.emit('transaction', { ...emitTransaction, swap: fresh });
+        }
+
+        if (!(await this.handleSendApproval(fresh, approval))) {
+          return;
+        }
+
+        await proceed(fresh, approval);
+      });
+    } finally {
+      this.pendingSendApprovals.delete(id);
+    }
+  };
+
+  private retryHeldSendApprovals = async () => {
+    for (const hold of await SendApprovalHoldRepository.getAll()) {
+      await this.retryHeldLockup(hold);
+    }
+  };
+
+  private retryHeldLockup = async (hold: SendApprovalHold) => {
+    if (hold.type === SwapType.Submarine) {
+      await this.lock.acquire(SwapNursery.swapLock, 'retry', () =>
+        this.pruneStaleSubmarineHolds(hold),
+      );
+      return;
+    }
+
+    if (hold.type === SwapType.Chain) {
+      await this.withSendApproval<ChainSwapInfo>({
+        id: hold.swapId,
+        symbolFor: (swap) => swap.sendingData.symbol,
+        lock: SwapNursery.chainSwapLock,
+        lockReason: 'retry',
+        loadEligible: async () => {
+          const swap = await ChainSwapRepository.getChainSwap({
+            id: hold.swapId,
+          });
+          return swap === null ? undefined : this.getChainSwapForLockup(swap);
+        },
+        proceed: (swap, approval) => this.handleChainSwapLockup(swap, approval),
+      });
+      return;
+    }
+
+    await this.withSendApproval<ReverseSwap>({
+      id: hold.swapId,
+      symbolFor: (swap) => {
+        const { base, quote } = splitPairId(swap.pair);
+        return getChainCurrency(base, quote, swap.orderSide, true);
+      },
+      lock: SwapNursery.reverseSwapLock,
+      lockReason: 'retry',
+      loadEligible: () => this.loadEligibleReverseSwap(hold.swapId),
+      proceed: (swap, approval) => this.lockupReverseSwap(swap, approval),
+    });
+  };
+
+  // Held submarine sends are re-driven by the main retry loop, which re-runs
+  // payInvoice for every InvoicePending swap (payInvoice reads the hold via the
+  // repository to keep holding on a non-resolution). Here we only prune the hold
+  // row once the swap is gone or no longer InvoicePending; the row must persist
+  // while InvoicePending so the hook fallback keeps holding
+  private pruneStaleSubmarineHolds = async (hold: SendApprovalHold) => {
+    const swap = await SwapRepository.getSwap({ id: hold.swapId });
+    if (swap === null || swap.status !== SwapUpdateEvent.InvoicePending) {
+      await SendApprovalHoldRepository.remove(hold.swapId);
+    }
+  };
+
+  private lockupReverseSwap = async (
+    reverseSwap: ReverseSwap,
+    approval: SendApprovalAction,
+  ) => {
+    const { base, quote } = splitPairId(reverseSwap.pair);
+    const chainSymbol = getChainCurrency(
+      base,
+      quote,
+      reverseSwap.orderSide,
+      true,
+    );
+    const lightningSymbol = getLightningCurrency(
+      base,
+      quote,
+      reverseSwap.orderSide,
+      true,
+    );
+    const chainCurrency = this.currencies.get(chainSymbol)!;
+    const resolved = NodeSwitch.tryResolveReverseSwapNode(
+      this.currencies.get(lightningSymbol)!,
+      reverseSwap,
+    );
+    if (resolved.status !== ReverseSwapNodeResolutionStatus.Resolved) {
+      this.logger.warn(
+        `Skipping lockup of Reverse Swap ${reverseSwap.id}: ${resolved.reason}`,
+      );
+      return;
+    }
+    const lightningClient = resolved.lightningClient;
+
+    const wallet = this.walletManager.wallets.get(chainSymbol)!;
+
+    switch (chainCurrency.type) {
+      case CurrencyType.BitcoinLike:
+      case CurrencyType.Liquid:
+        await this.lockupUtxo(
+          reverseSwap,
+          chainCurrency.chainClient!,
+          wallet,
+          approval,
+          lightningClient,
+        );
+        break;
+
+      case CurrencyType.Ether:
+        await this.lockupEther(reverseSwap, wallet, approval, lightningClient);
+        break;
+
+      case CurrencyType.ERC20:
+        await this.lockupERC20(reverseSwap, wallet, approval, lightningClient);
+        break;
+
+      case CurrencyType.Ark:
+        await this.lockupVtxo(reverseSwap, wallet, approval, lightningClient);
+        break;
+    }
+  };
+
   private lockupUtxo = async (
     swap: ReverseSwap | ChainSwapInfo,
     chainClient: IChainClient,
     wallet: Wallet,
+    approval: SendApprovalAction,
     lightningClient?: LightningClient,
   ) => {
     try {
       this.assertLockupSignerEnabled(swap);
+      this.assertSendApproved(approval);
+
+      const onchainAmount = this.lockupAmount(swap);
 
       let feePerVbyte: number;
 
@@ -1535,10 +1760,6 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
         feePerVbyte = await chainClient.estimateFee();
       }
 
-      const onchainAmount =
-        swap.type === SwapType.ReverseSubmarine
-          ? (swap as ReverseSwap).onchainAmount
-          : (swap as ChainSwapInfo).sendingData.expectedAmount;
       const lockupAddress =
         swap.type === SwapType.ReverseSubmarine
           ? (swap as ReverseSwap).lockupAddress
@@ -1582,22 +1803,21 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     }
   };
 
-  public lockupVtxo = async (
+  private lockupVtxo = async (
     swap: ReverseSwap | ChainSwapInfo,
     wallet: Wallet,
+    approval: SendApprovalAction,
     lightningClient?: LightningClient,
   ) => {
     try {
       this.assertLockupSignerEnabled(swap);
+      this.assertSendApproved(approval);
 
       const lockupAddress =
         swap.type === SwapType.ReverseSubmarine
           ? (swap as ReverseSwap).lockupAddress
           : (swap as ChainSwapInfo).sendingData.lockupAddress;
-      const onchainAmount =
-        swap.type === SwapType.ReverseSubmarine
-          ? (swap as ReverseSwap).onchainAmount
-          : (swap as ChainSwapInfo).sendingData.expectedAmount;
+      const onchainAmount = this.lockupAmount(swap);
 
       const { transactionId, vout, fee } = await wallet.sendToAddress(
         lockupAddress,
@@ -1635,16 +1855,19 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
   private lockupEther = async (
     swap: ReverseSwap | ChainSwapInfo,
     wallet: Wallet,
+    approval: SendApprovalAction,
     lightningClient?: LightningClient,
   ) => {
     try {
       this.assertLockupSignerEnabled(swap);
+      this.assertSendApproved(approval);
 
-      const nursery = this.findEthereumNursery(wallet.symbol)!;
       const lockupDetails =
         swap.type === SwapType.ReverseSubmarine
           ? (swap as ReverseSwap)
           : (swap as ChainSwapInfo).sendingData;
+
+      const nursery = this.findEthereumNursery(wallet.symbol)!;
       const contracts = (await nursery.ethereumManager.contractsForAddress(
         lockupDetails.lockupAddress,
       ))!;
@@ -1705,18 +1928,20 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
   private lockupERC20 = async (
     swap: ReverseSwap | ChainSwapInfo,
     wallet: Wallet,
+    approval: SendApprovalAction,
     lightningClient?: LightningClient,
   ) => {
     try {
       this.assertLockupSignerEnabled(swap);
-
-      const nursery = this.findEthereumNursery(wallet.symbol)!;
-      const walletProvider = wallet.walletProvider as ERC20WalletProvider;
+      this.assertSendApproved(approval);
 
       const lockupDetails =
         swap.type === SwapType.ReverseSubmarine
           ? (swap as ReverseSwap)
           : (swap as ChainSwapInfo).sendingData;
+
+      const nursery = this.findEthereumNursery(wallet.symbol)!;
+      const walletProvider = wallet.walletProvider as ERC20WalletProvider;
       const contracts = (await nursery.ethereumManager.contractsForAddress(
         lockupDetails.lockupAddress,
       ))!;
@@ -1966,10 +2191,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       }
     }
 
-    const onchainAmount =
-      swap.type === SwapType.ReverseSubmarine
-        ? (swap as ReverseSwap).onchainAmount
-        : (swap as ChainSwapInfo).sendingData.expectedAmount;
+    const onchainAmount = this.lockupAmount(swap);
 
     this.logger.warn(
       `Failed to lockup ${onchainAmount} ${chainSymbol} for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${formatError(

--- a/lib/swap/hooks/Hook.ts
+++ b/lib/swap/hooks/Hook.ts
@@ -9,7 +9,10 @@ interface HookResponse {
 }
 
 abstract class Hook<P, Req, Res extends HookResponse> {
-  private readonly pendingHooks = new Map<string, (parsed: P) => void>();
+  private readonly pendingHooks = new Map<
+    string,
+    { resolve: (parsed: P) => void; fallback: P }
+  >();
 
   private stream?: ServerDuplexStream<Res, Req> = undefined;
 
@@ -58,19 +61,22 @@ abstract class Hook<P, Req, Res extends HookResponse> {
 
       const hook = this.pendingHooks.get(data.id);
       if (hook !== undefined) {
-        hook(this.parseGrpcAction(data));
+        hook.resolve(this.parseGrpcAction(data));
       }
     });
   };
 
   protected isConnected = (): boolean => this.stream !== undefined;
 
-  protected sendHook = (id: string, request: Req): Promise<P> => {
+  protected sendHook = (id: string, request: Req, fallback?: P): Promise<P> => {
+    const onNotConnected = fallback ?? this.notConnectedAction;
+    const onTimeout = fallback ?? this.defaultAction;
+
     if (!this.isConnected()) {
       this.logger.silly(
-        `gRPC ${this.name} hook is not connected, returning accept action`,
+        `gRPC ${this.name} hook is not connected, returning default action`,
       );
-      return Promise.resolve(this.notConnectedAction);
+      return Promise.resolve(onNotConnected);
     }
 
     const hook = new Promise<P>((resolve) => {
@@ -82,13 +88,16 @@ abstract class Hook<P, Req, Res extends HookResponse> {
       const timeout = setTimeout(() => {
         if (this.pendingHooks.has(id)) {
           this.logger.warn(`Hook ${this.name} timed out for ${id}`);
-          resolver(this.defaultAction);
+          resolver(onTimeout);
         }
       }, this.hookResolveTimeout);
 
-      this.pendingHooks.set(id, (parsed: P) => {
-        clearTimeout(timeout);
-        resolver(parsed);
+      this.pendingHooks.set(id, {
+        resolve: (parsed: P) => {
+          clearTimeout(timeout);
+          resolver(parsed);
+        },
+        fallback: onTimeout,
       });
     });
 
@@ -105,8 +114,8 @@ abstract class Hook<P, Req, Res extends HookResponse> {
     this.stream?.end();
     this.stream = undefined;
 
-    this.pendingHooks.forEach((resolve) => {
-      resolve(this.defaultAction);
+    this.pendingHooks.forEach((hook) => {
+      hook.resolve(hook.fallback);
     });
     this.pendingHooks.clear();
   };

--- a/lib/swap/hooks/SendApprovalHook.ts
+++ b/lib/swap/hooks/SendApprovalHook.ts
@@ -1,0 +1,84 @@
+import type Logger from '../../Logger';
+import { toProtoInt } from '../../Utils';
+import type NotificationClient from '../../notifications/NotificationClient';
+import * as boltzrpc from '../../proto/boltzrpc';
+import Hook from './Hook';
+
+enum SendApprovalAction {
+  Accept,
+  Reject,
+  Hold,
+}
+
+const sendApprovalActions = {
+  accept: SendApprovalAction.Accept,
+  reject: SendApprovalAction.Reject,
+  hold: SendApprovalAction.Hold,
+} as const;
+
+type SendApprovalDefaultAction = keyof typeof sendApprovalActions;
+
+const parseDefaultAction = (action?: string): SendApprovalAction => {
+  if (action === undefined) {
+    return SendApprovalAction.Accept;
+  }
+
+  const key = action.toLowerCase();
+  if (!Object.prototype.hasOwnProperty.call(sendApprovalActions, key)) {
+    throw new Error(`invalid send approval default action: ${action}`);
+  }
+
+  return sendApprovalActions[key as SendApprovalDefaultAction];
+};
+
+class SendApprovalHook extends Hook<
+  SendApprovalAction,
+  boltzrpc.SendApprovalHookRequest,
+  boltzrpc.SendApprovalHookResponse
+> {
+  constructor(
+    logger: Logger,
+    notificationClient?: NotificationClient,
+    defaultAction?: string,
+  ) {
+    const action = parseDefaultAction(defaultAction);
+    super(logger, 'send approval', action, action, 60_000, notificationClient);
+  }
+
+  public hook = (
+    swapId: string,
+    pair: string,
+    symbol: string,
+    amount: number,
+    fallback?: SendApprovalAction,
+  ): Promise<SendApprovalAction> => {
+    const msg: boltzrpc.SendApprovalHookRequest = {
+      id: swapId,
+      pair,
+      symbol,
+      amount: toProtoInt(amount),
+    };
+
+    return this.sendHook(swapId, msg, fallback);
+  };
+
+  protected parseGrpcAction = (
+    res: boltzrpc.SendApprovalHookResponse,
+  ): SendApprovalAction => {
+    switch (res.action) {
+      case boltzrpc.SendApprovalAction.SEND_APPROVAL_ACCEPT:
+        return SendApprovalAction.Accept;
+      case boltzrpc.SendApprovalAction.SEND_APPROVAL_REJECT:
+        this.logger.warn(`Hook ${this.name} rejected for ${res.id}`);
+        return SendApprovalAction.Reject;
+      case boltzrpc.SendApprovalAction.SEND_APPROVAL_HOLD:
+        return SendApprovalAction.Hold;
+      default:
+        throw new Error(`unknown action: ${res.action}`);
+    }
+  };
+}
+
+export default SendApprovalHook;
+export { SendApprovalAction };
+export type { SendApprovalDefaultAction };

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -68,6 +68,7 @@ service Boltz {
   rpc InvoiceCreationHook (stream InvoiceCreationHookResponse) returns (stream InvoiceCreationHookRequest);
   rpc TransactionHook (stream TransactionHookResponse) returns (stream TransactionHookRequest);
   rpc InvoicePaymentHook (stream InvoicePaymentHookResponse) returns (stream InvoicePaymentHookRequest);
+  rpc SendApprovalHook (stream SendApprovalHookResponse) returns (stream SendApprovalHookRequest);
 
   rpc SetLogLevel (SetLogLevelRequest) returns (SetLogLevelResponse);
 
@@ -510,6 +511,29 @@ message InvoicePaymentHookRequest {
   string id = 1;
   string invoice = 2;
   boltzr.DecodeInvoiceOrOfferResponse decoded = 3;
+}
+
+enum SendApprovalAction {
+  SEND_APPROVAL_ACCEPT = 0;
+  SEND_APPROVAL_REJECT = 1;
+  SEND_APPROVAL_HOLD = 2;
+}
+
+message SendApprovalHookResponse {
+  // Swap ID
+  string id = 1;
+  // ACCEPT to continue the send, REJECT to fail the swap, HOLD to pause the
+  // send and keep retrying until a later response
+  SendApprovalAction action = 2;
+}
+
+message SendApprovalHookRequest {
+  // Swap ID
+  string id = 1;
+  string pair = 2;
+  // Symbol of the asset being sent out
+  string symbol = 3;
+  uint64 amount = 4;
 }
 
 message SetLogLevelRequest {

--- a/test/integration/db/repositories/SendApprovalHoldRepository.spec.ts
+++ b/test/integration/db/repositories/SendApprovalHoldRepository.spec.ts
@@ -1,0 +1,105 @@
+import Logger from '../../../../lib/Logger';
+import { SwapType } from '../../../../lib/consts/Enums';
+import Database from '../../../../lib/db/Database';
+import SendApprovalHold from '../../../../lib/db/models/SendApprovalHold';
+import SendApprovalHoldRepository from '../../../../lib/db/repositories/SendApprovalHoldRepository';
+
+describe('SendApprovalHoldRepository', () => {
+  let database: Database;
+
+  beforeAll(async () => {
+    database = new Database(Logger.disabledLogger, Database.memoryDatabase);
+    await database.init();
+  });
+
+  beforeEach(async () => {
+    await SendApprovalHold.truncate();
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  test('should create a hold', async () => {
+    const hold = await SendApprovalHoldRepository.create({
+      swapId: 'swap-id',
+      type: SwapType.ReverseSubmarine,
+    });
+
+    expect(hold.swapId).toEqual('swap-id');
+    expect(hold.type).toEqual(SwapType.ReverseSubmarine);
+    expect(await SendApprovalHoldRepository.getAll()).toHaveLength(1);
+  });
+
+  test('should reject a hold with an invalid type', async () => {
+    await expect(
+      SendApprovalHoldRepository.create({
+        swapId: 'swap-id',
+        type: 99 as unknown as SwapType,
+      }),
+    ).rejects.toThrow();
+
+    expect(await SendApprovalHoldRepository.getAll()).toHaveLength(0);
+  });
+
+  test('should be idempotent when the hold already exists', async () => {
+    await SendApprovalHoldRepository.create({
+      swapId: 'swap-id',
+      type: SwapType.Chain,
+    });
+    const again = await SendApprovalHoldRepository.create({
+      swapId: 'swap-id',
+      type: SwapType.ReverseSubmarine,
+    });
+
+    expect(again.type).toEqual(SwapType.Chain);
+    expect(await SendApprovalHoldRepository.getAll()).toHaveLength(1);
+  });
+
+  test('should get all holds', async () => {
+    await SendApprovalHoldRepository.create({
+      swapId: 'a',
+      type: SwapType.Chain,
+    });
+    await SendApprovalHoldRepository.create({
+      swapId: 'b',
+      type: SwapType.ReverseSubmarine,
+    });
+
+    const all = await SendApprovalHoldRepository.getAll();
+    expect(all.map((hold) => hold.swapId).sort()).toEqual(['a', 'b']);
+    expect(all.find((hold) => hold.swapId === 'a')?.type).toEqual(
+      SwapType.Chain,
+    );
+    expect(all.find((hold) => hold.swapId === 'b')?.type).toEqual(
+      SwapType.ReverseSubmarine,
+    );
+  });
+
+  test('should remove a hold', async () => {
+    await SendApprovalHoldRepository.create({
+      swapId: 'swap-id',
+      type: SwapType.Chain,
+    });
+
+    expect(await SendApprovalHoldRepository.remove('swap-id')).toEqual(1);
+    expect(await SendApprovalHoldRepository.getAll()).toHaveLength(0);
+  });
+
+  test('should not fail removing a non-existent hold', async () => {
+    expect(await SendApprovalHoldRepository.remove('missing')).toEqual(0);
+  });
+
+  test('should report whether a hold exists', async () => {
+    expect(await SendApprovalHoldRepository.exists('swap-id')).toEqual(false);
+
+    await SendApprovalHoldRepository.create({
+      swapId: 'swap-id',
+      type: SwapType.Chain,
+    });
+    expect(await SendApprovalHoldRepository.exists('swap-id')).toEqual(true);
+
+    await SendApprovalHoldRepository.remove('swap-id');
+    expect(await SendApprovalHoldRepository.exists('swap-id')).toEqual(false);
+  });
+});

--- a/test/unit/lightning/PendingPaymentTracker.spec.ts
+++ b/test/unit/lightning/PendingPaymentTracker.spec.ts
@@ -109,6 +109,50 @@ describe('PendingPaymentTracker', () => {
     ).stop();
   });
 
+  describe('getRelevantNode', () => {
+    const preferredNode = { id: 'preferred' } as unknown as LightningClient;
+    const swap = { invoice: 'lnbcrt1' } as unknown as Swap;
+    const currency = { lndClients: new Map(), clnClient: undefined } as any;
+
+    beforeEach(() => {
+      (tracker as any).sidecar = {
+        decodeInvoiceOrOffer: jest
+          .fn()
+          .mockResolvedValue({ paymentHash: randomBytes(32) }),
+      };
+    });
+
+    test('should return existingRelevantAction undefined when no relevant payment exists', async () => {
+      LightningPaymentRepository.findByPreimageHash = jest
+        .fn()
+        .mockResolvedValue([
+          {
+            status: LightningPaymentStatus.TemporaryFailure,
+          } as LightningPayment,
+        ]);
+
+      const res = await tracker.getRelevantNode(currency, swap, preferredNode);
+
+      expect(res.existingRelevantAction).toBeUndefined();
+      expect(res.node).toBe(preferredNode);
+    });
+
+    test('should return the in-flight payment as existingRelevantAction', async () => {
+      const pending = {
+        status: LightningPaymentStatus.Pending,
+        nodeId: 'missing',
+      } as LightningPayment;
+      LightningPaymentRepository.findByPreimageHash = jest
+        .fn()
+        .mockResolvedValue([pending]);
+
+      const res = await tracker.getRelevantNode(currency, swap, preferredNode);
+
+      expect(res.existingRelevantAction).toBe(pending);
+      expect(res.node).toBe(preferredNode);
+    });
+  });
+
   describe('sendPaymentWithNode', () => {
     const lightningClient = {
       id: 'lnd-1',

--- a/test/unit/swap/PaymentHandler.spec.ts
+++ b/test/unit/swap/PaymentHandler.spec.ts
@@ -1,7 +1,9 @@
 import Logger from '../../../lib/Logger';
 import { getHexBuffer } from '../../../lib/Utils';
-import { SwapUpdateEvent } from '../../../lib/consts/Enums';
+import { SwapType, SwapUpdateEvent } from '../../../lib/consts/Enums';
+import { LightningPaymentStatus } from '../../../lib/db/models/LightningPayment';
 import type Swap from '../../../lib/db/models/Swap';
+import SendApprovalHoldRepository from '../../../lib/db/repositories/SendApprovalHoldRepository';
 import LightningErrors from '../../../lib/lightning/Errors';
 import type { LightningClient } from '../../../lib/lightning/LightningClient';
 import LndClient from '../../../lib/lightning/LndClient';
@@ -15,6 +17,7 @@ import type Sidecar from '../../../lib/sidecar/Sidecar';
 import NodeSwitch from '../../../lib/swap/NodeSwitch';
 import PaymentHandler from '../../../lib/swap/PaymentHandler';
 import { InvoicePaymentHookAction } from '../../../lib/swap/hooks/InvoicePaymentHook';
+import { SendApprovalAction } from '../../../lib/swap/hooks/SendApprovalHook';
 import type { Currency } from '../../../lib/wallet/WalletManager';
 import { raceCall } from '../../Utils';
 
@@ -34,6 +37,15 @@ jest.mock('../../../lib/swap/NodeSwitch', () => {
 });
 
 const MockedNodeSwitch = <jest.Mock<NodeSwitch>>(<any>NodeSwitch);
+
+jest.mock('../../../lib/db/repositories/SendApprovalHoldRepository', () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    exists: jest.fn().mockResolvedValue(false),
+  },
+}));
 
 let cltvLimit = 100;
 
@@ -84,6 +96,10 @@ describe('PaymentHandler', () => {
 
   const mockedEmit = jest.fn();
 
+  const sendApprovalHook = {
+    hook: jest.fn().mockResolvedValue(SendApprovalAction.Accept),
+  };
+
   const btcLndClient = MockedLndClient();
 
   const btcCurrency = {
@@ -95,6 +111,7 @@ describe('PaymentHandler', () => {
     id: 'test',
     invoice: 'lnbcrt1testinvoice',
     pair: 'BTC/BTC',
+    type: SwapType.Submarine,
     preimageHash:
       '8bc944ac6563a0dc50c2666ffc1f6cc6295d5f093859f869c8d065fcb965443a',
     status: SwapUpdateEvent.InvoicePending,
@@ -122,10 +139,18 @@ describe('PaymentHandler', () => {
             node,
             paymentHash: swap.preimageHash,
             payments: relevantPayments,
+            existingRelevantAction: relevantPayments.find((p: any) =>
+              [
+                LightningPaymentStatus.Pending,
+                LightningPaymentStatus.Success,
+                LightningPaymentStatus.PermanentFailure,
+              ].includes(p.status),
+            ),
           };
         }),
     } as any,
     { emit: mockedEmit } as any,
+    sendApprovalHook as any,
   );
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
@@ -143,6 +168,12 @@ describe('PaymentHandler', () => {
     trackPaymentResponse = undefined;
     (signerControlRegistry as any)['disabledSigners'].clear();
     (signerControlRegistry as any)['repository'] = undefined;
+    sendApprovalHook.hook.mockResolvedValue(SendApprovalAction.Accept);
+    (SendApprovalHoldRepository.exists as jest.Mock)
+      .mockReset()
+      .mockResolvedValue(false);
+    (SendApprovalHoldRepository.create as jest.Mock).mockReset();
+    (SendApprovalHoldRepository.remove as jest.Mock).mockReset();
     relevantPayments = [];
     (
       handler['selfPaymentClient'].handleSelfPayment as jest.Mock
@@ -192,11 +223,136 @@ describe('PaymentHandler', () => {
     });
   });
 
-  test('should allow payment retries with history when signer is disabled', async () => {
+  test('should fail when the send approval hook rejects', async () => {
+    sendApprovalHook.hook.mockResolvedValue(SendApprovalAction.Reject);
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(sendApprovalHook.hook).toHaveBeenCalledTimes(1);
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+    expect(swap.update).toHaveBeenCalledTimes(1);
+    expect(swap.update).toHaveBeenCalledWith({
+      failureReason: 'invoice could not be paid',
+      status: SwapUpdateEvent.InvoiceFailedToPay,
+    });
+  });
+
+  test('should hold the payment without paying or failing when the send approval hook holds', async () => {
+    sendApprovalHook.hook.mockResolvedValue(SendApprovalAction.Hold);
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(sendApprovalHook.hook).toHaveBeenCalledTimes(1);
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+    expect(swap.update).not.toHaveBeenCalled();
+    expect(SendApprovalHoldRepository.create).toHaveBeenCalledWith({
+      swapId: swap.id,
+      type: SwapType.Submarine,
+    });
+  });
+
+  test('should ask with a hold fallback and not release a held payment', async () => {
+    (SendApprovalHoldRepository.exists as jest.Mock).mockResolvedValue(true);
+    sendApprovalHook.hook.mockResolvedValue(SendApprovalAction.Hold);
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(sendApprovalHook.hook).toHaveBeenCalledWith(
+      swap.id,
+      swap.pair,
+      'BTC',
+      expect.anything(),
+      SendApprovalAction.Hold,
+    );
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+    expect(SendApprovalHoldRepository.remove).not.toHaveBeenCalled();
+  });
+
+  test('should remove the hold and pay when accepted after being held', async () => {
+    (SendApprovalHoldRepository.exists as jest.Mock).mockResolvedValue(true);
+    sendApprovalHook.hook.mockResolvedValue(SendApprovalAction.Accept);
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(swap.id);
+    expect(btcLndClient.sendPayment).toHaveBeenCalledTimes(1);
+  });
+
+  test('should remove the hold when a held payment is rejected', async () => {
+    (SendApprovalHoldRepository.exists as jest.Mock).mockResolvedValue(true);
+    sendApprovalHook.hook.mockResolvedValue(SendApprovalAction.Reject);
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(swap.id);
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+    expect(swap.update).toHaveBeenCalledWith({
+      failureReason: 'invoice could not be paid',
+      status: SwapUpdateEvent.InvoiceFailedToPay,
+    });
+  });
+
+  test('should clear any hold and pay on a normal accepted payment', async () => {
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(sendApprovalHook.hook).toHaveBeenCalledWith(
+      swap.id,
+      swap.pair,
+      'BTC',
+      expect.anything(),
+      undefined,
+    );
+    expect(SendApprovalHoldRepository.create).not.toHaveBeenCalled();
+    expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(swap.id);
+    expect(btcLndClient.sendPayment).toHaveBeenCalledTimes(1);
+  });
+
+  test('should pay once the send approval hook stops holding', async () => {
+    sendApprovalHook.hook
+      .mockResolvedValueOnce(SendApprovalAction.Hold)
+      .mockResolvedValueOnce(SendApprovalAction.Accept);
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+
+    await handler.payInvoice(swap);
+
+    expect(sendApprovalHook.hook).toHaveBeenCalledTimes(2);
+    expect(btcLndClient.sendPayment).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not ask the send approval hook when a payment is already in flight', async () => {
+    relevantPayments = [{ status: LightningPaymentStatus.Pending } as any];
+    sendApprovalHook.hook.mockResolvedValue(SendApprovalAction.Reject);
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(sendApprovalHook.hook).not.toHaveBeenCalled();
+    expect(btcLndClient.sendPayment).toHaveBeenCalledTimes(1);
+    expect(swap.update).not.toHaveBeenCalled();
+  });
+
+  test('should ask the send approval hook on a retry after a temporary failure', async () => {
+    relevantPayments = [
+      { status: LightningPaymentStatus.TemporaryFailure } as any,
+    ];
+    sendApprovalHook.hook.mockResolvedValue(SendApprovalAction.Reject);
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(sendApprovalHook.hook).toHaveBeenCalledTimes(1);
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+    expect(swap.update).toHaveBeenCalledWith({
+      failureReason: 'invoice could not be paid',
+      status: SwapUpdateEvent.InvoiceFailedToPay,
+    });
+  });
+
+  test('should allow an in-flight payment to resolve when signer is disabled', async () => {
     await signerControlRegistry.disableSigners([
       Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
     ]);
-    relevantPayments = [{} as any];
+    relevantPayments = [{ status: LightningPaymentStatus.Pending } as any];
 
     await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
 
@@ -211,6 +367,24 @@ describe('PaymentHandler', () => {
     );
     expect(btcLndClient.sendPayment).toHaveBeenCalledTimes(1);
     expect(swap.update).not.toHaveBeenCalled();
+  });
+
+  test('should fail fast on a temporary-failure retry when signer is disabled', async () => {
+    await signerControlRegistry.disableSigners([
+      Signer.SIGNER_SUBMARINE_INVOICE_PAYMENT,
+    ]);
+    relevantPayments = [
+      { status: LightningPaymentStatus.TemporaryFailure } as any,
+    ];
+
+    await expect(handler.payInvoice(swap)).resolves.toEqual(undefined);
+
+    expect(sendApprovalHook.hook).not.toHaveBeenCalled();
+    expect(btcLndClient.sendPayment).not.toHaveBeenCalled();
+    expect(swap.update).toHaveBeenCalledWith({
+      failureReason: 'invoice could not be paid',
+      status: SwapUpdateEvent.InvoiceFailedToPay,
+    });
   });
 
   test.each`

--- a/test/unit/swap/SendApprovalGuard.spec.ts
+++ b/test/unit/swap/SendApprovalGuard.spec.ts
@@ -1,0 +1,95 @@
+import { SwapType } from '../../../lib/consts/Enums';
+import SendApprovalHoldRepository from '../../../lib/db/repositories/SendApprovalHoldRepository';
+import {
+  persistSendApprovalDecision,
+  resolveSendApprovalDecision,
+} from '../../../lib/swap/SendApprovalGuard';
+import { SendApprovalAction } from '../../../lib/swap/hooks/SendApprovalHook';
+
+jest.mock('../../../lib/db/repositories/SendApprovalHoldRepository', () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    exists: jest.fn().mockResolvedValue(false),
+  },
+}));
+
+describe('SendApprovalGuard', () => {
+  const hook = { hook: jest.fn().mockResolvedValue(SendApprovalAction.Accept) };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (SendApprovalHoldRepository.exists as jest.Mock).mockResolvedValue(false);
+  });
+
+  describe('resolveSendApprovalDecision', () => {
+    test('should ask without a fallback when the swap is not held', async () => {
+      await expect(
+        resolveSendApprovalDecision(hook as any, 'id', 'L-BTC/BTC', 'BTC', 100),
+      ).resolves.toEqual(SendApprovalAction.Accept);
+
+      expect(hook.hook).toHaveBeenCalledWith(
+        'id',
+        'L-BTC/BTC',
+        'BTC',
+        100,
+        undefined,
+      );
+    });
+
+    test('should ask with a hold fallback when the swap is already held', async () => {
+      (SendApprovalHoldRepository.exists as jest.Mock).mockResolvedValue(true);
+
+      await resolveSendApprovalDecision(
+        hook as any,
+        'id',
+        'L-BTC/BTC',
+        'BTC',
+        100,
+      );
+
+      expect(hook.hook).toHaveBeenCalledWith(
+        'id',
+        'L-BTC/BTC',
+        'BTC',
+        100,
+        SendApprovalAction.Hold,
+      );
+    });
+  });
+
+  describe('persistSendApprovalDecision', () => {
+    test('should create the hold and not allow proceeding on Hold', async () => {
+      await expect(
+        persistSendApprovalDecision(
+          'id',
+          SwapType.Chain,
+          SendApprovalAction.Hold,
+        ),
+      ).resolves.toEqual(false);
+
+      expect(SendApprovalHoldRepository.create).toHaveBeenCalledWith({
+        swapId: 'id',
+        type: SwapType.Chain,
+      });
+      expect(SendApprovalHoldRepository.remove).not.toHaveBeenCalled();
+    });
+
+    test.each`
+      action
+      ${SendApprovalAction.Accept}
+      ${SendApprovalAction.Reject}
+    `(
+      'should remove the hold and allow proceeding on $action',
+      async ({ action }) => {
+        await expect(
+          persistSendApprovalDecision('id', SwapType.Submarine, action),
+        ).resolves.toEqual(true);
+
+        expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith('id');
+        expect(SendApprovalHoldRepository.create).not.toHaveBeenCalled();
+      },
+    );
+  });
+});

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -10,10 +10,12 @@ import {
 } from '../../../lib/consts/Enums';
 import type ReverseSwap from '../../../lib/db/models/ReverseSwap';
 import { NodeType } from '../../../lib/db/models/ReverseSwap';
+import type Swap from '../../../lib/db/models/Swap';
 import type { ChainSwapInfo } from '../../../lib/db/repositories/ChainSwapRepository';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
 import RefundTransactionRepository from '../../../lib/db/repositories/RefundTransactionRepository';
 import ReverseSwapRepository from '../../../lib/db/repositories/ReverseSwapRepository';
+import SendApprovalHoldRepository from '../../../lib/db/repositories/SendApprovalHoldRepository';
 import SwapRepository from '../../../lib/db/repositories/SwapRepository';
 import WrappedSwapRepository from '../../../lib/db/repositories/WrappedSwapRepository';
 import type { LightningClient } from '../../../lib/lightning/LightningClient';
@@ -22,6 +24,7 @@ import { Signer } from '../../../lib/proto/boltzrpc';
 import SignerControlRegistry from '../../../lib/service/SignerControlRegistry';
 import Errors from '../../../lib/swap/Errors';
 import SwapNursery from '../../../lib/swap/SwapNursery';
+import { SendApprovalAction } from '../../../lib/swap/hooks/SendApprovalHook';
 import type { Currency } from '../../../lib/wallet/WalletManager';
 import {
   queryERC20SwapValuesFromLock,
@@ -36,6 +39,15 @@ jest.mock('../../../lib/db/repositories/ReverseSwapRepository');
 jest.mock('../../../lib/db/repositories/ChainSwapRepository');
 jest.mock('../../../lib/db/repositories/WrappedSwapRepository');
 jest.mock('../../../lib/db/repositories/RefundTransactionRepository');
+jest.mock('../../../lib/db/repositories/SendApprovalHoldRepository', () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    getAll: jest.fn().mockResolvedValue([]),
+    exists: jest.fn().mockResolvedValue(false),
+  },
+}));
 jest.mock('../../../lib/wallet/ethereum/contracts/ContractUtils', () => ({
   queryEtherSwapValuesFromLock: jest.fn(),
   queryERC20SwapValuesFromLock: jest.fn(),
@@ -351,6 +363,251 @@ describe('SwapNursery', () => {
         );
       },
     );
+
+    const makeSendApprovalNursery = () => {
+      const signerControlRegistry = SignerControlRegistry.getInstance();
+      (signerControlRegistry as any)['disabledSigners'].clear();
+      (signerControlRegistry as any)['repository'] = undefined;
+
+      return new SwapNursery(
+        mockLogger,
+        {} as any,
+        mockNotifications,
+        {} as any,
+        {} as any,
+        {} as any,
+        mockWalletManager,
+        {} as any,
+        0,
+        mockClaimer,
+        mockChainSwapSigner,
+        {} as any,
+        {} as any,
+      );
+    };
+
+    const chainSendSwap = {
+      id: 'chain-swap-id',
+      pair: 'BTC/BTC',
+      type: SwapType.Chain,
+      sendingData: {
+        expectedAmount: 100_000,
+        lockupAddress: 'bcrt1lockup',
+        symbol: 'BTC',
+      },
+    };
+    const reverseSendSwap = {
+      id: 'reverse-swap-id',
+      pair: 'BTC/BTC',
+      type: SwapType.ReverseSubmarine,
+      onchainAmount: 90_000,
+      lockupAddress: 'bcrt1reverse',
+    };
+
+    test.each`
+      method           | swap
+      ${'lockupUtxo'}  | ${chainSendSwap}
+      ${'lockupVtxo'}  | ${chainSendSwap}
+      ${'lockupEther'} | ${chainSendSwap}
+      ${'lockupERC20'} | ${chainSendSwap}
+      ${'lockupUtxo'}  | ${reverseSendSwap}
+      ${'lockupVtxo'}  | ${reverseSendSwap}
+      ${'lockupEther'} | ${reverseSendSwap}
+      ${'lockupERC20'} | ${reverseSendSwap}
+    `(
+      'should fail $method ($swap.type) when the send approval is rejected',
+      async ({ method, swap }) => {
+        const nursery = makeSendApprovalNursery();
+
+        const wallet = {
+          symbol: 'BTC',
+          sendToAddress: jest.fn(),
+        };
+        const handleSwapSendFailedSpy = jest
+          .spyOn(nursery as any, 'handleSwapSendFailed')
+          .mockResolvedValue(undefined);
+
+        if (method === 'lockupUtxo') {
+          await (nursery as any)[method](
+            swap,
+            mockChainClient,
+            wallet,
+            SendApprovalAction.Reject,
+          );
+        } else {
+          await (nursery as any)[method](
+            swap,
+            wallet,
+            SendApprovalAction.Reject,
+          );
+        }
+
+        expect(wallet.sendToAddress).not.toHaveBeenCalled();
+        expect(handleSwapSendFailedSpy).toHaveBeenCalledTimes(1);
+        expect(
+          (handleSwapSendFailedSpy.mock.calls[0][2] as Error).message,
+        ).toEqual(Errors.HOOK_REJECTED().message);
+      },
+    );
+
+    test('should fail the lockup defensively when the approval is a hold', async () => {
+      const nursery = makeSendApprovalNursery();
+      const wallet = { symbol: 'BTC', sendToAddress: jest.fn() };
+      const handleSwapSendFailedSpy = jest
+        .spyOn(nursery as any, 'handleSwapSendFailed')
+        .mockResolvedValue(undefined);
+
+      await (nursery as any).lockupVtxo(
+        chainSendSwap,
+        wallet,
+        SendApprovalAction.Hold,
+      );
+
+      expect(wallet.sendToAddress).not.toHaveBeenCalled();
+      expect(handleSwapSendFailedSpy).toHaveBeenCalledTimes(1);
+      expect(
+        (handleSwapSendFailedSpy.mock.calls[0][2] as Error).message,
+      ).toEqual(Errors.HOOK_REJECTED().message);
+    });
+
+    test('should lock up when the send approval is accepted', async () => {
+      const nursery = makeSendApprovalNursery();
+
+      const wallet = {
+        symbol: 'BTC',
+        sendToAddress: jest
+          .fn()
+          .mockResolvedValue({ transactionId: 'txid', vout: 0, fee: 1 }),
+      };
+
+      await (nursery as any).lockupVtxo(
+        chainSendSwap,
+        wallet,
+        SendApprovalAction.Accept,
+      );
+
+      expect(wallet.sendToAddress).toHaveBeenCalledTimes(1);
+      expect(wallet.sendToAddress).toHaveBeenCalledWith(
+        chainSendSwap.sendingData.lockupAddress,
+        chainSendSwap.sendingData.expectedAmount,
+        undefined,
+        expect.anything(),
+      );
+    });
+
+    test.each`
+      swap               | amount
+      ${chainSendSwap}   | ${chainSendSwap.sendingData.expectedAmount}
+      ${reverseSendSwap} | ${reverseSendSwap.onchainAmount}
+    `(
+      'should resolve send approval with the $swap.type lockup amount',
+      async ({ swap, amount }) => {
+        const nursery = makeSendApprovalNursery();
+        const hook = jest.fn().mockResolvedValue(SendApprovalAction.Accept);
+        (nursery as any).sendApprovalHook = { hook };
+
+        await expect(
+          (nursery as any).resolveSendApproval(swap, 'BTC'),
+        ).resolves.toEqual(SendApprovalAction.Accept);
+
+        expect(hook).toHaveBeenCalledWith(
+          swap.id,
+          swap.pair,
+          'BTC',
+          amount,
+          undefined,
+        );
+      },
+    );
+
+    test('should share one in-flight send approval per swap id', async () => {
+      const nursery = makeSendApprovalNursery();
+      let resolveHook!: (action: SendApprovalAction) => void;
+      const hook = jest.fn().mockReturnValue(
+        new Promise<SendApprovalAction>((resolve) => {
+          resolveHook = resolve;
+        }),
+      );
+      (nursery as any).sendApprovalHook = { hook };
+
+      const first = (nursery as any).resolveSendApproval(chainSendSwap, 'BTC');
+      const second = (nursery as any).resolveSendApproval(chainSendSwap, 'BTC');
+
+      expect(second).toBe(first);
+      // the deduped hook call fires after the async already-held check
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(hook).toHaveBeenCalledTimes(1);
+
+      resolveHook(SendApprovalAction.Accept);
+      await expect(first).resolves.toEqual(SendApprovalAction.Accept);
+
+      await (nursery as any).resolveSendApproval(chainSendSwap, 'BTC');
+      expect(hook).toHaveBeenCalledTimes(1);
+
+      await (nursery as any).handleSendApproval(
+        chainSendSwap,
+        SendApprovalAction.Accept,
+      );
+
+      await (nursery as any).resolveSendApproval(chainSendSwap, 'BTC');
+      expect(hook).toHaveBeenCalledTimes(2);
+    });
+
+    test('keeps the in-flight decision until it is persisted', async () => {
+      const nursery = makeSendApprovalNursery();
+      const hook = jest.fn().mockResolvedValue(SendApprovalAction.Hold);
+      (nursery as any).sendApprovalHook = { hook };
+
+      await expect(
+        (nursery as any).resolveSendApproval(chainSendSwap, 'BTC'),
+      ).resolves.toEqual(SendApprovalAction.Hold);
+
+      await (nursery as any).resolveSendApproval(chainSendSwap, 'BTC');
+
+      expect(hook).toHaveBeenCalledTimes(1);
+      expect(SendApprovalHoldRepository.exists).toHaveBeenCalledTimes(1);
+    });
+
+    test('should ask with a hold fallback when the swap is already held', async () => {
+      const nursery = makeSendApprovalNursery();
+      const hook = jest.fn().mockResolvedValue(SendApprovalAction.Hold);
+      (nursery as any).sendApprovalHook = { hook };
+      (SendApprovalHoldRepository.exists as jest.Mock).mockResolvedValueOnce(
+        true,
+      );
+
+      await (nursery as any).resolveSendApproval(chainSendSwap, 'BTC');
+
+      expect(hook).toHaveBeenCalledWith(
+        chainSendSwap.id,
+        chainSendSwap.pair,
+        'BTC',
+        chainSendSwap.sendingData.expectedAmount,
+        SendApprovalAction.Hold,
+      );
+    });
+
+    test('should keep an already-held swap held when the hook is disconnected', async () => {
+      const nursery = makeSendApprovalNursery();
+      (SendApprovalHoldRepository.exists as jest.Mock).mockResolvedValueOnce(
+        true,
+      );
+
+      await expect(
+        (nursery as any).resolveSendApproval(chainSendSwap, 'BTC'),
+      ).resolves.toEqual(SendApprovalAction.Hold);
+    });
+
+    test('should fall back to the configured default on first contact when the hook is disconnected', async () => {
+      const nursery = makeSendApprovalNursery();
+      (SendApprovalHoldRepository.exists as jest.Mock).mockResolvedValueOnce(
+        false,
+      );
+
+      await expect(
+        (nursery as any).resolveSendApproval(chainSendSwap, 'BTC'),
+      ).resolves.toEqual(SendApprovalAction.Accept);
+    });
 
     test('should not register chain swaps for claim when UTXO lockup signer is disabled', async () => {
       const guardedNursery = await createGuardedNursery(
@@ -713,6 +970,491 @@ describe('SwapNursery', () => {
     });
   });
 
+  describe('invoice.paid', () => {
+    const getInvoicePaidHandler = async () => {
+      await swapNursery.init([mockCurrency]);
+      const handler = (swapNursery as any).lightningNursery.on.mock.calls.find(
+        ([event]: [string]) => event === 'invoice.paid',
+      )?.[1];
+      expect(handler).toBeDefined();
+      return handler;
+    };
+
+    test('should warn and not ask approval when the reverse swap is missing', async () => {
+      jest
+        .spyOn(ReverseSwapRepository, 'getReverseSwap')
+        .mockResolvedValue(null);
+      (swapNursery as any).sendApprovalHook = { hook: jest.fn() };
+
+      const handler = await getInvoicePaidHandler();
+      await handler({ id: 'missing' });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Could not find Reverse Swap with id: missing',
+      );
+      expect((swapNursery as any).sendApprovalHook.hook).not.toHaveBeenCalled();
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith('missing');
+    });
+
+    test('should not ask approval when the reverse swap status is not eligible', async () => {
+      jest.spyOn(ReverseSwapRepository, 'getReverseSwap').mockResolvedValue({
+        id: 'reverse-swap-id',
+        pair: 'BTC/BTC',
+        orderSide: OrderSide.BUY,
+        status: SwapUpdateEvent.TransactionMempool,
+      } as ReverseSwap);
+      (swapNursery as any).sendApprovalHook = { hook: jest.fn() };
+
+      const handler = await getInvoicePaidHandler();
+      await handler({ id: 'reverse-swap-id' });
+
+      expect((swapNursery as any).sendApprovalHook.hook).not.toHaveBeenCalled();
+    });
+
+    test.each`
+      type                        | method           | hasChainClient
+      ${CurrencyType.BitcoinLike} | ${'lockupUtxo'}  | ${true}
+      ${CurrencyType.Ether}       | ${'lockupEther'} | ${false}
+      ${CurrencyType.ERC20}       | ${'lockupERC20'} | ${false}
+      ${CurrencyType.Ark}         | ${'lockupVtxo'}  | ${false}
+    `(
+      'should resolve the send approval and thread it into $method',
+      async ({ type, method, hasChainClient }) => {
+        const reverseSwap = {
+          id: 'reverse-swap-id',
+          pair: 'BTC/BTC',
+          type: SwapType.ReverseSubmarine,
+          orderSide: OrderSide.BUY,
+          status: SwapUpdateEvent.SwapCreated,
+          onchainAmount: 100_000,
+          nodeId: mockLndClient.id,
+        } as unknown as ReverseSwap;
+        jest
+          .spyOn(ReverseSwapRepository, 'getReverseSwap')
+          .mockResolvedValue(reverseSwap);
+        (swapNursery as any).sendApprovalHook = {
+          hook: jest.fn().mockResolvedValue(SendApprovalAction.Reject),
+        };
+        const methodSpy = jest
+          .spyOn(swapNursery as any, method)
+          .mockResolvedValue(undefined);
+
+        const handler = await getInvoicePaidHandler();
+        swapNursery.currencies = new Map([['BTC', { ...mockCurrency, type }]]);
+        await handler({ id: reverseSwap.id });
+
+        expect((swapNursery as any).sendApprovalHook.hook).toHaveBeenCalledWith(
+          reverseSwap.id,
+          reverseSwap.pair,
+          'BTC',
+          reverseSwap.onchainAmount,
+          undefined,
+        );
+        expect(methodSpy).toHaveBeenCalledWith(
+          reverseSwap,
+          ...(hasChainClient ? [mockCurrency.chainClient] : []),
+          mockWallet,
+          SendApprovalAction.Reject,
+          mockLndClient,
+        );
+      },
+    );
+
+    test('should record a hold and not lock up when the send approval holds', async () => {
+      const reverseSwap = {
+        id: 'reverse-swap-id',
+        pair: 'BTC/BTC',
+        type: SwapType.ReverseSubmarine,
+        orderSide: OrderSide.BUY,
+        status: SwapUpdateEvent.SwapCreated,
+        onchainAmount: 100_000,
+        nodeId: mockLndClient.id,
+      } as unknown as ReverseSwap;
+      jest
+        .spyOn(ReverseSwapRepository, 'getReverseSwap')
+        .mockResolvedValue(reverseSwap);
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Hold),
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'lockupReverseSwap')
+        .mockResolvedValue(undefined);
+
+      const handler = await getInvoicePaidHandler();
+      swapNursery.currencies = new Map([
+        ['BTC', { ...mockCurrency, type: CurrencyType.BitcoinLike }],
+      ]);
+      await handler({ id: reverseSwap.id });
+
+      expect(SendApprovalHoldRepository.create).toHaveBeenCalledWith({
+        swapId: reverseSwap.id,
+        type: SwapType.ReverseSubmarine,
+      });
+      expect(lockupSpy).not.toHaveBeenCalled();
+    });
+
+    test('should not lock up when the reverse swap becomes final while approval is pending', async () => {
+      const reverseSwap = {
+        id: 'reverse-swap-id',
+        pair: 'BTC/BTC',
+        type: SwapType.ReverseSubmarine,
+        orderSide: OrderSide.BUY,
+        status: SwapUpdateEvent.SwapCreated,
+        onchainAmount: 100_000,
+        nodeId: mockLndClient.id,
+      } as unknown as ReverseSwap;
+      jest
+        .spyOn(ReverseSwapRepository, 'getReverseSwap')
+        .mockResolvedValueOnce(reverseSwap)
+        .mockResolvedValueOnce({
+          ...reverseSwap,
+          status: SwapUpdateEvent.TransactionRefunded,
+        } as ReverseSwap);
+      let resolveApproval!: (action: SendApprovalAction) => void;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockReturnValue(
+          new Promise<SendApprovalAction>((resolve) => {
+            resolveApproval = resolve;
+          }),
+        ),
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'lockupReverseSwap')
+        .mockResolvedValue(undefined);
+
+      const handler = await getInvoicePaidHandler();
+      const handlerPromise = handler({ id: reverseSwap.id });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      resolveApproval(SendApprovalAction.Accept);
+      await handlerPromise;
+
+      expect(lockupSpy).not.toHaveBeenCalled();
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        reverseSwap.id,
+      );
+      expect((swapNursery as any).pendingSendApprovals.size).toEqual(0);
+    });
+  });
+
+  describe('retryHeldLockup', () => {
+    const heldReverseSwap = {
+      id: 'reverse-swap-id',
+      pair: 'BTC/BTC',
+      type: SwapType.ReverseSubmarine,
+      orderSide: OrderSide.BUY,
+      status: SwapUpdateEvent.SwapCreated,
+      onchainAmount: 100_000,
+    } as unknown as ReverseSwap;
+
+    test('should re-drive a held reverse swap and lock up when accepted', async () => {
+      jest
+        .spyOn(ReverseSwapRepository, 'getReverseSwap')
+        .mockResolvedValue(heldReverseSwap);
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Accept),
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'lockupReverseSwap')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldReverseSwap.id,
+        type: SwapType.ReverseSubmarine,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        heldReverseSwap.id,
+      );
+      expect(lockupSpy).toHaveBeenCalledWith(
+        heldReverseSwap,
+        SendApprovalAction.Accept,
+      );
+    });
+
+    test('should keep holding and not lock up when still held', async () => {
+      jest
+        .spyOn(ReverseSwapRepository, 'getReverseSwap')
+        .mockResolvedValue(heldReverseSwap);
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Hold),
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'lockupReverseSwap')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldReverseSwap.id,
+        type: SwapType.ReverseSubmarine,
+      });
+
+      expect(lockupSpy).not.toHaveBeenCalled();
+    });
+
+    test('should drop the hold for a missing reverse swap', async () => {
+      jest
+        .spyOn(ReverseSwapRepository, 'getReverseSwap')
+        .mockResolvedValue(null);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: 'missing',
+        type: SwapType.ReverseSubmarine,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith('missing');
+    });
+
+    test('should fail a held reverse swap when rejected', async () => {
+      jest
+        .spyOn(ReverseSwapRepository, 'getReverseSwap')
+        .mockResolvedValue(heldReverseSwap);
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Reject),
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'lockupReverseSwap')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldReverseSwap.id,
+        type: SwapType.ReverseSubmarine,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        heldReverseSwap.id,
+      );
+      expect(lockupSpy).toHaveBeenCalledWith(
+        heldReverseSwap,
+        SendApprovalAction.Reject,
+      );
+    });
+
+    const heldChainSwap = {
+      id: 'chain-swap-id',
+      pair: 'BTC/BTC',
+      type: SwapType.Chain,
+      status: SwapUpdateEvent.TransactionConfirmed,
+      createdRefundSignature: false,
+      sendingData: {
+        transactionId: null,
+        expectedAmount: 100_000,
+        symbol: 'BTC',
+      },
+    };
+
+    test('should re-drive a held chain swap and lock up when accepted', async () => {
+      mockGetChainSwapResult = heldChainSwap;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Accept),
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldChainSwap.id,
+        type: SwapType.Chain,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        heldChainSwap.id,
+      );
+      expect(lockupSpy).toHaveBeenCalledWith(
+        heldChainSwap,
+        SendApprovalAction.Accept,
+      );
+    });
+
+    test('should fail a held chain swap when rejected', async () => {
+      mockGetChainSwapResult = heldChainSwap;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Reject),
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldChainSwap.id,
+        type: SwapType.Chain,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        heldChainSwap.id,
+      );
+      expect(lockupSpy).toHaveBeenCalledWith(
+        heldChainSwap,
+        SendApprovalAction.Reject,
+      );
+    });
+
+    test('should drop the hold for a held chain swap in a final state', async () => {
+      mockGetChainSwapResult = {
+        ...heldChainSwap,
+        status: SwapUpdateEvent.TransactionFailed,
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldChainSwap.id,
+        type: SwapType.Chain,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        heldChainSwap.id,
+      );
+      expect(lockupSpy).not.toHaveBeenCalled();
+    });
+
+    test('should drop the hold for a held chain swap with rejected zero-conf', async () => {
+      mockGetChainSwapResult = {
+        ...heldChainSwap,
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldChainSwap.id,
+        type: SwapType.Chain,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        heldChainSwap.id,
+      );
+      expect(lockupSpy).not.toHaveBeenCalled();
+    });
+
+    test('should drop the hold for a chain swap that already locked up', async () => {
+      mockGetChainSwapResult = {
+        ...heldChainSwap,
+        sendingData: { ...heldChainSwap.sendingData, transactionId: 'sent' },
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldChainSwap.id,
+        type: SwapType.Chain,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        heldChainSwap.id,
+      );
+      expect(lockupSpy).not.toHaveBeenCalled();
+    });
+
+    test('should keep holding a chain swap that is still held', async () => {
+      mockGetChainSwapResult = heldChainSwap;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Hold),
+      };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: heldChainSwap.id,
+        type: SwapType.Chain,
+      });
+
+      expect(SendApprovalHoldRepository.create).toHaveBeenCalledWith({
+        swapId: heldChainSwap.id,
+        type: SwapType.Chain,
+      });
+      expect(lockupSpy).not.toHaveBeenCalled();
+    });
+
+    test('should drop the hold for a missing chain swap', async () => {
+      mockGetChainSwapResult = null;
+      (swapNursery as any).sendApprovalHook = { hook: jest.fn() };
+      const lockupSpy = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: 'chain-swap-id',
+        type: SwapType.Chain,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        'chain-swap-id',
+      );
+      expect((swapNursery as any).sendApprovalHook.hook).not.toHaveBeenCalled();
+      expect(lockupSpy).not.toHaveBeenCalled();
+    });
+
+    test('should leave a held submarine swap that is still pending', async () => {
+      jest
+        .spyOn(SwapRepository, 'getSwap')
+        .mockResolvedValue({ status: SwapUpdateEvent.InvoicePending } as any);
+      const reverseSpy = jest.spyOn(ReverseSwapRepository, 'getReverseSwap');
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: 'submarine-id',
+        type: SwapType.Submarine,
+      });
+
+      expect(SendApprovalHoldRepository.remove).not.toHaveBeenCalled();
+      expect(reverseSpy).not.toHaveBeenCalled();
+    });
+
+    test('should drop the hold for a missing submarine swap', async () => {
+      jest.spyOn(SwapRepository, 'getSwap').mockResolvedValue(null);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: 'submarine-id',
+        type: SwapType.Submarine,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        'submarine-id',
+      );
+    });
+
+    test('should drop the hold for a submarine swap that left InvoicePending', async () => {
+      jest.spyOn(SwapRepository, 'getSwap').mockResolvedValue({
+        status: SwapUpdateEvent.InvoiceFailedToPay,
+      } as any);
+
+      await (swapNursery as any).retryHeldLockup({
+        swapId: 'submarine-id',
+        type: SwapType.Submarine,
+      });
+
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        'submarine-id',
+      );
+    });
+  });
+
+  describe('retryHeldSendApprovals', () => {
+    test('should re-drive every held swap under the matching lock', async () => {
+      const holds = [
+        { swapId: 'reverse-id', type: SwapType.ReverseSubmarine },
+        { swapId: 'chain-id', type: SwapType.Chain },
+        { swapId: 'submarine-id', type: SwapType.Submarine },
+      ];
+      (SendApprovalHoldRepository.getAll as jest.Mock).mockResolvedValueOnce(
+        holds,
+      );
+      const retrySpy = jest
+        .spyOn(swapNursery as any, 'retryHeldLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).retryHeldSendApprovals();
+
+      expect(retrySpy).toHaveBeenCalledTimes(3);
+      expect(retrySpy).toHaveBeenCalledWith(holds[0]);
+      expect(retrySpy).toHaveBeenCalledWith(holds[1]);
+      expect(retrySpy).toHaveBeenCalledWith(holds[2]);
+    });
+  });
+
   describe('chainSwap.lockup', () => {
     let baseMockChainSwap: ChainSwapInfo;
     let mockTransaction: any;
@@ -721,10 +1463,14 @@ describe('SwapNursery', () => {
     beforeEach(async () => {
       baseMockChainSwap = {
         id: 'test-chain-swap-id',
+        pair: 'BTC/BTC',
         type: SwapType.Chain,
+        status: SwapUpdateEvent.TransactionConfirmed,
         createdRefundSignature: false,
         sendingData: {
           transactionId: null,
+          expectedAmount: 100_000,
+          symbol: 'BTC',
         },
       } as unknown as ChainSwapInfo;
 
@@ -761,18 +1507,44 @@ describe('SwapNursery', () => {
       });
 
       await eventPromise;
+      await new Promise((resolve) => setImmediate(resolve));
 
       expect(ChainSwapRepository.getChainSwap).toHaveBeenCalledWith({
         id: baseMockChainSwap.id,
       });
       expect(mockHandleChainSwapLockup).toHaveBeenCalledWith(
         mockGetChainSwapResult,
+        SendApprovalAction.Accept,
       );
       expect(swapNursery.emit).toHaveBeenCalledWith('transaction', {
         confirmed: true,
         transaction: mockTransaction,
         swap: mockGetChainSwapResult,
       });
+    });
+
+    test('should record a hold and not lock up when the send approval holds', async () => {
+      mockGetChainSwapResult = baseMockChainSwap;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Hold),
+      };
+
+      const eventPromise = new Promise<void>((resolve) => {
+        swapNursery.once('transaction', () => resolve());
+      });
+      (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
+        swap: baseMockChainSwap,
+        transaction: mockTransaction,
+        confirmed: true,
+      });
+      await eventPromise;
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(SendApprovalHoldRepository.create).toHaveBeenCalledWith({
+        swapId: baseMockChainSwap.id,
+        type: SwapType.Chain,
+      });
+      expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
     });
 
     test('should return early when fetched swap is null', async () => {
@@ -821,6 +1593,9 @@ describe('SwapNursery', () => {
         'transaction',
         expect.anything(),
       );
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        baseMockChainSwap.id,
+      );
     });
 
     test('should prevent second lockup when sendingData.transactionId exists', async () => {
@@ -850,6 +1625,91 @@ describe('SwapNursery', () => {
         'transaction',
         expect.anything(),
       );
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        baseMockChainSwap.id,
+      );
+    });
+
+    test('should not lock up when the chain swap becomes final while approval is pending', async () => {
+      mockGetChainSwapResult = baseMockChainSwap;
+      let resolveApproval!: (action: SendApprovalAction) => void;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockReturnValue(
+          new Promise<SendApprovalAction>((resolve) => {
+            resolveApproval = resolve;
+          }),
+        ),
+      };
+
+      (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
+        swap: baseMockChainSwap,
+        transaction: mockTransaction,
+        confirmed: true,
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect((swapNursery as any).sendApprovalHook.hook).toHaveBeenCalled();
+
+      mockGetChainSwapResult = {
+        ...baseMockChainSwap,
+        status: SwapUpdateEvent.TransactionFailed,
+      };
+      resolveApproval(SendApprovalAction.Accept);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('final status'),
+      );
+      expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'transaction',
+        expect.anything(),
+      );
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        baseMockChainSwap.id,
+      );
+      expect((swapNursery as any).pendingSendApprovals.size).toEqual(0);
+    });
+
+    test('should not lock up when zero-conf is rejected while approval is pending', async () => {
+      mockGetChainSwapResult = baseMockChainSwap;
+      let resolveApproval!: (action: SendApprovalAction) => void;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockReturnValue(
+          new Promise<SendApprovalAction>((resolve) => {
+            resolveApproval = resolve;
+          }),
+        ),
+      };
+
+      (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
+        swap: baseMockChainSwap,
+        transaction: mockTransaction,
+        confirmed: true,
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect((swapNursery as any).sendApprovalHook.hook).toHaveBeenCalled();
+
+      mockGetChainSwapResult = {
+        ...baseMockChainSwap,
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      };
+      resolveApproval(SendApprovalAction.Accept);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('non-actionable status'),
+      );
+      expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'transaction',
+        expect.anything(),
+      );
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        baseMockChainSwap.id,
+      );
+      expect((swapNursery as any).pendingSendApprovals.size).toEqual(0);
     });
   });
 
@@ -868,6 +1728,7 @@ describe('SwapNursery', () => {
       const baseMockChainSwap = {
         id: 'test-chain-swap-id',
         type: SwapType.Chain,
+        status: SwapUpdateEvent.SwapCreated,
         sendingData: {
           transactionId: null,
         },
@@ -901,6 +1762,140 @@ describe('SwapNursery', () => {
       expect(swapNursery.emit).not.toHaveBeenCalledWith(
         'transaction',
         expect.anything(),
+      );
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        baseMockChainSwap.id,
+      );
+    });
+
+    test('should thread the resolved approval into the chain lockup', async () => {
+      const listeners: Record<string, (...args: any[]) => Promise<void>> = {};
+      const ethereumNursery = {
+        on: jest.fn(
+          (event: string, callback: (...args: any[]) => Promise<void>) => {
+            listeners[event] = callback;
+          },
+        ),
+        init: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const chainSwap = {
+        id: 'test-chain-swap-id',
+        pair: 'BTC/BTC',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.SwapCreated,
+        sendingData: {
+          transactionId: null,
+          expectedAmount: 100_000,
+          symbol: 'BTC',
+        },
+      } as unknown as ChainSwapInfo;
+      mockGetChainSwapResult = chainSwap;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Accept),
+      };
+      const mockHandleChainSwapLockup = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).listenEthereumNursery(ethereumNursery);
+      await listeners['eth.lockup']({
+        swap: chainSwap,
+        transactionHash: '0xaccept',
+      });
+
+      expect((swapNursery as any).sendApprovalHook.hook).toHaveBeenCalledWith(
+        chainSwap.id,
+        chainSwap.pair,
+        'BTC',
+        chainSwap.sendingData.expectedAmount,
+        undefined,
+      );
+      expect(mockHandleChainSwapLockup).toHaveBeenCalledWith(
+        mockGetChainSwapResult,
+        SendApprovalAction.Accept,
+      );
+    });
+
+    test('should record a hold and not lock up the chain swap when the send approval holds', async () => {
+      const listeners: Record<string, (...args: any[]) => Promise<void>> = {};
+      const ethereumNursery = {
+        on: jest.fn(
+          (event: string, callback: (...args: any[]) => Promise<void>) => {
+            listeners[event] = callback;
+          },
+        ),
+        init: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const chainSwap = {
+        id: 'test-chain-swap-id',
+        pair: 'BTC/BTC',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.SwapCreated,
+        sendingData: {
+          transactionId: null,
+          expectedAmount: 100_000,
+          symbol: 'BTC',
+        },
+      } as unknown as ChainSwapInfo;
+      mockGetChainSwapResult = chainSwap;
+      (swapNursery as any).sendApprovalHook = {
+        hook: jest.fn().mockResolvedValue(SendApprovalAction.Hold),
+      };
+      const mockHandleChainSwapLockup = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).listenEthereumNursery(ethereumNursery);
+      await listeners['eth.lockup']({
+        swap: chainSwap,
+        transactionHash: '0xhold',
+      });
+
+      expect(SendApprovalHoldRepository.create).toHaveBeenCalledWith({
+        swapId: chainSwap.id,
+        type: SwapType.Chain,
+      });
+      expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
+    });
+
+    test('should not consult the chain approval pre-gate for submarine swaps', async () => {
+      const listeners: Record<string, (...args: any[]) => Promise<void>> = {};
+      const ethereumNursery = {
+        on: jest.fn(
+          (event: string, callback: (...args: any[]) => Promise<void>) => {
+            listeners[event] = callback;
+          },
+        ),
+        init: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const submarineSwap = {
+        id: 'submarine-swap-id',
+        pair: 'BTC/BTC',
+        type: SwapType.Submarine,
+        orderSide: OrderSide.BUY,
+        invoice: 'lnbcrt1',
+        createdRefundSignature: false,
+      } as unknown as Swap;
+      mockGetSwapResult = submarineSwap;
+      (swapNursery as any).sendApprovalHook = { hook: jest.fn() };
+      const attemptSettleSwapSpy = jest
+        .spyOn(swapNursery, 'attemptSettleSwap')
+        .mockResolvedValue(undefined);
+
+      await (swapNursery as any).listenEthereumNursery(ethereumNursery);
+      await listeners['eth.lockup']({
+        swap: submarineSwap,
+        transactionHash: '0xsubmarine',
+      });
+
+      expect(ChainSwapRepository.getChainSwap).not.toHaveBeenCalled();
+      expect((swapNursery as any).sendApprovalHook.hook).not.toHaveBeenCalled();
+      expect(attemptSettleSwapSpy).toHaveBeenCalledWith(
+        mockCurrency,
+        submarineSwap,
       );
     });
   });

--- a/test/unit/swap/hooks/CreationHook.spec.ts
+++ b/test/unit/swap/hooks/CreationHook.spec.ts
@@ -56,7 +56,10 @@ describe('CreationHook', () => {
     `('should handle hook on data $action', ({ action, result }) => {
       const pendingHookId = '1';
       const pendingHook = jest.fn();
-      hook['pendingHooks'].set(pendingHookId, pendingHook);
+      hook['pendingHooks'].set(pendingHookId, {
+        resolve: pendingHook,
+        fallback: hook['defaultAction'],
+      });
 
       let emitData: any;
       stream.on = jest.fn().mockImplementation((event: string, data: any) => {
@@ -131,7 +134,7 @@ describe('CreationHook', () => {
       };
 
       const promise = hook.hook(SwapType.Submarine, params);
-      hook['pendingHooks'].get(params.id)?.(Action.Accept);
+      hook['pendingHooks'].get(params.id)?.resolve(Action.Accept);
       await promise;
 
       expect(stream.write).toHaveBeenCalledTimes(1);
@@ -162,7 +165,7 @@ describe('CreationHook', () => {
       };
 
       const promise = hook.hook(SwapType.ReverseSubmarine, params);
-      hook['pendingHooks'].get(params.id)?.(Action.Accept);
+      hook['pendingHooks'].get(params.id)?.resolve(Action.Accept);
       await promise;
 
       expect(stream.write).toHaveBeenCalledTimes(1);
@@ -192,7 +195,7 @@ describe('CreationHook', () => {
       };
 
       const promise = hook.hook(SwapType.Chain, params);
-      hook['pendingHooks'].get(params.id)?.(Action.Accept);
+      hook['pendingHooks'].get(params.id)?.resolve(Action.Accept);
       await promise;
 
       expect(stream.write).toHaveBeenCalledTimes(1);
@@ -225,7 +228,10 @@ describe('CreationHook', () => {
 
     const pendingHookId = '1';
     const pendingHook = jest.fn();
-    hook['pendingHooks'].set(pendingHookId, pendingHook);
+    hook['pendingHooks'].set(pendingHookId, {
+      resolve: pendingHook,
+      fallback: hook['defaultAction'],
+    });
 
     hook['closeStream']();
 

--- a/test/unit/swap/hooks/InvoiceCreationHook.spec.ts
+++ b/test/unit/swap/hooks/InvoiceCreationHook.spec.ts
@@ -60,7 +60,7 @@ describe('InvoiceCreationHook', () => {
         params.invoiceAmount,
         params.referral,
       );
-      hook['pendingHooks'].get(params.id)?.({ nodeId: 'node-1' });
+      hook['pendingHooks'].get(params.id)?.resolve({ nodeId: 'node-1' });
 
       await expect(promise).resolves.toEqual({ nodeId: 'node-1' });
 

--- a/test/unit/swap/hooks/SendApprovalHook.spec.ts
+++ b/test/unit/swap/hooks/SendApprovalHook.spec.ts
@@ -1,0 +1,275 @@
+import { status } from '@grpc/grpc-js';
+import Logger from '../../../../lib/Logger';
+import * as boltzrpc from '../../../../lib/proto/boltzrpc';
+import SendApprovalHook, {
+  SendApprovalAction,
+} from '../../../../lib/swap/hooks/SendApprovalHook';
+
+describe('SendApprovalHook', () => {
+  let hook: SendApprovalHook;
+
+  let handlers: Record<string, (data?: any) => void>;
+  let stream: any;
+
+  const request = {
+    swapId: 'swap-id',
+    pair: 'L-BTC/BTC',
+    symbol: 'BTC',
+    amount: 100_000,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+
+    handlers = {};
+    stream = {
+      on: jest.fn().mockImplementation((event: string, handler: any) => {
+        handlers[event] = handler;
+      }),
+      end: jest.fn(),
+      write: jest.fn(),
+      removeAllListeners: jest.fn(),
+      emit: jest.fn(),
+    };
+
+    hook = new SendApprovalHook(Logger.disabledLogger);
+  });
+
+  describe('hook', () => {
+    test('should resolve accept action if stream is not connected', async () => {
+      await expect(
+        hook.hook(request.swapId, request.pair, request.symbol, request.amount),
+      ).resolves.toEqual(SendApprovalAction.Accept);
+
+      expect(stream.write).not.toHaveBeenCalled();
+    });
+
+    test('should send send approval hook request', async () => {
+      hook.connectToStream(stream);
+
+      const promise = hook.hook(
+        request.swapId,
+        request.pair,
+        request.symbol,
+        request.amount,
+      );
+      hook['pendingHooks']
+        .get(request.swapId)
+        ?.resolve(SendApprovalAction.Accept);
+
+      await expect(promise).resolves.toEqual(SendApprovalAction.Accept);
+
+      expect(stream.write).toHaveBeenCalledTimes(1);
+      expect(stream.write).toHaveBeenCalledWith({
+        id: request.swapId,
+        pair: request.pair,
+        symbol: request.symbol,
+        amount: request.amount.toString(),
+      } satisfies boltzrpc.SendApprovalHookRequest);
+    });
+
+    test('should resolve accept action if hook is not resolved after timeout', async () => {
+      jest.useFakeTimers();
+
+      hook.connectToStream(stream);
+
+      const promise = hook.hook(
+        request.swapId,
+        request.pair,
+        request.symbol,
+        request.amount,
+      );
+      expect(hook['pendingHooks'].has(request.swapId)).toEqual(true);
+
+      jest.runAllTimers();
+
+      await expect(promise).resolves.toEqual(SendApprovalAction.Accept);
+      expect(hook['pendingHooks'].has(request.swapId)).toEqual(false);
+    });
+
+    test.each`
+      event      | payload
+      ${'end'}   | ${undefined}
+      ${'error'} | ${{ code: status.UNAVAILABLE, details: 'test' }}
+    `(
+      'should resolve pending hooks to accept action on $event',
+      async ({ event, payload }) => {
+        hook.connectToStream(stream);
+
+        const promise = hook.hook(
+          request.swapId,
+          request.pair,
+          request.symbol,
+          request.amount,
+        );
+        expect(hook['pendingHooks'].has(request.swapId)).toEqual(true);
+
+        handlers[event](payload);
+
+        await expect(promise).resolves.toEqual(SendApprovalAction.Accept);
+        expect(hook['pendingHooks'].has(request.swapId)).toEqual(false);
+      },
+    );
+  });
+
+  describe('fallback', () => {
+    test('should resolve to the fallback action if stream is not connected', async () => {
+      await expect(
+        hook.hook(
+          request.swapId,
+          request.pair,
+          request.symbol,
+          request.amount,
+          SendApprovalAction.Hold,
+        ),
+      ).resolves.toEqual(SendApprovalAction.Hold);
+    });
+
+    test('should resolve to the fallback action on timeout', async () => {
+      jest.useFakeTimers();
+      hook.connectToStream(stream);
+
+      const promise = hook.hook(
+        request.swapId,
+        request.pair,
+        request.symbol,
+        request.amount,
+        SendApprovalAction.Hold,
+      );
+      jest.runAllTimers();
+
+      await expect(promise).resolves.toEqual(SendApprovalAction.Hold);
+    });
+
+    test.each`
+      event      | payload
+      ${'end'}   | ${undefined}
+      ${'error'} | ${{ code: status.UNAVAILABLE, details: 'test' }}
+    `(
+      'should resolve pending hooks to the fallback action on $event',
+      async ({ event, payload }) => {
+        hook.connectToStream(stream);
+
+        const promise = hook.hook(
+          request.swapId,
+          request.pair,
+          request.symbol,
+          request.amount,
+          SendApprovalAction.Hold,
+        );
+        handlers[event](payload);
+
+        await expect(promise).resolves.toEqual(SendApprovalAction.Hold);
+      },
+    );
+
+    test('should apply a real response over the fallback', async () => {
+      hook.connectToStream(stream);
+
+      const promise = hook.hook(
+        request.swapId,
+        request.pair,
+        request.symbol,
+        request.amount,
+        SendApprovalAction.Hold,
+      );
+      hook['pendingHooks']
+        .get(request.swapId)
+        ?.resolve(SendApprovalAction.Accept);
+
+      await expect(promise).resolves.toEqual(SendApprovalAction.Accept);
+    });
+  });
+
+  describe('defaultAction', () => {
+    test('should default to accept when not configured', async () => {
+      const defaultHook = new SendApprovalHook(Logger.disabledLogger);
+
+      await expect(
+        defaultHook.hook(
+          request.swapId,
+          request.pair,
+          request.symbol,
+          request.amount,
+        ),
+      ).resolves.toEqual(SendApprovalAction.Accept);
+    });
+
+    test.each`
+      action      | expected
+      ${'reject'} | ${SendApprovalAction.Reject}
+      ${'REJECT'} | ${SendApprovalAction.Reject}
+      ${'accept'} | ${SendApprovalAction.Accept}
+      ${'hold'}   | ${SendApprovalAction.Hold}
+    `(
+      'should resolve $action to the configured action when not connected',
+      async ({ action, expected }) => {
+        const configuredHook = new SendApprovalHook(
+          Logger.disabledLogger,
+          undefined,
+          action,
+        );
+
+        await expect(
+          configuredHook.hook(
+            request.swapId,
+            request.pair,
+            request.symbol,
+            request.amount,
+          ),
+        ).resolves.toEqual(expected);
+      },
+    );
+
+    test('should resolve to the configured action on timeout', async () => {
+      jest.useFakeTimers();
+
+      const configuredHook = new SendApprovalHook(
+        Logger.disabledLogger,
+        undefined,
+        'reject',
+      );
+      configuredHook.connectToStream(stream);
+
+      const promise = configuredHook.hook(
+        request.swapId,
+        request.pair,
+        request.symbol,
+        request.amount,
+      );
+
+      jest.runAllTimers();
+
+      await expect(promise).resolves.toEqual(SendApprovalAction.Reject);
+    });
+
+    test.each`
+      action
+      ${'maybe'}
+      ${'constructor'}
+      ${'__proto__'}
+      ${'toString'}
+    `('should throw for the invalid action $action', ({ action }) => {
+      expect(
+        () => new SendApprovalHook(Logger.disabledLogger, undefined, action),
+      ).toThrow(`invalid send approval default action: ${action}`);
+    });
+  });
+
+  describe('parseGrpcAction', () => {
+    test.each`
+      action                                              | result
+      ${boltzrpc.SendApprovalAction.SEND_APPROVAL_ACCEPT} | ${SendApprovalAction.Accept}
+      ${boltzrpc.SendApprovalAction.SEND_APPROVAL_REJECT} | ${SendApprovalAction.Reject}
+      ${boltzrpc.SendApprovalAction.SEND_APPROVAL_HOLD}   | ${SendApprovalAction.Hold}
+    `('should parse action $action', ({ action, result }) => {
+      expect(
+        hook['parseGrpcAction']({
+          id: request.swapId,
+          action,
+        }),
+      ).toEqual(result);
+    });
+  });
+});

--- a/test/unit/swap/hooks/TransactionHook.spec.ts
+++ b/test/unit/swap/hooks/TransactionHook.spec.ts
@@ -68,7 +68,7 @@ describe('TransactionHook', () => {
         request.swapType,
         request.vout,
       );
-      hook['pendingHooks'].get(request.swapId)?.(Action.Accept);
+      hook['pendingHooks'].get(request.swapId)?.resolve(Action.Accept);
 
       await expect(promise).resolves.toEqual(Action.Accept);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a streaming send-approval hook with **Accept**, **Reject**, or **Hold** outcomes, wired into swap execution (including invoice payments).
  * Added **send approval default action** configuration (optional) to define behavior when the hook is disconnected or times out.
  * Persisted **held** send-approval decisions and retried them later.

* **Bug Fixes**
  * Improved hook fallback behavior for disconnected, timeout, and shutdown scenarios using per-request fallback handling.

* **Documentation**
  * Documented send-approval fallback behavior and default-action options.

* **Tests**
  * Added/expanded unit and integration test coverage for the new guard, persistence, gRPC streaming, and retry flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->