### PR TITLE
docs: align swagger spec with actual API behavior

### DIFF
--- a/lib/api/v2/routers/ChainRouter.ts
+++ b/lib/api/v2/routers/ChainRouter.ts
@@ -348,7 +348,7 @@ class ChainRouter extends RouterBase {
      *         description: Currency of the chain to query for
      *     responses:
      *       '200':
-     *         description: Raw transaction
+     *         description: Network information and contract addresses on the chain
      *         content:
      *           application/json:
      *             schema:
@@ -357,13 +357,19 @@ class ChainRouter extends RouterBase {
      *               json:
      *                 value: '{"network":{"chainId":31337},"swapContracts":{"EtherSwap":"0x5FbDB2315678afecb367f032d93F642f64180aa3","ERC20Swap":"0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"},"supportedContracts":{"3":{"EtherSwap":"0x5FbDB2315678afecb367f032d93F642f64180aa3","ERC20Swap":"0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512","features":[]}},"tokens":{"USDT":"0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"}}'
      *       '400':
-     *         description: Error that caused the query for the transaction to fail
+     *         description: Error that caused the query for the contracts to fail
      *         content:
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
      *       '404':
      *         description: Error when the currency is not on an EVM chain
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+     *       '501':
+     *         description: The Ethereum integration is not enabled
      *         content:
      *           application/json:
      *             schema:

--- a/lib/api/v2/routers/LightningRouter.ts
+++ b/lib/api/v2/routers/LightningRouter.ts
@@ -52,7 +52,7 @@
  *
  *     LightningChannel:
  *       type: object
- *       required: ["source", "shortChannelId"]
+ *       required: ["source", "shortChannelId", "active", "info"]
  *       properties:
  *         source:
  *           $ref: '#/components/schemas/LightningNode'
@@ -68,9 +68,19 @@
  *         info:
  *           $ref: '#/components/schemas/LightningChannelPolicy'
  *
+ *     LightningChannelSide:
+ *       description: One channel partner's policy together with its node
+ *       allOf:
+ *         - $ref: '#/components/schemas/LightningChannelPolicy'
+ *         - type: object
+ *           required: ["node"]
+ *           properties:
+ *             node:
+ *               $ref: '#/components/schemas/LightningNode'
+ *
  *     LightningChannelInfo:
  *       type: object
- *       required: ["shortChannelId", "capacity", "policies"]
+ *       required: ["shortChannelId", "policies"]
  *       properties:
  *         shortChannelId:
  *           type: string
@@ -82,7 +92,7 @@
  *           type: array
  *           description: Policies of the channel partners
  *           items:
- *             $ref: '#/components/schemas/LightningChannelPolicy'
+ *             $ref: '#/components/schemas/LightningChannelSide'
  */
 
 /**
@@ -151,12 +161,6 @@
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/LightningChannelInfo'
- *       '400':
- *         description: Unprocessable request parameters
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
  *       '404':
  *         description: When the channel cannot be found or the currency is not supported
  *         content:
@@ -334,23 +338,67 @@
  *             schema:
  *               type: object
  *       '400':
- *         description: Invalid request parameters
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/BadRequest'
  *       '404':
- *         description: When the currency has no BOLT12 support or the offer was not found
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/Bolt12NotFound'
+ *       '401':
+ *         $ref: '#/components/responses/InvalidSignature'
  *       '422':
- *         description: When the signature is invalid hex
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/InvalidSignatureHex'
+ */
+
+/**
+ * @openapi
+ * components:
+ *   requestBodies:
+ *     Bolt12Delete:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - offer
+ *               - signature
+ *             properties:
+ *               offer:
+ *                 type: string
+ *                 description: The BOLT12 offer
+ *               signature:
+ *                 type: string
+ *                 description: Schnorr signature of the SHA256 hash of "DELETE"
+ *
+ *   responses:
+ *     Bolt12DeleteSuccess:
+ *       description: BOLT12 offer deleted successfully
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *     BadRequest:
+ *       description: Invalid request parameters
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ErrorResponse'
+ *     InvalidSignature:
+ *       description: When the signature is invalid
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ErrorResponse'
+ *     Bolt12NotFound:
+ *       description: When the currency has no BOLT12 support or the offer was not found
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ErrorResponse'
+ *     InvalidSignatureHex:
+ *       description: When the signature is invalid hex
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ErrorResponse'
  */
 
 /**
@@ -367,46 +415,47 @@
  *           type: string
  *         description: Currency of the lightning network to use
  *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required:
- *               - offer
- *               - signature
- *             properties:
- *               offer:
- *                 type: string
- *                 description: The BOLT12 offer
- *               signature:
- *                 type: string
- *                 description: Schnorr signature of the SHA256 hash of "DELETE"
+ *       $ref: '#/components/requestBodies/Bolt12Delete'
  *     responses:
  *       '200':
- *         description: BOLT12 offer deleted successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
+ *         $ref: '#/components/responses/Bolt12DeleteSuccess'
  *       '400':
- *         description: Invalid request parameters
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/InvalidSignature'
  *       '404':
- *         description: When the currency has no BOLT12 support or the offer was not found
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/Bolt12NotFound'
  *       '422':
- *         description: When the signature is invalid hex
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/InvalidSignatureHex'
+ */
+
+/**
+ * @openapi
+ * /lightning/{currency}/bolt12/delete:
+ *   post:
+ *     tags: [Lightning]
+ *     deprecated: true
+ *     description: Deletes a BOLT12 offer. Deprecated alias of DELETE /lightning/{currency}/bolt12
+ *     parameters:
+ *       - in: path
+ *         name: currency
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Currency of the lightning network to use
+ *     requestBody:
+ *       $ref: '#/components/requestBodies/Bolt12Delete'
+ *     responses:
+ *       '200':
+ *         $ref: '#/components/responses/Bolt12DeleteSuccess'
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/InvalidSignature'
+ *       '404':
+ *         $ref: '#/components/responses/Bolt12NotFound'
+ *       '422':
+ *         $ref: '#/components/responses/InvalidSignatureHex'
  */
 
 /**
@@ -440,12 +489,6 @@
  *                 minCltv:
  *                   type: integer
  *                   description: Minimum CLTV value
- *       '400':
- *         description: Invalid request parameters
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
  *       '404':
  *         description: BOLT12 Reverse Swaps not available for the sending symbol
  *         content:
@@ -500,6 +543,12 @@
  *                   $ref: '#/components/schemas/ReverseBip21'
  *       '404':
  *         description: When the currency has no BOLT12 support
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       '422':
+ *         description: When the amount is invalid (e.g. zero)
  *         content:
  *           application/json:
  *             schema:

--- a/lib/api/v2/routers/NodesRouter.ts
+++ b/lib/api/v2/routers/NodesRouter.ts
@@ -104,7 +104,7 @@ class NodesRouter extends RouterBase {
      *   schemas:
      *     NodeStats:
      *       type: object
-     *       required: ["capacity", "channels", "peers", "oldestChannel"]
+     *       required: ["capacity", "channels", "peers"]
      *       properties:
      *         capacity:
      *           type: integer

--- a/lib/api/v2/routers/ReferralRouter.ts
+++ b/lib/api/v2/routers/ReferralRouter.ts
@@ -110,7 +110,8 @@ class ReferralRouter extends RouterBase {
      *                   type: object
      *                   description: Fees collected in that month
      *                   additionalProperties:
-     *                     type: string
+     *                     type: integer
+     *                     format: int64
      *                     description: Fees collected in that currency in satoshis
      *             examples:
      *               json:

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -70,6 +70,18 @@ class SwapRouter extends RouterBase {
     /**
      * @openapi
      * components:
+     *   responses:
+     *     SwapNotFound:
+     *       description: When no Swap with the ID could be found
+     *       content:
+     *         application/json:
+     *           schema:
+     *             $ref: '#/components/schemas/ErrorResponse'
+     */
+
+    /**
+     * @openapi
+     * components:
      *   schemas:
      *     SwapTreeLeaf:
      *       type: object
@@ -184,6 +196,13 @@ class SwapRouter extends RouterBase {
      *   get:
      *     description: Possible pairs for Submarine Swaps
      *     tags: [Submarine Swap]
+     *     parameters:
+     *       - name: referral
+     *         in: header
+     *         required: false
+     *         schema:
+     *           type: string
+     *         description: Optional referral ID to receive referral-specific pairs and fees
      *     responses:
      *       '200':
      *         description: Dictionary of the from -> to currencies that can be used in a Submarine Swap
@@ -231,6 +250,11 @@ class SwapRouter extends RouterBase {
      *     SubmarineRequest:
      *       type: object
      *       required: ["from", "to"]
+     *       anyOf:
+     *         - title: With invoice
+     *           required: ["invoice"]
+     *         - title: With preimage hash
+     *           required: ["preimageHash"]
      *       properties:
      *         from:
      *           type: string
@@ -240,10 +264,10 @@ class SwapRouter extends RouterBase {
      *           description: The asset that is received on lightning
      *         invoice:
      *           type: string
-     *           description: BOLT11 invoice that should be paid
+     *           description: BOLT11 invoice that should be paid. Either this or "preimageHash" has to be specified; takes precedence over "preimageHash" if both are set
      *         preimageHash:
      *           type: string
-     *           description: Preimage hash of an invoice that will be set later
+     *           description: Preimage hash of an invoice that will be set later. Either this or "invoice" has to be specified
      *         refundPublicKey:
      *           type: string
      *           description: Public key with which the Submarine Swap can be refunded encoded as HEX
@@ -274,14 +298,14 @@ class SwapRouter extends RouterBase {
      *   schemas:
      *     SubmarineResponse:
      *       type: object
-     *       required: ["id", "expectedAmount"]
+     *       required: ["id"]
      *       properties:
      *         id:
      *           type: string
      *           description: ID of the created Submarine Swap
      *         bip21:
      *           type: string
-     *           description: BIP21 for the onchain payment request
+     *           description: BIP21 for the onchain payment request. Only set when the swap was created with an invoice
      *         address:
      *           type: string
      *           description: Onchain HTLC address
@@ -290,6 +314,9 @@ class SwapRouter extends RouterBase {
      *         claimPublicKey:
      *           type: string
      *           description: Public key of Boltz that will be used to sweep the onchain HTLC
+     *         claimAddress:
+     *           type: string
+     *           description: EVM address of Boltz that will be used to claim the onchain HTLC. Only set for swaps to EVM based chains
      *         timeoutBlockHeight:
      *           type: number
      *           description: Timeout block height of the onchain HTLC
@@ -297,10 +324,10 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/ArkTimeouts'
      *         acceptZeroConf:
      *           type: boolean
-     *           description: Whether 0-conf will be accepted assuming the transaction does not signal RBF and has a reasonably high fee
+     *           description: Whether 0-conf will be accepted assuming the transaction does not signal RBF and has a reasonably high fee. Only set when the swap was created with an invoice
      *         expectedAmount:
      *           type: number
-     *           description: Amount that is expected to be sent to the onchain HTLC address in satoshis
+     *           description: Amount that is expected to be sent to the onchain HTLC address in satoshis. Only set when the swap was created with an invoice
      *         blindingKey:
      *           type: string
      *           description: Liquid blinding private key encoded as HEX
@@ -369,6 +396,8 @@ class SwapRouter extends RouterBase {
      *                 description: BOLT11 invoice that should be paid. The preimage hash has to match the one specified when creating the swap
      *               pairHash:
      *                 type: string
+     *               extraFees:
+     *                 $ref: '#/components/schemas/ExtraFees'
      *     responses:
      *       '200':
      *         description: Information about the onchain part of the Submarine Swap
@@ -393,6 +422,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      *       '409':
      *         description: That swap has an invoice already
      *         content:
@@ -436,6 +467,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.get(
       '/submarine/:id/invoice/amount',
@@ -490,6 +523,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.get(
       '/submarine/:id/transaction',
@@ -578,6 +613,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.get('/submarine/:id/refund', this.handleError(this.refundEvm));
 
@@ -680,6 +717,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.post(
       '/submarine/:id/refund',
@@ -785,11 +824,7 @@ class SwapRouter extends RouterBase {
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
      *       '404':
-     *         description: When no Swap with the ID could be found
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/ErrorResponse'
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.get(
       '/submarine/:id/claim',
@@ -829,11 +864,7 @@ class SwapRouter extends RouterBase {
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
      *       '404':
-     *         description: When no Swap with the ID could be found
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/ErrorResponse'
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.post('/submarine/:id/claim', this.handleError(this.claimSubmarine));
 
@@ -893,6 +924,13 @@ class SwapRouter extends RouterBase {
      *   get:
      *     description: Possible pairs for Reverse Swaps
      *     tags: [Reverse Swap]
+     *     parameters:
+     *       - name: referral
+     *         in: header
+     *         required: false
+     *         schema:
+     *           type: string
+     *         description: Optional referral ID to receive referral-specific pairs and fees
      *     responses:
      *       '200':
      *         description: Dictionary of the from -> to currencies that can be used in a Reverse Swap
@@ -916,7 +954,12 @@ class SwapRouter extends RouterBase {
      *   schemas:
      *     ReverseRequest:
      *       type: object
-     *       required: ["from", "to", "preimageHash"]
+     *       required: ["from", "to"]
+     *       oneOf:
+     *         - title: With preimage hash
+     *           required: ["preimageHash"]
+     *         - title: With BOLT12 invoice
+     *           required: ["invoice"]
      *       properties:
      *         from:
      *           type: string
@@ -926,7 +969,10 @@ class SwapRouter extends RouterBase {
      *           description: The asset that is received onchain
      *         preimageHash:
      *           type: string
-     *           description: SHA-256 hash of the preimage of the Reverse Swap encoded as HEX
+     *           description: SHA-256 hash of the preimage of the Reverse Swap encoded as HEX. Either this or "invoice" has to be specified
+     *         invoice:
+     *           type: string
+     *           description: BOLT12 invoice to be used for the Reverse Swap instead of a preimage hash. The amount of the invoice is used as the invoice amount; conflicts with "preimageHash", "invoiceAmount" and "onchainAmount"
      *         claimPublicKey:
      *           type: string
      *           description: Public key with which the Reverse Swap can be claimed encoded as HEX
@@ -935,10 +981,10 @@ class SwapRouter extends RouterBase {
      *           description: EVM address with which the Reverse Swap can be claimed
      *         invoiceAmount:
      *           type: number
-     *           description: Amount for which the invoice should be; conflicts with "onchainAmount"
+     *           description: Amount for which the invoice should be; conflicts with "onchainAmount" and "invoice"
      *         onchainAmount:
      *           type: number
-     *           description: Amount that should be locked in the onchain HTLC; conflicts with "invoiceAmount"
+     *           description: Amount that should be locked in the onchain HTLC; conflicts with "invoiceAmount" and "invoice"
      *         pairHash:
      *           type: string
      *           description: Pair hash from the pair information for the client to check if their fee data is up-to-date
@@ -981,14 +1027,14 @@ class SwapRouter extends RouterBase {
      *   schemas:
      *     ReverseResponse:
      *       type: object
-     *       required: ["id", "invoice"]
+     *       required: ["id"]
      *       properties:
      *         id:
      *           type: string
      *           description: ID of the created Reverse Swap
      *         invoice:
      *           type: string
-     *           description: Hold invoice of the Reverse Swap
+     *           description: Hold invoice of the Reverse Swap. Not set when the Reverse Swap was created with a client-provided BOLT12 invoice
      *         swapTree:
      *           $ref: '#/components/schemas/SwapTree'
      *         lockupAddress:
@@ -1131,6 +1177,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.get(
       '/reverse/:id/transaction',
@@ -1191,6 +1239,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.post('/reverse/:id/claim', this.handleError(this.claimReverse));
 
@@ -1317,6 +1367,13 @@ class SwapRouter extends RouterBase {
      *   get:
      *     description: Possible pairs for Chain Swaps
      *     tags: [Chain Swap]
+     *     parameters:
+     *       - name: referral
+     *         in: header
+     *         required: false
+     *         schema:
+     *           type: string
+     *         description: Optional referral ID to receive referral-specific pairs and fees
      *     responses:
      *       '200':
      *         description: Dictionary of the from -> to currencies that can be used in a Chain Swap
@@ -1403,7 +1460,7 @@ class SwapRouter extends RouterBase {
      *         timeoutBlockHeight:
      *           type: number
      *           description: Timeout block height of the onchain HTLC
-     *         timeoutBlockHeights:
+     *         timeouts:
      *           $ref: '#/components/schemas/ArkTimeouts'
      *         amount:
      *           type: number
@@ -1716,6 +1773,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.get(
       '/chain/:id/refund',
@@ -1755,6 +1814,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.post(
       '/chain/:id/refund',
@@ -1848,6 +1909,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      *       '409':
      *         description: The quote cannot be renegotiated because a refund was signed already
      *         content:
@@ -1897,6 +1960,8 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         $ref: '#/components/responses/SwapNotFound'
      *       '409':
      *         description: The quote cannot be renegotiated because a refund was signed already
      *         content:
@@ -1933,6 +1998,7 @@ class SwapRouter extends RouterBase {
      *         transaction:
      *           type: object
      *           description: Details of the transaction relevant to the status update
+     *           required: ["id"]
      *           properties:
      *             id:
      *               type: string
@@ -1940,9 +2006,26 @@ class SwapRouter extends RouterBase {
      *             hex:
      *               type: string
      *               description: Raw hex of the transaction
+     *             eta:
+     *               type: number
+     *               description: Estimated time in blocks until the transaction is confirmed; only set while the transaction is still in the mempool
      *             confirmed:
      *               type: boolean
      *               description: Whether the transaction is confirmed; only set for `transaction.refunded`. Clients can only request cooperative refund signatures after this is `true`
+     *         failureReason:
+     *           type: string
+     *           description: Reason for the failure of the Swap; only set for failure statuses
+     *         failureDetails:
+     *           type: object
+     *           description: Details about the incorrect amount that caused the Swap to fail; only set for some failure statuses
+     *           required: ["expected", "actual"]
+     *           properties:
+     *             expected:
+     *               type: number
+     *               description: Amount that was expected in satoshis
+     *             actual:
+     *               type: number
+     *               description: Amount that was actually received in satoshis
      */
 
     /**
@@ -1978,6 +2061,12 @@ class SwapRouter extends RouterBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         description: When any of the queried Swap IDs could not be found
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
      */
     router.get('/status', this.handleError(this.getSwapStatusMultiple));
 
@@ -2002,11 +2091,7 @@ class SwapRouter extends RouterBase {
      *             schema:
      *               $ref: '#/components/schemas/SwapStatus'
      *       '404':
-     *         description: When no Swap with the ID could be found
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/ErrorResponse'
+     *         $ref: '#/components/responses/SwapNotFound'
      */
     router.get('/:id', this.handleError(this.getSwapStatus));
 
@@ -2132,6 +2217,9 @@ class SwapRouter extends RouterBase {
      *         invoice:
      *           type: string
      *           description: Invoice of the swap, if set. Only returned for submarine swaps
+     *         amount:
+     *           type: number
+     *           description: Amount of the swap in satoshis
      *         timeoutBlockHeight:
      *           type: number
      *           description: Block height at which the rescuable onchain HTLCs will time out
@@ -2572,11 +2660,7 @@ class SwapRouter extends RouterBase {
      *           items:
      *             type: array
      *             items:
-     *               oneOf:
-     *                 - type: integer
-     *                   description: UNIX timestamp
-     *                 - type: number
-     *                   description: Fee value
+     *               type: number
      *             minItems: 2
      *             maxItems: 2
      *         maximalRoutingFee:
@@ -2585,11 +2669,7 @@ class SwapRouter extends RouterBase {
      *           items:
      *             type: array
      *             items:
-     *               oneOf:
-     *                 - type: integer
-     *                   description: UNIX timestamp
-     *                 - type: number
-     *                   description: Maximal Lightning routing fee percentage
+     *               type: number
      *             minItems: 2
      *             maxItems: 2
      */
@@ -2620,7 +2700,7 @@ class SwapRouter extends RouterBase {
      *         schema:
      *           type: string
      *         description: Destination currency symbol
-     *       - name: Referral
+     *       - name: referral
      *         in: header
      *         required: true
      *         schema:

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -86,6 +86,17 @@
         "tags": [
           "Submarine Swap"
         ],
+        "parameters": [
+          {
+            "name": "referral",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional referral ID to receive referral-specific pairs and fees"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Dictionary of the from -> to currencies that can be used in a Submarine Swap",
@@ -192,6 +203,9 @@
                   },
                   "pairHash": {
                     "type": "string"
+                  },
+                  "extraFees": {
+                    "$ref": "#/components/schemas/ExtraFees"
                   }
                 }
               }
@@ -237,6 +251,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           },
           "409": {
             "description": "That swap has an invoice already",
@@ -297,6 +314,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       }
@@ -338,6 +358,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       }
@@ -439,6 +462,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       },
@@ -488,6 +514,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       }
@@ -592,14 +621,7 @@
             }
           },
           "404": {
-            "description": "When no Swap with the ID could be found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       },
@@ -651,14 +673,7 @@
             }
           },
           "404": {
-            "description": "When no Swap with the ID could be found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       }
@@ -668,6 +683,17 @@
         "description": "Possible pairs for Reverse Swaps",
         "tags": [
           "Reverse Swap"
+        ],
+        "parameters": [
+          {
+            "name": "referral",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional referral ID to receive referral-specific pairs and fees"
+          }
         ],
         "responses": {
           "200": {
@@ -805,6 +831,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       }
@@ -856,6 +885,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       }
@@ -916,6 +948,17 @@
         "description": "Possible pairs for Chain Swaps",
         "tags": [
           "Chain Swap"
+        ],
+        "parameters": [
+          {
+            "name": "referral",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional referral ID to receive referral-specific pairs and fees"
+          }
         ],
         "responses": {
           "200": {
@@ -1214,6 +1257,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       },
@@ -1263,6 +1309,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       }
@@ -1366,6 +1415,9 @@
               }
             }
           },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
