### PR TITLE
fix: nonce races on Anvil

### DIFF
--- a/lib/db/repositories/PendingEthereumTransactionRepository.ts
+++ b/lib/db/repositories/PendingEthereumTransactionRepository.ts
@@ -1,4 +1,4 @@
-import type { WhereOptions } from 'sequelize';
+import { UniqueConstraintError, type WhereOptions } from 'sequelize';
 import PendingEthereumTransaction from '../models/PendingEthereumTransaction';
 
 class PendingEthereumTransactionRepository {
@@ -47,20 +47,35 @@ class PendingEthereumTransactionRepository {
     );
   };
 
-  public static addTransaction = (
+  // Idempotent on the hash: the signer writes the row under its lock, then
+  // broadcastTransaction writes the same row again after broadcasting.
+  public static addTransaction = async (
     hash: string,
     chain: string,
     nonce: number,
     etherAmount: bigint,
     hex: string,
   ): Promise<PendingEthereumTransaction> => {
-    return PendingEthereumTransaction.create({
-      hash,
-      chain,
-      nonce,
-      etherAmount,
-      hex,
-    });
+    try {
+      const [transaction] = await PendingEthereumTransaction.findOrCreate({
+        where: { hash },
+        defaults: {
+          hash,
+          chain,
+          nonce,
+          etherAmount,
+          hex,
+        },
+      });
+      return transaction;
+    } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        throw new Error(
+          `nonce ${nonce} on ${chain} already used by another transaction`,
+        );
+      }
+      throw error;
+    }
   };
 }
 

--- a/lib/wallet/ethereum/EthereumTransactionTracker.ts
+++ b/lib/wallet/ethereum/EthereumTransactionTracker.ts
@@ -1,13 +1,14 @@
-import type { Provider, Signer } from 'ethers';
+import type { Signer } from 'ethers';
 import type Logger from '../../Logger';
 import PendingEthereumTransactionRepository from '../../db/repositories/PendingEthereumTransactionRepository';
 import type { NetworkDetails } from './EvmNetworks';
