### PR TITLE
chore: harden ARK timeout delta calculations

### DIFF
--- a/lib/service/TimeoutDeltaProvider.ts
+++ b/lib/service/TimeoutDeltaProvider.ts
@@ -152,6 +152,12 @@ class TimeoutDeltaProvider {
     const chainCurrency = this.currencies.get(
       getChainCurrency(base, quote, swap.orderSide, false),
     )!;
+    const lightningCurrency = getLightningCurrency(
+      base,
+      quote,
+      swap.orderSide,
+      false,
+    );
 
     let blocksLeft: number;
 
@@ -166,8 +172,9 @@ class TimeoutDeltaProvider {
         (swap.timeoutBlockHeight - currentTimestamp) /
           // To minutes
           60 /
-          // To blocks
-          TimeoutDeltaProvider.blockTimes.get(chainCurrency.symbol)!,
+          // To blocks of the lightning currency, which is the unit the CLTV
+          // limit is denominated in
+          TimeoutDeltaProvider.blockTimes.get(lightningCurrency)!,
       );
     } else {
       let currentBlock: number;
@@ -191,7 +198,7 @@ class TimeoutDeltaProvider {
 
       blocksLeft = TimeoutDeltaProvider.convertBlocks(
         chainCurrency.symbol,
-        getLightningCurrency(base, quote, swap.orderSide, false),
+        lightningCurrency,
         swap.timeoutBlockHeight - currentBlock,
       );
     }

--- a/test/unit/service/TimeoutDeltaProvider.spec.ts
+++ b/test/unit/service/TimeoutDeltaProvider.spec.ts
@@ -596,5 +596,35 @@ describe('TimeoutDeltaProvider', () => {
         usesLocktimeSeconds: false,
       } as any;
     });
+
+    test('should convert timestamp-based ARK locks with the lightning currency block time', async () => {
+      const currentTimestamp = 1_000_000;
+
+      const arkCurrency = currenciesMap.get(ArkClient.symbol)!;
+      arkCurrency.arkNode = {
+        usesLocktimeSeconds: true,
+        getBlockHeight: jest.fn().mockResolvedValue(500),
+        getBlockTimestamp: jest.fn().mockResolvedValue(currentTimestamp),
+      } as any;
+
+      const originalBlockTime = TimeoutDeltaProvider.blockTimes.get(
+        ArkClient.symbol,
+      )!;
+      TimeoutDeltaProvider.blockTimes.set(ArkClient.symbol, 5);
+
+      const swap = {
+        pair: `${ArkClient.symbol}/BTC`,
+        orderSide: OrderSide.SELL,
+        timeoutBlockHeight: currentTimestamp + 500 * 60,
+      } as Swap;
+
+      await expect(deltaProvider.getCltvLimit(swap)).resolves.toEqual(30);
+
+      TimeoutDeltaProvider.blockTimes.set(ArkClient.symbol, originalBlockTime);
+      arkCurrency.arkNode = {
+        getBlockHeight: jest.fn().mockResolvedValue(500),
+        usesLocktimeSeconds: false,
+      } as any;
+    });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLTV limit calculation for Lightning flows, including ARK timestamp-based lock handling with the correct block-time conversion.
  * Reused the Lightning currency setting during timeout calculations for more consistent results.

* **Tests**
  * Added coverage for ARK timestamp-based lock scenarios to verify CLTV limits when block-time settings are overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->