+          },
           "409": {
             "description": "The quote cannot be renegotiated because a refund was signed already",
             "content": {
@@ -1424,6 +1476,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/SwapNotFound"
           },
           "409": {
             "description": "The quote cannot be renegotiated because a refund was signed already",
@@ -1484,6 +1539,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "When any of the queried Swap IDs could not be found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -1517,14 +1582,7 @@
             }
           },
           "404": {
-            "description": "When no Swap with the ID could be found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/SwapNotFound"
           }
         }
       }
@@ -1798,7 +1856,7 @@
             "description": "Destination currency symbol"
           },
           {
-            "name": "Referral",
+            "name": "referral",
             "in": "header",
             "required": true,
             "schema": {
@@ -1947,16 +2005,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LightningChannelInfo"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Unprocessable request parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2229,34 +2277,16 @@
             }
           },
           "400": {
-            "description": "Invalid request parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/InvalidSignature"
           },
           "404": {
-            "description": "When the currency has no BOLT12 support or the offer was not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/Bolt12NotFound"
           },
           "422": {
-            "description": "When the signature is invalid hex",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/InvalidSignatureHex"
           }
         }
       },
@@ -2277,69 +2307,63 @@
           }
         ],
         "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "offer",
-                  "signature"
-                ],
-                "properties": {
-                  "offer": {
-                    "type": "string",
-                    "description": "The BOLT12 offer"
-                  },
-                  "signature": {
-                    "type": "string",
-                    "description": "Schnorr signature of the SHA256 hash of \"DELETE\""
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "#/components/requestBodies/Bolt12Delete"
         },
         "responses": {
           "200": {
-            "description": "BOLT12 offer deleted successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
+            "$ref": "#/components/responses/Bolt12DeleteSuccess"
           },
           "400": {
-            "description": "Invalid request parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/InvalidSignature"
           },
           "404": {
-            "description": "When the currency has no BOLT12 support or the offer was not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/Bolt12NotFound"
           },
           "422": {
-            "description": "When the signature is invalid hex",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+            "$ref": "#/components/responses/InvalidSignatureHex"
+          }
+        }
+      }
+    },
+    "/lightning/{currency}/bolt12/delete": {
+      "post": {
+        "tags": [
+          "Lightning"
+        ],
+        "deprecated": true,
+        "description": "Deletes a BOLT12 offer. Deprecated alias of DELETE /lightning/{currency}/bolt12",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "currency",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Currency of the lightning network to use"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Bolt12Delete"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Bolt12DeleteSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/InvalidSignature"
+          },
+          "404": {
+            "$ref": "#/components/responses/Bolt12NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidSignatureHex"
           }
         }
       }