+import type InjectedProvider from './InjectedProvider';
 
 class EthereumTransactionTracker {
   constructor(
     private readonly logger: Logger,
     private readonly networkDetails: NetworkDetails,
-    private readonly provider: Provider,
+    private readonly provider: InjectedProvider,
     private readonly wallet: Signer,
   ) {}
 
@@ -27,16 +28,33 @@ class EthereumTransactionTracker {
    * in that class already
    */
   public scanPendingTransactions = async (): Promise<void> => {
-    for (const transaction of await PendingEthereumTransactionRepository.getTransactions(
-      this.networkDetails.symbol,
-    )) {
+    const transactions =
+      await PendingEthereumTransactionRepository.getTransactions(
+        this.networkDetails.symbol,
+      );
+    if (transactions.length === 0) {
+      return;
+    }
+
+    // A pending row below the confirmed nonce is orphaned: its own hash never
+    // confirmed, so the nonce went to a different tx
+    const confirmedNonce = await this.provider.getConfirmedTransactionCount(
+      await this.wallet.getAddress(),
+    );
+
+    for (const transaction of transactions) {
       const receipt = await this.provider.getTransactionReceipt(
         transaction.hash,
       );
 
-      if (receipt) {
+      if (receipt !== null) {
         this.logger.silly(
           `Removing confirmed ${this.networkDetails.name} transaction: ${transaction.hash}`,
+        );
+        await transaction.destroy();
+      } else if (transaction.nonce < confirmedNonce) {
+        this.logger.warn(
+          `Pruning orphaned ${this.networkDetails.name} transaction ${transaction.hash} (nonce ${transaction.nonce} already settled on chain)`,
         );
         await transaction.destroy();
       }

--- a/lib/wallet/ethereum/InjectedProvider.ts
+++ b/lib/wallet/ethereum/InjectedProvider.ts
@@ -256,22 +256,26 @@ class InjectedProvider implements Provider {
     addressOrName: string,
     blockTag?: BlockTag,
   ): Promise<number> => {
-    {
-      const highestNonce =
-        await PendingEthereumTransactionRepository.getHighestNonce(
-          this.networkDetails.symbol,
-        );
-      if (highestNonce !== undefined) {
-        return highestNonce;
-      }
-    }
+    // Max of our pending-tx high-water mark and the chain's count, so a stale or
+    // orphaned pending row can't drag the nonce below the chain's floor.
+    const [highestNonce, rpc] = await Promise.all([
+      PendingEthereumTransactionRepository.getHighestNonce(
+        this.networkDetails.symbol,
+      ),
+      this.forwardMethod<number>(
+        'getTransactionCount',
+        addressOrName,
+        blockTag,
+      ),
+    ]);
 
-    return await this.forwardMethod(
-      'getTransactionCount',
-      addressOrName,
-      blockTag,
-    );
+    return Math.max(highestNonce ?? 0, rpc);
   };
+
+  public getConfirmedTransactionCount = (
+    addressOrName: string,
+  ): Promise<number> =>
+    this.forwardMethod<number>('getTransactionCount', addressOrName, 'latest');
 
   public getTransactionReceipt = (
     transactionHash: string,

--- a/lib/wallet/ethereum/SequentialSigner.ts
+++ b/lib/wallet/ethereum/SequentialSigner.ts
@@ -6,7 +6,7 @@ import type {
   TypedDataDomain,
   TypedDataField,
 } from 'ethers';
-import { AbstractSigner, getBigInt } from 'ethers';
+import { AbstractSigner, Transaction, getBigInt } from 'ethers';
 import InstrumentedLock from '../../InstrumentedLock';
 import Tracing from '../../Tracing';
 import { formatError } from '../../Utils';
@@ -19,6 +19,10 @@ class SequentialSigner extends AbstractSigner {
   // One lock per symbol, shared across connect() clones so they serialize
   // together and never register duplicate InstrumentedLock instances
   private static readonly locks = new Map<string, InstrumentedLock>();
+
+  // Per-symbol high-water nonce advanced under the lock so concurrent bursts get
+  // distinct nonces (see signTransactionInternal)
+  private static readonly reservedNonces = new Map<string, number>();
 
   private readonly lock: InstrumentedLock;
 
@@ -83,20 +87,72 @@ class SequentialSigner extends AbstractSigner {
       SequentialSigner.txLock,
       'signTransaction',
       async () => {
-        if (tx.value !== undefined && tx.value !== null) {
-          const [ourBalance, pendingTxsValue] = await Promise.all([
-            this.signer.provider!.getBalance(await this.getAddress()),
-            PendingEthereumTransactionRepository.getTotalSent(this.symbol),
-          ]);
-
-          if (ourBalance - pendingTxsValue < BigInt(tx.value)) {
-            throw new Error('insufficient balance');
-          }
-        }
-
-        return await this.signer.signTransaction(
-          await this.addGasLimitBuffer(tx),
+        let reservedNonce: number | undefined;
+        const previousReservedNonce = SequentialSigner.reservedNonces.get(
+          this.symbol,
         );
+
+        try {
+          // Allocate the nonce under the lock. ethers resolves tx.nonce during
+          // populateTransaction (outside the lock), so concurrent sends arrive
+          // with the same stale value; re-resolving isn't enough on a fast chain,
+          // where a just-mined tx's pending row is reaped before the RPC nonce
+          // advances. Bridge that window with an in-memory high-water mark, max'd
+          // with the resolved nonce so it re-syncs when the chain moves ahead
+          if (this.provider !== null && this.provider !== undefined) {
+            const resolved = await this.getNonce('pending');
+            reservedNonce =
+              previousReservedNonce === undefined
+                ? resolved
+                : Math.max(resolved, previousReservedNonce + 1);
+            tx.nonce = reservedNonce;
+            SequentialSigner.reservedNonces.set(this.symbol, reservedNonce);
+          }
+
+          if (tx.value !== undefined && tx.value !== null) {
+            const [ourBalance, pendingTxsValue] = await Promise.all([
+              this.signer.provider!.getBalance(await this.getAddress()),
+              PendingEthereumTransactionRepository.getTotalSent(this.symbol),
+            ]);
+
+            if (ourBalance - pendingTxsValue < BigInt(tx.value)) {
+              throw new Error('insufficient balance');
+            }
+          }
+
+          const signed = await this.signer.signTransaction(
+            await this.addGasLimitBuffer(tx),
+          );
+
+          // Persist before releasing the lock so the next caller's nonce
+          // resolution sees it; idempotent with broadcastTransaction's write.
+          const parsed = Transaction.from(signed);
+          await PendingEthereumTransactionRepository.addTransaction(
+            parsed.hash!,
+            this.symbol,
+            parsed.nonce,
+            parsed.value,
+            parsed.serialized,
+          );
+
+          return signed;
+        } catch (error) {
+          if (
+            reservedNonce !== undefined &&
+            SequentialSigner.reservedNonces.get(this.symbol) === reservedNonce
+          ) {
+            if (previousReservedNonce === undefined) {
+              SequentialSigner.reservedNonces.delete(this.symbol);
+            } else {
+              SequentialSigner.reservedNonces.set(
+                this.symbol,
+                previousReservedNonce,
+              );
+            }
+          }
+
+          throw error;
+        }
       },
     );
   };

--- a/test/integration/db/repositories/PendingEthereumTransactionRepository.spec.ts
+++ b/test/integration/db/repositories/PendingEthereumTransactionRepository.spec.ts
@@ -95,6 +95,76 @@ describe('PendingEthereumTransactionRepository', () => {
     });
   });
 
+  describe('addTransaction', () => {
+    test('should be idempotent when the same hash is added again', async () => {
+      const first = await PendingEthereumTransactionRepository.addTransaction(
+        'txHash',
+        networks.Rootstock.symbol,
+        10,
+        100n,
+        'hex',
+      );
+      const second = await PendingEthereumTransactionRepository.addTransaction(
+        'txHash',
+        networks.Rootstock.symbol,
+        10,
+        100n,
+        'hex',
+      );
+
+      expect(second.hash).toEqual(first.hash);
+      await expect(
+        PendingEthereumTransactionRepository.getTransactions(
+          networks.Rootstock.symbol,
+        ),
+      ).resolves.toHaveLength(1);
+    });
+
+    test('should surface a (chain, nonce) collision as a legible error', async () => {
+      await PendingEthereumTransactionRepository.addTransaction(
+        'txHash1',
+        networks.Rootstock.symbol,
+        10,
+        100n,
+        'hex1',
+      );
+
+      await expect(
+        PendingEthereumTransactionRepository.addTransaction(
+          'txHash2',
+          networks.Rootstock.symbol,
+          10,
+          200n,
+          'hex2',
+        ),
+      ).rejects.toEqual(
+        new Error(
+          `nonce 10 on ${networks.Rootstock.symbol} already used by another transaction`,
+        ),
+      );
+    });
+
+    test('should allow the same nonce on a different chain', async () => {
+      await PendingEthereumTransactionRepository.addTransaction(
+        'txHash1',
+        networks.Rootstock.symbol,
+        10,
+        100n,
+        'hex1',
+      );
+
+      await expect(
+        PendingEthereumTransactionRepository.addTransaction(
+          'txHash2',
+          networks.Ethereum.symbol,
+          10,
+          200n,
+          'hex2',
+        ),
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe('getHighestNonce', () => {
     test('should get highest nonce when there are no pending transactions', async () => {
       await expect(

--- a/test/integration/wallet/ethereum/EthereumTransactionTracker.spec.ts
+++ b/test/integration/wallet/ethereum/EthereumTransactionTracker.spec.ts
@@ -2,8 +2,13 @@ import Logger from '../../../../lib/Logger';
 import PendingEthereumTransactionRepository from '../../../../lib/db/repositories/PendingEthereumTransactionRepository';
 import EthereumTransactionTracker from '../../../../lib/wallet/ethereum/EthereumTransactionTracker';
 import { networks } from '../../../../lib/wallet/ethereum/EvmNetworks';
+import InjectedProvider from '../../../../lib/wallet/ethereum/InjectedProvider';
 import type { EthereumSetup } from '../EthereumTools';
-import { fundSignerWallet, getSigner } from '../EthereumTools';
+import {
+  fundSignerWallet,
+  getSigner,
+  providerEndpoint,
+} from '../EthereumTools';
 
 const mockAddTransaction = jest.fn().mockImplementation(async () => {});
 
@@ -22,14 +27,24 @@ jest.mock(
 
 describe('EthereumTransactionTracker', () => {
   let setup: EthereumSetup;
+  let injectedProvider: InjectedProvider;
   let transactionTracker: EthereumTransactionTracker;
 
   beforeAll(async () => {
     setup = await getSigner();
+    injectedProvider = new InjectedProvider(
+      Logger.disabledLogger,
+      networks.Ethereum,
+      {
+        providerEndpoint,
+      },
+    );
+    await injectedProvider.init();
+
     transactionTracker = new EthereumTransactionTracker(
       Logger.disabledLogger,
       networks.Ethereum,
-      setup.provider,
+      injectedProvider,
       setup.signer,
     );
     await fundSignerWallet(setup.signer, setup.etherBase);
@@ -42,7 +57,8 @@ describe('EthereumTransactionTracker', () => {
     jest.clearAllMocks();
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    await injectedProvider.destroy();
     setup.provider.destroy();
   });
 

--- a/test/integration/wallet/ethereum/SequentialSigner.spec.ts
+++ b/test/integration/wallet/ethereum/SequentialSigner.spec.ts
@@ -17,6 +17,10 @@ describe('SequentialSigner', () => {
     PendingEthereumTransactionRepository.getTotalSent = jest
       .fn()
       .mockResolvedValue(0n);
+    // The signer now persists the row under its lock; keep this test DB-independent
+    PendingEthereumTransactionRepository.addTransaction = jest
+      .fn()
+      .mockResolvedValue(null as never);
   });
 
   test('should get address', async () => {

--- a/test/integration/wallet/providers/EtherWalletProvider.spec.ts
+++ b/test/integration/wallet/providers/EtherWalletProvider.spec.ts
@@ -1,6 +1,7 @@
 import Logger from '../../../../lib/Logger';
 import { etherDecimals } from '../../../../lib/consts/Consts';
 import Database from '../../../../lib/db/Database';
+import PendingEthereumTransaction from '../../../../lib/db/models/PendingEthereumTransaction';
 import TransactionLabel from '../../../../lib/db/models/TransactionLabel';
 import TransactionLabelRepository from '../../../../lib/db/repositories/TransactionLabelRepository';
 import { bumpGasLimit } from '../../../../lib/wallet/ethereum/EthereumUtils';
@@ -81,6 +82,11 @@ describe('EtherWalletProvider', () => {
   });
 
   test('should sweep wallet', async () => {
+    // The earlier send leaves a pending row that the tracker would normally
+    // reap once it confirms; there is no tracker here, so drop it ourselves to
+    // avoid double-counting its value against the sweep balance.
+    await PendingEthereumTransaction.destroy({ truncate: true });
+
     const balance = await setup.provider.getBalance(
       await setup.signer.getAddress(),
     );

--- a/test/unit/wallet/ethereum/SequentialSigner.spec.ts
+++ b/test/unit/wallet/ethereum/SequentialSigner.spec.ts
@@ -1,0 +1,92 @@
+import { Transaction, Wallet } from 'ethers';
+import type { Provider, TransactionRequest } from 'ethers';
+import PendingEthereumTransactionRepository from '../../../../lib/db/repositories/PendingEthereumTransactionRepository';
+import SequentialSigner from '../../../../lib/wallet/ethereum/SequentialSigner';
+
+jest.mock(
+  '../../../../lib/db/repositories/PendingEthereumTransactionRepository',
+  () => ({
+    getTotalSent: jest.fn().mockResolvedValue(0n),
+    addTransaction: jest.fn().mockResolvedValue(null),
+  }),
+);
+
+describe('SequentialSigner nonce reservation', () => {
+  const getTotalSent =
+    PendingEthereumTransactionRepository.getTotalSent as jest.MockedFunction<
+      typeof PendingEthereumTransactionRepository.getTotalSent
+    >;
+  const addTransaction =
+    PendingEthereumTransactionRepository.addTransaction as jest.MockedFunction<
+      typeof PendingEthereumTransactionRepository.addTransaction
+    >;
+
+  const build = (
+    symbol: string,
+    getCount: () => Promise<number>,
+  ): SequentialSigner => {
+    const provider = {
+      getTransactionCount: jest.fn(getCount),
+    } as unknown as Provider;
+    return new SequentialSigner(
+      symbol,
+      Wallet.createRandom().connect(provider),
+    );
+  };
+
+  const makeTx = (nonce: number): TransactionRequest => ({
+    to: '0x000000000000000000000000000000000000dEaD',
+    chainId: 1,
+    type: 2,
+    nonce,
+    gasLimit: 21_000n,
+    maxFeePerGas: 2_000_000_000n,
+    maxPriorityFeePerGas: 1_000_000_000n,
+  });
+
+  const sortedNonces = (signed: string[]): number[] =>
+    signed.map((s) => Transaction.from(s).nonce).sort((a, b) => a - b);
+
+  beforeEach(() => {
+    getTotalSent.mockReset();
+    addTransaction.mockReset();
+
+    getTotalSent.mockResolvedValue(0n);
+    addTransaction.mockResolvedValue(null as never);
+  });
+
+  test('bursty concurrent sends get distinct nonces even when the resolved count is stale', async () => {
+    const signer = build('RACE-1', () => Promise.resolve(5));
+
+    const signed = await Promise.all([
+      signer.signTransaction(makeTx(5)),
+      signer.signTransaction(makeTx(5)),
+      signer.signTransaction(makeTx(5)),
+    ]);
+
+    expect(sortedNonces(signed)).toEqual([5, 6, 7]);
+    expect(new Set(sortedNonces(signed)).size).toBe(3);
+  });
+
+  test('re-syncs forward when the chain moves ahead of the reservation', async () => {
+    let count = 5;
+    const signer = build('RACE-2', () => Promise.resolve(count));
+
+    await signer.signTransaction(makeTx(5));
+    count = 10;
+    const signed = await signer.signTransaction(makeTx(5));
+
+    expect(Transaction.from(signed).nonce).toBe(10);
+  });
+
+  test('rolls back the nonce reservation when the signing path fails', async () => {
+    const signer = build('RACE-3', () => Promise.resolve(20));
+    addTransaction.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(signer.signTransaction(makeTx(20))).rejects.toThrow('db down');
+
+    const signed = await signer.signTransaction(makeTx(20));
+
+    expect(Transaction.from(signed).nonce).toBe(20);
+  });
+});


### PR DESCRIPTION
When blocks are mined instantly after sending a transaction, it is possible we race nonces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pending Ethereum transactions are now tracked automatically when transactions are signed.
  * Wallet nonce handling is improved to better support concurrent transaction creation.

* **Bug Fixes**
  * Prevented duplicate pending transactions from being saved more than once.
  * Improved handling of nonce conflicts so reused nonces are reported clearly.
  * Removed stale pending transactions during scans, including ones already confirmed on-chain.
  * Reduced nonce-related failures by keeping transaction counts better aligned with on-chain state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->