### PR TITLE
fix: catch unhandled errors from static file routes

### DIFF
--- a/lib/api/Api.ts
+++ b/lib/api/Api.ts
@@ -9,6 +9,29 @@ import SwapInfos from './SwapInfos';
 import { errorResponse } from './Utils';
 import ApiV2 from './v2/ApiV2';
 
+// Catches errors that skip the try/catch in route handlers, e.g. sendFile
+// (used for static files) rejecting requests with a bogus Range header
+export const handleUnhandledError = (
+  logger: Logger,
+  error: any,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  if (res.headersSent) {
+    next(error);
+    return;
+  }
+
+  errorResponse(
+    logger,
+    req,
+    res,
+    error,
+    error.status || error.statusCode || 500,
+  );
+};
+
 class Api {
   public readonly swapInfos: SwapInfos;
   public readonly controller: Controller;
@@ -53,6 +76,11 @@ class Api {
 
     new ApiV2(this.logger, service, this.swapInfos).registerRoutes(this.app);
     this.registerRoutes(this.controller);
+
+    this.app.use(
+      (error: any, req: Request, res: Response, next: NextFunction) =>
+        handleUnhandledError(logger, error, req, res, next),
+    );
   }
 
   public init = async (): Promise<void> => {

--- a/test/unit/api/Api.spec.ts
+++ b/test/unit/api/Api.spec.ts
@@ -1,0 +1,63 @@
+import Logger from '../../../lib/Logger';
+import { handleUnhandledError } from '../../../lib/api/Api';
+import { mockRequest, mockResponse } from './Utils';
+
+describe('Api', () => {
+  describe('handleUnhandledError', () => {
+    test('should forward to next when headers were already sent', () => {
+      const req = mockRequest({});
+      const res = mockResponse();
+      (res as any).headersSent = true;
+      const next = jest.fn();
+      const error = new Error('some error');
+
+      handleUnhandledError(Logger.disabledLogger, error, req, res, next);
+
+      expect(next).toHaveBeenCalledWith(error);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    test('should respond with the status code of the error, e.g. Range Not Satisfiable', () => {
+      const req = mockRequest({});
+      const res = mockResponse();
+      const next = jest.fn();
+
+      const error: any = new Error('Range Not Satisfiable');
+      error.status = 416;
+
+      handleUnhandledError(Logger.disabledLogger, error, req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(416);
+      expect(res.json).toHaveBeenCalledWith({ error: error.message });
+    });
+
+    test('should fall back to statusCode when status is not set', () => {
+      const req = mockRequest({});
+      const res = mockResponse();
+      const next = jest.fn();
+
+      const error: any = new Error('Teapot');
+      error.statusCode = 418;
+
+      handleUnhandledError(Logger.disabledLogger, error, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(418);
+      expect(res.json).toHaveBeenCalledWith({ error: error.message });
+    });
+
+    test('should fall back to 500 when neither status nor statusCode is set', () => {
+      const req = mockRequest({});
+      const res = mockResponse();
+      const next = jest.fn();
+
+      const error = new Error('unknown error');
+
+      handleUnhandledError(Logger.disabledLogger, error, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: error.message });
+    });
+  });
+});


### PR DESCRIPTION
res.sendFile rejects requests with a bogus Range header asynchronously, bypassing the route handlers' try/catch. Add a catch-all Express error middleware so these errors get a proper JSON response instead of going unhandled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling so unhandled server errors are returned consistently instead of slipping through.
  * Added better handling for file-serving and range request errors.
  * When an error occurs, the API now uses the best available status code and falls back to `500` if needed.
* **Tests**
  * Added coverage for error forwarding and response behavior, including cases where headers were already sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->