@@ -2386,16 +2410,6 @@
                       "description": "Minimum CLTV value"
                     }
                   }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2483,6 +2497,16 @@
           },
           "404": {
             "description": "When the currency has no BOLT12 support",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "When the amount is invalid (e.g. zero)",
             "content": {
               "application/json": {
                 "schema": {
@@ -2871,7 +2895,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Raw transaction",
+            "description": "Network information and contract addresses on the chain",
             "content": {
               "application/json": {
                 "schema": {
@@ -2886,7 +2910,7 @@
             }
           },
           "400": {
-            "description": "Error that caused the query for the transaction to fail",
+            "description": "Error that caused the query for the contracts to fail",
             "content": {
               "application/json": {
                 "schema": {
@@ -2897,6 +2921,16 @@
           },
           "404": {
             "description": "Error when the currency is not on an EVM chain",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "The Ethereum integration is not enabled",
             "content": {
               "application/json": {
                 "schema": {
@@ -3554,7 +3588,8 @@
                       "type": "object",
                       "description": "Fees collected in that month",
                       "additionalProperties": {
-                        "type": "string",
+                        "type": "integer",
+                        "format": "int64",
                         "description": "Fees collected in that currency in satoshis"
                       }
                     }
@@ -4026,6 +4061,20 @@
           "from",
           "to"
         ],
+        "anyOf": [
+          {
+            "title": "With invoice",
+            "required": [
+              "invoice"
+            ]
+          },
+          {
+            "title": "With preimage hash",
+            "required": [
+              "preimageHash"
+            ]
+          }
+        ],
         "properties": {
           "from": {
             "type": "string",
@@ -4037,11 +4086,11 @@
           },
           "invoice": {
             "type": "string",
-            "description": "BOLT11 invoice that should be paid"
+            "description": "BOLT11 invoice that should be paid. Either this or \"preimageHash\" has to be specified; takes precedence over \"preimageHash\" if both are set"
           },
           "preimageHash": {
             "type": "string",
-            "description": "Preimage hash of an invoice that will be set later"
+            "description": "Preimage hash of an invoice that will be set later. Either this or \"invoice\" has to be specified"
           },
           "refundPublicKey": {
             "type": "string",
@@ -4077,8 +4126,7 @@
       "SubmarineResponse": {
         "type": "object",
         "required": [
-          "id",
-          "expectedAmount"
+          "id"
         ],
         "properties": {
           "id": {
@@ -4087,7 +4135,7 @@
           },
           "bip21": {
             "type": "string",
-            "description": "BIP21 for the onchain payment request"
+            "description": "BIP21 for the onchain payment request. Only set when the swap was created with an invoice"
           },
           "address": {
             "type": "string",
@@ -4100,6 +4148,10 @@
             "type": "string",
             "description": "Public key of Boltz that will be used to sweep the onchain HTLC"
           },
+          "claimAddress": {
+            "type": "string",
+            "description": "EVM address of Boltz that will be used to claim the onchain HTLC. Only set for swaps to EVM based chains"
+          },
           "timeoutBlockHeight": {
             "type": "number",
             "description": "Timeout block height of the onchain HTLC"
@@ -4109,11 +4161,11 @@
           },
           "acceptZeroConf": {
             "type": "boolean",
-            "description": "Whether 0-conf will be accepted assuming the transaction does not signal RBF and has a reasonably high fee"
+            "description": "Whether 0-conf will be accepted assuming the transaction does not signal RBF and has a reasonably high fee. Only set when the swap was created with an invoice"
           },
           "expectedAmount": {
             "type": "number",
-            "description": "Amount that is expected to be sent to the onchain HTLC address in satoshis"
+            "description": "Amount that is expected to be sent to the onchain HTLC address in satoshis. Only set when the swap was created with an invoice"
           },
           "blindingKey": {
             "type": "string",
@@ -4332,8 +4384,21 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "preimageHash"
+          "to"
+        ],
+        "oneOf": [
+          {
+            "title": "With preimage hash",
+            "required": [
+              "preimageHash"
+            ]
+          },
+          {
+            "title": "With BOLT12 invoice",
+            "required": [
+              "invoice"
+            ]
+          }
         ],
         "properties": {
           "from": {
@@ -4346,7 +4411,11 @@
           },
           "preimageHash": {
             "type": "string",
-            "description": "SHA-256 hash of the preimage of the Reverse Swap encoded as HEX"
+            "description": "SHA-256 hash of the preimage of the Reverse Swap encoded as HEX. Either this or \"invoice\" has to be specified"
+          },
+          "invoice": {
+            "type": "string",
+            "description": "BOLT12 invoice to be used for the Reverse Swap instead of a preimage hash. The amount of the invoice is used as the invoice amount; conflicts with \"preimageHash\", \"invoiceAmount\" and \"onchainAmount\""
           },
           "claimPublicKey": {
             "type": "string",
@@ -4358,11 +4427,11 @@
           },
           "invoiceAmount": {
             "type": "number",
-            "description": "Amount for which the invoice should be; conflicts with \"onchainAmount\""
+            "description": "Amount for which the invoice should be; conflicts with \"onchainAmount\" and \"invoice\""
           },
           "onchainAmount": {
             "type": "number",
-            "description": "Amount that should be locked in the onchain HTLC; conflicts with \"invoiceAmount\""
+            "description": "Amount that should be locked in the onchain HTLC; conflicts with \"invoiceAmount\" and \"invoice\""
           },
           "pairHash": {
             "type": "string",
@@ -4415,8 +4484,7 @@
       "ReverseResponse": {
         "type": "object",
         "required": [
-          "id",
-          "invoice"
+          "id"
         ],
         "properties": {
           "id": {
@@ -4425,7 +4493,7 @@
           },
           "invoice": {
             "type": "string",
-            "description": "Hold invoice of the Reverse Swap"
+            "description": "Hold invoice of the Reverse Swap. Not set when the Reverse Swap was created with a client-provided BOLT12 invoice"
           },
           "swapTree": {
             "$ref": "#/components/schemas/SwapTree"
@@ -4710,7 +4778,7 @@
             "type": "number",
             "description": "Timeout block height of the onchain HTLC"
           },
-          "timeoutBlockHeights": {
+          "timeouts": {
             "$ref": "#/components/schemas/ArkTimeouts"
           },
           "amount": {
@@ -4898,6 +4966,9 @@
           "transaction": {
             "type": "object",
             "description": "Details of the transaction relevant to the status update",
+            "required": [
+              "id"
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -4907,9 +4978,35 @@
                 "type": "string",
                 "description": "Raw hex of the transaction"
               },
+              "eta": {
+                "type": "number",
+                "description": "Estimated time in blocks until the transaction is confirmed; only set while the transaction is still in the mempool"
+              },
               "confirmed": {
                 "type": "boolean",
                 "description": "Whether the transaction is confirmed; only set for `transaction.refunded`. Clients can only request cooperative refund signatures after this is `true`"
+              }
+            }
+          },
+          "failureReason": {
+            "type": "string",
+            "description": "Reason for the failure of the Swap; only set for failure statuses"
+          },
+          "failureDetails": {
+            "type": "object",
+            "description": "Details about the incorrect amount that caused the Swap to fail; only set for some failure statuses",
+            "required": [
+              "expected",
+              "actual"
+            ],
+            "properties": {
+              "expected": {
+                "type": "number",
+                "description": "Amount that was expected in satoshis"
+              },
+              "actual": {
+                "type": "number",
+                "description": "Amount that was actually received in satoshis"
               }
             }
           }
@@ -5084,6 +5181,10 @@
           "invoice": {
             "type": "string",
             "description": "Invoice of the swap, if set. Only returned for submarine swaps"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Amount of the swap in satoshis"
           },
           "timeoutBlockHeight": {
             "type": "number",
@@ -5462,16 +5563,7 @@
             "items": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
-                    "type": "integer",
-                    "description": "UNIX timestamp"
-                  },
-                  {
-                    "type": "number",
-                    "description": "Fee value"
-                  }
-                ]
+                "type": "number"
               },
               "minItems": 2,
               "maxItems": 2
@@ -5483,16 +5575,7 @@
             "items": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
-                    "type": "integer",
-                    "description": "UNIX timestamp"
-                  },
-                  {
-                    "type": "number",
-                    "description": "Maximal Lightning routing fee percentage"
-                  }
-                ]
+                "type": "number"
               },
               "minItems": 2,
               "maxItems": 2
@@ -5559,7 +5642,9 @@
         "type": "object",
         "required": [
           "source",
-          "shortChannelId"
+          "shortChannelId",
+          "active",
+          "info"
         ],
         "properties": {
           "source": {
@@ -5582,11 +5667,29 @@
           }
         }
       },
+      "LightningChannelSide": {
+        "description": "One channel partner's policy together with its node",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LightningChannelPolicy"
+          },
+          {
+            "type": "object",
+            "required": [
+              "node"
+            ],
+            "properties": {
+              "node": {
+                "$ref": "#/components/schemas/LightningNode"
+              }
+            }
+          }
+        ]
+      },
       "LightningChannelInfo": {
         "type": "object",
         "required": [
           "shortChannelId",
-          "capacity",
           "policies"
         ],
         "properties": {
@@ -5602,7 +5705,7 @@
             "type": "array",
             "description": "Policies of the channel partners",
             "items": {
-              "$ref": "#/components/schemas/LightningChannelPolicy"
+              "$ref": "#/components/schemas/LightningChannelSide"
             }
           }
         }
@@ -5757,8 +5860,7 @@
         "required": [
           "capacity",
           "channels",
-          "peers",
-          "oldestChannel"
+          "peers"
         ],
         "properties": {
           "capacity": {
@@ -5807,6 +5909,94 @@
           "error": {
             "type": "string",
             "description": "Description of the error that caused the request to fail"
+          }
+        }
+      }
+    },
+    "responses": {
+      "SwapNotFound": {
+        "description": "When no Swap with the ID could be found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Bolt12DeleteSuccess": {
+        "description": "BOLT12 offer deleted successfully",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "Invalid request parameters",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "InvalidSignature": {
+        "description": "When the signature is invalid",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Bolt12NotFound": {
+        "description": "When the currency has no BOLT12 support or the offer was not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "InvalidSignatureHex": {
+        "description": "When the signature is invalid hex",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "requestBodies": {
+      "Bolt12Delete": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "offer",
+                "signature"
+              ],
+              "properties": {
+                "offer": {
+                  "type": "string",
+                  "description": "The BOLT12 offer"
+                },
+                "signature": {
+                  "type": "string",
+                  "description": "Schnorr signature of the SHA256 hash of \"DELETE\""
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed OpenAPI specs for swap, lightning, node stats, referral, and chain endpoints.
  * Updated Lightning BOLT12 and channel schema contracts; added documented responses (401/404/422/501) and corrected response descriptions.
  * Standardized swap “not found” documentation across relevant endpoints.
* **New Features**
  * Added optional `referral` header support to swap pair-list endpoints.
* **Bug Fixes**
  * Corrected `/referral/fees` amount type to `int64` and updated other contract field typing/requirements (e.g., timeout naming, swap status details).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->