### PR TITLE
fix: accept single id in swap status query

### DIFF
--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -3330,11 +3330,12 @@ class SwapRouter extends RouterBase {
   };
 
   private getSwapStatusMultiple = async (req: Request, res: Response) => {
-    const ids = req.query.ids as string[];
-    if (!Array.isArray(ids)) {
-      errorResponse(this.logger, req, res, 'ids must be an array', 400);
-      return;
-    }
+    // A single `?ids=x` is parsed as a bare string by Express's query parser;
+    // treat it as a one-element array so callers needn't special-case one id.
+    const raw = req.query.ids;
+    const ids = (
+      Array.isArray(raw) ? raw : raw === undefined ? [] : [raw]
+    ) as string[];
 
     if (ids.length > 64) {
       errorResponse(this.logger, req, res, 'too many ids', 400);

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -320,15 +320,26 @@ describe('SwapRouter', () => {
   });
 
   describe('getSwapStatusMultiple', () => {
-    test('should not get multiple swap statuses when ids is not an array', async () => {
+    test('should return an empty result when ids is missing', async () => {
       const res = mockResponse();
       await swapRouter['getSwapStatusMultiple'](
         mockRequest(undefined, {}),
         res,
       );
 
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ error: 'ids must be an array' });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({});
+    });
+
+    test('should return an empty result when ids is an empty array', async () => {
+      const res = mockResponse();
+      await swapRouter['getSwapStatusMultiple'](
+        mockRequest(undefined, { ids: [] }),
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({});
     });
 
     test('should not get multiple swap statuses when ids contains non-strings', async () => {
@@ -358,6 +369,19 @@ describe('SwapRouter', () => {
       const res = mockResponse();
       await swapRouter['getSwapStatusMultiple'](
         mockRequest(undefined, { ids: ['swapId'] }),
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        swapId: await swapInfos.get('swapId'),
+      });
+    });
+
+    test('should get a single status when ids is a bare string (one ?ids=x param)', async () => {
+      const res = mockResponse();
+      await swapRouter['getSwapStatusMultiple'](
+        mockRequest(undefined, { ids: 'swapId' }),
         res,
       );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap status lookups when `ids` is provided as a single query value; the request is now interpreted correctly and returns the expected status.
  * When `ids` is missing or empty, the endpoint now returns `200` with an empty result instead of an error.
* **Tests**
  * Updated and added unit tests to verify `200` responses for missing/empty `ids` and correct handling of single-value `ids` input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->