### PR TITLE
feat: gRPC method to update balance cache

### DIFF
--- a/boltzr-cli/src/grpc/mod.rs
+++ b/boltzr-cli/src/grpc/mod.rs
@@ -465,6 +465,19 @@ impl BoltzClient {
         Ok(response.into_inner())
     }
 
+    pub async fn dev_refresh_balance_cache(
+        &mut self,
+        symbol: Option<String>,
+    ) -> Result<boltz_rpc::DevRefreshBalanceCacheResponse> {
+        let response = self
+            .client
+            .dev_refresh_balance_cache(
+                self.req(boltz_rpc::DevRefreshBalanceCacheRequest { symbol }),
+            )
+            .await?;
+        Ok(response.into_inner())
+    }
+
     pub async fn issue_jwt(
         &mut self,
         label: String,

--- a/boltzr-cli/src/main.rs
+++ b/boltzr-cli/src/main.rs
@@ -229,6 +229,8 @@ enum DevCommands {
     ClearSwapUpdateCache { id: Option<String> },
     #[command(about = "Dumps the heap of the daemon into a file")]
     HeapDump { path: Option<String> },
+    #[command(about = "Refreshes the balance cache used for liquidity checks")]
+    RefreshBalanceCache { symbol: Option<String> },
     #[command(about = "Sets the log level")]
     SetLogLevel { level: parsers::LogLevel },
     #[command(about = "Subscribes to swap updates via WebSocket")]
@@ -1146,6 +1148,13 @@ async fn run_command(cli: Cli) -> Result<()> {
                 let response = get_grpc_client(&cli)
                     .await?
                     .dev_heap_dump(path.clone())
+                    .await?;
+                print_pretty(&response)?;
+            }
+            DevCommands::RefreshBalanceCache { symbol } => {
+                let response = get_grpc_client(&cli)
+                    .await?
+                    .dev_refresh_balance_cache(symbol.clone())
                     .await?;
                 print_pretty(&response)?;
             }

--- a/lib/grpc/GrpcServer.ts
+++ b/lib/grpc/GrpcServer.ts
@@ -64,6 +64,7 @@ class GrpcServer {
       setReferral: grpcService.setReferral,
       invoiceClnThreshold: grpcService.invoiceClnThreshold,
       devClearSwapUpdateCache: grpcService.devClearSwapUpdateCache,
+      devRefreshBalanceCache: grpcService.devRefreshBalanceCache,
       issueJwt: grpcService.issueJwt,
       revokeJwt: grpcService.revokeJwt,
       listJwts: grpcService.listJwts,

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -685,6 +685,28 @@ class GrpcService {
     });
   };
 
+  public devRefreshBalanceCache: handleUnaryCall<
+    boltzrpc.DevRefreshBalanceCacheRequest,
+    boltzrpc.DevRefreshBalanceCacheResponse
+  > = async (call, callback) => {
+    await GrpcService.handleCallback(call, callback, async () => {
+      const { symbol } = call.request;
+      const target =
+        symbol !== undefined && symbol !== null && symbol !== ''
+          ? symbol
+          : undefined;
+
+      this.logger.debug(
+        target !== undefined
+          ? `Refreshing balance cache for ${target}`
+          : 'Refreshing entire balance cache',
+      );
+      await this.service.refreshBalanceCache(target);
+
+      return {};
+    });
+  };
+
   public issueJwt: handleUnaryCall<
     boltzrpc.IssueJwtRequest,
     boltzrpc.IssueJwtResponse

--- a/lib/service/BalanceCheck.ts
+++ b/lib/service/BalanceCheck.ts
@@ -1,5 +1,6 @@
 import type Logger from '../Logger';
 import { formatError } from '../Utils';
+import type Wallet from '../wallet/Wallet';
 import type WalletManager from '../wallet/WalletManager';
 import type { WalletBalance } from '../wallet/providers/WalletProviderInterface';
 import Errors from './Errors';
@@ -38,28 +39,42 @@ class BalanceCheck {
     }
   };
 
+  public refresh = async (symbol?: string): Promise<void> => {
+    if (symbol === undefined) {
+      await this.updateBalances();
+      return;
+    }
+
+    const wallet = this.walletManager.wallets.get(symbol);
+    if (wallet === undefined) {
+      throw Errors.CURRENCY_NOT_FOUND(symbol);
+    }
+
+    await this.updateBalance(symbol, wallet);
+  };
+
   private updateBalances = async (): Promise<void> => {
     this.logger.silly('Updating balance cache');
 
-    const updatePromises: Promise<void>[] = [];
+    await Promise.allSettled(
+      Array.from(this.walletManager.wallets).map(([symbol, wallet]) =>
+        this.updateBalance(symbol, wallet),
+      ),
+    );
+  };
 
-    for (const [symbol, wallet] of this.walletManager.wallets) {
-      updatePromises.push(
-        wallet
-          .getBalance()
-          .then((balance) => {
-            this.balanceCache.set(symbol, balance);
-          })
-          .catch((error) => {
-            this.balanceCache.delete(symbol);
-            this.logger.warn(
-              `Failed to update balance cache for ${symbol}: ${formatError(error)}`,
-            );
-          }),
+  private updateBalance = async (
+    symbol: string,
+    wallet: Wallet,
+  ): Promise<void> => {
+    try {
+      this.balanceCache.set(symbol, await wallet.getBalance());
+    } catch (error) {
+      this.logger.warn(
+        `Failed to update balance cache for ${symbol}: ${formatError(error)}`,
       );
+      throw error;
     }
-
-    await Promise.allSettled(updatePromises);
   };
 
   private startPeriodicUpdates = (): void => {

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -672,6 +672,9 @@ class Service {
     return response;
   };
 
+  public refreshBalanceCache = (symbol?: string): Promise<void> =>
+    this.balanceCheck.refresh(symbol);
+
   /**
    * Gets all supported pairs and their conversion rates
    */

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -73,6 +73,7 @@ service Boltz {
 
   rpc DevHeapDump (DevHeapDumpRequest) returns (DevHeapDumpResponse);
   rpc DevClearSwapUpdateCache (DevClearSwapUpdateCacheRequest) returns (DevClearSwapUpdateCacheResponse);
+  rpc DevRefreshBalanceCache (DevRefreshBalanceCacheRequest) returns (DevRefreshBalanceCacheResponse);
 
   rpc IssueJwt (IssueJwtRequest) returns (IssueJwtResponse);
   rpc RevokeJwt (RevokeJwtRequest) returns (RevokeJwtResponse);
@@ -531,6 +532,11 @@ message DevClearSwapUpdateCacheRequest {
   optional string id = 1;
 }
 message DevClearSwapUpdateCacheResponse {}
+
+message DevRefreshBalanceCacheRequest {
+  optional string symbol = 1;
+}
+message DevRefreshBalanceCacheResponse {}
 
 message IssueJwtRequest {
   string label = 1;

--- a/test/integration/service/BalanceCheck.spec.ts
+++ b/test/integration/service/BalanceCheck.spec.ts
@@ -56,4 +56,63 @@ describe('BalanceCheck', () => {
       ),
     ).rejects.toEqual(Errors.INSUFFICIENT_LIQUIDITY());
   });
+
+  test.each`
+    symbol
+    ${undefined}
+    ${'BTC'}
+  `('should refresh the cache with symbol $symbol', async ({ symbol }) => {
+    const getBalance = jest.spyOn(wallet, 'getBalance');
+    getBalance.mockClear();
+
+    await balanceCheck.refresh(symbol);
+
+    expect(getBalance).toHaveBeenCalledTimes(1);
+    await balanceCheck.checkBalance(
+      'BTC',
+      (await wallet.getBalance()).confirmedBalance,
+    );
+
+    getBalance.mockRestore();
+  });
+
+  test('should throw when refreshing an unknown symbol', async () => {
+    const symbol = 'notFound';
+    await expect(balanceCheck.refresh(symbol)).rejects.toEqual(
+      Errors.CURRENCY_NOT_FOUND(symbol),
+    );
+  });
+
+  test('should throw and keep the cached balance when refreshing a symbol fails', async () => {
+    const getBalance = jest
+      .fn()
+      .mockResolvedValueOnce({ confirmedBalance: 21, unconfirmedBalance: 0 })
+      .mockRejectedValue(new Error('failed to get balance'));
+    const check = new BalanceCheck(Logger.disabledLogger, {
+      wallets: new Map<string, any>([['BTC', { getBalance }]]),
+    } as unknown as WalletManager);
+
+    await check.refresh('BTC');
+    await check.checkBalance('BTC', 21);
+
+    await expect(check.refresh('BTC')).rejects.toThrow('failed to get balance');
+    await check.checkBalance('BTC', 21);
+  });
+
+  test('should not throw when refreshing all balances fails', async () => {
+    const check = new BalanceCheck(Logger.disabledLogger, {
+      wallets: new Map<string, any>([
+        [
+          'BTC',
+          {
+            getBalance: jest
+              .fn()
+              .mockRejectedValue(new Error('failed to get balance')),
+          },
+        ],
+      ]),
+    } as unknown as WalletManager);
+
+    await expect(check.refresh()).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development command and gRPC RPC to refresh the balance cache for a specific symbol or for all symbols.
  * Exposed a service method to trigger cache refresh from clients.
* **Bug Fixes**
  * Improved refresh robustness: if refreshing one wallet fails, existing cached values remain and other refreshes continue.
  * Refresh now rejects for unknown symbols while still preserving prior cached balances when a specific refresh fails.
* **Tests**
  * Added/updated integration coverage for targeted and full cache refresh scenarios, including failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->