### PR TITLE
feat: add PATCH endpoint for swap metadata

### DIFF
--- a/.github/actions/setup-build-environment/action.yml
+++ b/.github/actions/setup-build-environment/action.yml
@@ -37,10 +37,11 @@ runs:
         cache: 'npm'
 
     - name: Use Rust toolchain
+      id: rust-toolchain
       shell: bash
-      run:
-        rustup update ${{ inputs.rust-version }} && rustup default ${{
-        inputs.rust-version }}
+      run: |
+        rustup update ${{ inputs.rust-version }} && rustup default ${{ inputs.rust-version }}
+        echo "version=$(rustc --version | cut -d ' ' -f 2)" >> "$GITHUB_OUTPUT"
 
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
@@ -59,7 +60,8 @@ runs:
           ~/.cargo/git/db/
           target/
         key:
-          ${{ runner.os }}-${{ inputs.cache-prefix }}-${{ inputs.rust-version
-          }}-${{ hashFiles('**/Cargo.lock') }}
+          ${{ runner.os }}-${{ inputs.cache-prefix }}-${{
+          steps.rust-toolchain.outputs.version }}-${{ hashFiles('**/Cargo.lock')
+          }}
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache-prefix }}-${{ inputs.rust-version }}-
+          ${{ runner.os }}-${{ inputs.cache-prefix }}-${{ steps.rust-toolchain.outputs.version }}-

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -364,17 +364,17 @@ class SwapRouter extends RouterBase {
 
     /**
      * @openapi
-     * /swap/submarine/{id}/metadata:
+     * /swap/{id}/metadata:
      *   patch:
-     *     tags: [Submarine Swap]
-     *     description: Set or replace the metadata stored alongside a Submarine Swap
+     *     tags: [Swap]
+     *     description: Set or replace the metadata stored alongside a Swap
      *     parameters:
      *       - in: path
      *         name: id
      *         required: true
      *         schema:
      *           type: string
-     *         description: ID of the Submarine Swap
+     *         description: ID of the Swap
      *     requestBody:
      *       required: true
      *       content:
@@ -401,10 +401,7 @@ class SwapRouter extends RouterBase {
      *             schema:
      *               $ref: '#/components/schemas/ErrorResponse'
      */
-    router.patch(
-      '/submarine/:id/metadata',
-      this.handleError(this.patchSubmarineMetadata),
-    );
+    router.patch('/:id/metadata', this.handleError(this.patchMetadata));
 
     /**
      * @openapi
@@ -1113,50 +1110,6 @@ class SwapRouter extends RouterBase {
 
     /**
      * @openapi
-     * /swap/reverse/{id}/metadata:
-     *   patch:
-     *     tags: [Reverse Swap]
-     *     description: Set or replace the metadata stored alongside a Reverse Swap
-     *     parameters:
-     *       - in: path
-     *         name: id
-     *         required: true
-     *         schema:
-     *           type: string
-     *         description: ID of the Reverse Swap
-     *     requestBody:
-     *       required: true
-     *       content:
-     *         application/json:
-     *           schema:
-     *             $ref: '#/components/schemas/MetadataRequest'
-     *     responses:
-     *       '200':
-     *         description: Metadata was stored successfully
-     *         content:
-     *           application/json:
-     *             schema:
-     *               type: object
-     *       '400':
-     *         description: Error that caused the request to fail
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/ErrorResponse'
-     *       '404':
-     *         description: No swap with the provided ID exists
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/ErrorResponse'
-     */
-    router.patch(
-      '/reverse/:id/metadata',
-      this.handleError(this.patchReverseMetadata),
-    );
-
-    /**
-     * @openapi
      * components:
      *   schemas:
      *     InvoiceExpiryRange:
@@ -1578,50 +1531,6 @@ class SwapRouter extends RouterBase {
      *               $ref: '#/components/schemas/ErrorResponse'
      */
     router.post('/chain', this.handleError(this.createChain));
-
-    /**
-     * @openapi
-     * /swap/chain/{id}/metadata:
-     *   patch:
-     *     tags: [Chain Swap]
-     *     description: Set or replace the metadata stored alongside a Chain Swap
-     *     parameters:
-     *       - in: path
-     *         name: id
-     *         required: true
-     *         schema:
-     *           type: string
-     *         description: ID of the Chain Swap
-     *     requestBody:
-     *       required: true
-     *       content:
-     *         application/json:
-     *           schema:
-     *             $ref: '#/components/schemas/MetadataRequest'
-     *     responses:
-     *       '200':
-     *         description: Metadata was stored successfully
-     *         content:
-     *           application/json:
-     *             schema:
-     *               type: object
-     *       '400':
-     *         description: Error that caused the request to fail
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/ErrorResponse'
-     *       '404':
-     *         description: No swap with the provided ID exists
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/ErrorResponse'
-     */
-    router.patch(
-      '/chain/:id/metadata',
-      this.handleError(this.patchChainMetadata),
-    );
 
     /**
      * @openapi
@@ -3610,24 +3519,12 @@ class SwapRouter extends RouterBase {
     await SwapMetadataRepository.add(swapId, data);
   };
 
-  private patchSubmarineMetadata = async (req: Request, res: Response) =>
-    this.patchMetadata(req, res, async (id) => SwapRepository.getSwap({ id }));
+  private findSwapForMetadata = async (id: string) =>
+    (await SwapRepository.getSwap({ id })) ??
+    (await ReverseSwapRepository.getReverseSwap({ id })) ??
+    (await ChainSwapRepository.getChainSwap({ id }));
 
-  private patchReverseMetadata = async (req: Request, res: Response) =>
-    this.patchMetadata(req, res, async (id) =>
-      ReverseSwapRepository.getReverseSwap({ id }),
-    );
-
-  private patchChainMetadata = async (req: Request, res: Response) =>
-    this.patchMetadata(req, res, async (id) =>
-      ChainSwapRepository.getChainSwap({ id }),
-    );
-
-  private patchMetadata = async (
-    req: Request,
-    res: Response,
-    findSwap: (id: string) => Promise<unknown>,
-  ) => {
+  private patchMetadata = async (req: Request, res: Response) => {
     const { id } = validateRequest(req.params, [
       { name: 'id', type: 'string' },
     ]);
@@ -3646,7 +3543,7 @@ class SwapRouter extends RouterBase {
       throw ApiErrors.INVALID_PARAMETER('metadata');
     }
 
-    const swap = await findSwap(id);
+    const swap = await this.findSwapForMetadata(id);
     if (swap === null || swap === undefined) {
       errorResponse(this.logger, req, res, Errors.SWAP_NOT_FOUND(id), 404);
       return;

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -265,7 +265,7 @@ class SwapRouter extends RouterBase {
      *         metadata:
      *           allOf:
      *             - $ref: '#/components/schemas/MetadataHex'
-     *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint
+     *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the restore endpoint
      *         webhook:
      *           $ref: '#/components/schemas/WebhookData'
      *         extraFees:
@@ -1027,7 +1027,7 @@ class SwapRouter extends RouterBase {
      *         metadata:
      *           allOf:
      *             - $ref: '#/components/schemas/MetadataHex'
-     *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint
+     *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the restore endpoint
      *         webhook:
      *           $ref: '#/components/schemas/WebhookData'
      *         extraFees:
@@ -1433,7 +1433,7 @@ class SwapRouter extends RouterBase {
      *         metadata:
      *           allOf:
      *             - $ref: '#/components/schemas/MetadataHex'
-     *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint
+     *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the restore endpoint
      *         webhook:
      *           $ref: '#/components/schemas/WebhookData'
      *         extraFees:
@@ -3516,13 +3516,17 @@ class SwapRouter extends RouterBase {
       return;
     }
 
-    await SwapMetadataRepository.add(swapId, data);
+    await SwapMetadataRepository.set(swapId, data);
   };
 
-  private findSwapForMetadata = async (id: string) =>
-    (await SwapRepository.getSwap({ id })) ??
-    (await ReverseSwapRepository.getReverseSwap({ id })) ??
-    (await ChainSwapRepository.getChainSwap({ id }));
+  private findSwapForMetadata = async (id: string) => {
+    const [swap, reverseSwap, chainSwap] = await Promise.all([
+      SwapRepository.getSwap({ id }),
+      ReverseSwapRepository.getReverseSwap({ id }),
+      ChainSwapRepository.getChainSwap({ id }),
+    ]);
+    return swap ?? reverseSwap ?? chainSwap;
+  };
 
   private patchMetadata = async (req: Request, res: Response) => {
     const { id } = validateRequest(req.params, [
@@ -3538,13 +3542,10 @@ class SwapRouter extends RouterBase {
     const { metadata } = validateRequest(body, [
       { name: 'metadata', type: 'string' },
     ]);
-    const data = this.parseMetadata(metadata);
-    if (data === undefined) {
-      throw ApiErrors.INVALID_PARAMETER('metadata');
-    }
+    const data = this.parseMetadata(metadata)!;
 
     const swap = await this.findSwapForMetadata(id);
-    if (swap === null || swap === undefined) {
+    if (swap === null) {
       errorResponse(this.logger, req, res, Errors.SWAP_NOT_FOUND(id), 404);
       return;
     }

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -6,6 +6,7 @@ import { SwapUpdateEvent, SwapVersion } from '../../../consts/Enums';
 import { unsafeKeys } from '../../../data/Utils';
 import ChainSwapRepository from '../../../db/repositories/ChainSwapRepository';
 import ReferralRepository from '../../../db/repositories/ReferralRepository';
+import ReverseSwapRepository from '../../../db/repositories/ReverseSwapRepository';
 import SwapMetadataRepository from '../../../db/repositories/SwapMetadataRepository';
 import SwapRepository from '../../../db/repositories/SwapRepository';
 import RateProviderTaproot from '../../../rates/providers/RateProviderTaproot';
@@ -228,6 +229,11 @@ class SwapRouter extends RouterBase {
      * @openapi
      * components:
      *   schemas:
+     *     MetadataHex:
+     *       type: string
+     *       pattern: '^(?:[0-9a-fA-F]{2})+$'
+     *       minLength: 2
+     *       maxLength: 2048
      *     SubmarineRequest:
      *       type: object
      *       required: ["from", "to"]
@@ -257,10 +263,8 @@ class SwapRouter extends RouterBase {
      *           type: number
      *           description: Payment timeout in seconds
      *         metadata:
-     *           type: string
-     *           pattern: '^(?:[0-9a-fA-F]{2})+$'
-     *           minLength: 2
-     *           maxLength: 2048
+     *           allOf:
+     *             - $ref: '#/components/schemas/MetadataHex'
      *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint
      *         webhook:
      *           $ref: '#/components/schemas/WebhookData'
@@ -342,6 +346,65 @@ class SwapRouter extends RouterBase {
      *               $ref: '#/components/schemas/ErrorResponse'
      */
     router.post('/submarine', this.handleError(this.createSubmarine));
+
+    /**
+     * @openapi
+     * components:
+     *   schemas:
+     *     MetadataRequest:
+     *       type: object
+     *       required: ["metadata"]
+     *       additionalProperties: false
+     *       properties:
+     *         metadata:
+     *           allOf:
+     *             - $ref: '#/components/schemas/MetadataHex'
+     *           description: Metadata to store alongside the swap encoded as HEX, replacing any metadata set previously. Returned in the restore endpoint
+     */
+
+    /**
+     * @openapi
+     * /swap/submarine/{id}/metadata:
+     *   patch:
+     *     tags: [Submarine Swap]
+     *     description: Set or replace the metadata stored alongside a Submarine Swap
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: ID of the Submarine Swap
+     *     requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             $ref: '#/components/schemas/MetadataRequest'
+     *     responses:
+     *       '200':
+     *         description: Metadata was stored successfully
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *       '400':
+     *         description: Error that caused the request to fail
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         description: No swap with the provided ID exists
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+     */
+    router.patch(
+      '/submarine/:id/metadata',
+      this.handleError(this.patchSubmarineMetadata),
+    );
 
     /**
      * @openapi
@@ -965,10 +1028,8 @@ class SwapRouter extends RouterBase {
      *           type: number
      *           description: Expiry of the invoice in seconds
      *         metadata:
-     *           type: string
-     *           pattern: '^(?:[0-9a-fA-F]{2})+$'
-     *           minLength: 2
-     *           maxLength: 2048
+     *           allOf:
+     *             - $ref: '#/components/schemas/MetadataHex'
      *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint
      *         webhook:
      *           $ref: '#/components/schemas/WebhookData'
@@ -1049,6 +1110,50 @@ class SwapRouter extends RouterBase {
      *               $ref: '#/components/schemas/ErrorResponse'
      */
     router.post('/reverse', this.handleError(this.createReverse));
+
+    /**
+     * @openapi
+     * /swap/reverse/{id}/metadata:
+     *   patch:
+     *     tags: [Reverse Swap]
+     *     description: Set or replace the metadata stored alongside a Reverse Swap
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: ID of the Reverse Swap
+     *     requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             $ref: '#/components/schemas/MetadataRequest'
+     *     responses:
+     *       '200':
+     *         description: Metadata was stored successfully
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *       '400':
+     *         description: Error that caused the request to fail
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         description: No swap with the provided ID exists
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+     */
+    router.patch(
+      '/reverse/:id/metadata',
+      this.handleError(this.patchReverseMetadata),
+    );
 
     /**
      * @openapi
@@ -1373,10 +1478,8 @@ class SwapRouter extends RouterBase {
      *           type: string
      *           description: Referral ID to be used for the Chain Swap
      *         metadata:
-     *           type: string
-     *           pattern: '^(?:[0-9a-fA-F]{2})+$'
-     *           minLength: 2
-     *           maxLength: 2048
+     *           allOf:
+     *             - $ref: '#/components/schemas/MetadataHex'
      *           description: Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint
      *         webhook:
      *           $ref: '#/components/schemas/WebhookData'
@@ -1475,6 +1578,50 @@ class SwapRouter extends RouterBase {
      *               $ref: '#/components/schemas/ErrorResponse'
      */
     router.post('/chain', this.handleError(this.createChain));
+
+    /**
+     * @openapi
+     * /swap/chain/{id}/metadata:
+     *   patch:
+     *     tags: [Chain Swap]
+     *     description: Set or replace the metadata stored alongside a Chain Swap
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: ID of the Chain Swap
+     *     requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             $ref: '#/components/schemas/MetadataRequest'
+     *     responses:
+     *       '200':
+     *         description: Metadata was stored successfully
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *       '400':
+     *         description: Error that caused the request to fail
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+     *       '404':
+     *         description: No swap with the provided ID exists
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ErrorResponse'
+     */
+    router.patch(
+      '/chain/:id/metadata',
+      this.handleError(this.patchChainMetadata),
+    );
 
     /**
      * @openapi
@@ -2292,10 +2439,8 @@ class SwapRouter extends RouterBase {
      *         refundDetails:
      *           $ref: '#/components/schemas/RestoreRefundDetails'
      *         metadata:
-     *           type: string
-     *           pattern: '^(?:[0-9a-fA-F]{2})+$'
-     *           minLength: 2
-     *           maxLength: 2048
+     *           allOf:
+     *             - $ref: '#/components/schemas/MetadataHex'
      *           description: Metadata stored alongside the swap encoded as HEX, if available
      */
 
@@ -3463,6 +3608,52 @@ class SwapRouter extends RouterBase {
     }
 
     await SwapMetadataRepository.add(swapId, data);
+  };
+
+  private patchSubmarineMetadata = async (req: Request, res: Response) =>
+    this.patchMetadata(req, res, async (id) => SwapRepository.getSwap({ id }));
+
+  private patchReverseMetadata = async (req: Request, res: Response) =>
+    this.patchMetadata(req, res, async (id) =>
+      ReverseSwapRepository.getReverseSwap({ id }),
+    );
+
+  private patchChainMetadata = async (req: Request, res: Response) =>
+    this.patchMetadata(req, res, async (id) =>
+      ChainSwapRepository.getChainSwap({ id }),
+    );
+
+  private patchMetadata = async (
+    req: Request,
+    res: Response,
+    findSwap: (id: string) => Promise<unknown>,
+  ) => {
+    const { id } = validateRequest(req.params, [
+      { name: 'id', type: 'string' },
+    ]);
+
+    const body = req.body ?? {};
+    const unknownKey = Object.keys(body).find((key) => key !== 'metadata');
+    if (unknownKey !== undefined) {
+      throw ApiErrors.INVALID_PARAMETER(unknownKey);
+    }
+
+    const { metadata } = validateRequest(body, [
+      { name: 'metadata', type: 'string' },
+    ]);
+    const data = this.parseMetadata(metadata);
+    if (data === undefined) {
+      throw ApiErrors.INVALID_PARAMETER('metadata');
+    }
+
+    const swap = await findSwap(id);
+    if (swap === null || swap === undefined) {
+      errorResponse(this.logger, req, res, Errors.SWAP_NOT_FOUND(id), 404);
+      return;
+    }
+
+    await SwapMetadataRepository.set(id, data);
+    successResponse(res, {});
   };
 
   private getReferralFromHeader = async (req: Request) => {

--- a/lib/db/repositories/SwapMetadataRepository.ts
+++ b/lib/db/repositories/SwapMetadataRepository.ts
@@ -1,12 +1,6 @@
 import SwapMetadata from '../models/SwapMetadata';
 
 class SwapMetadataRepository {
-  public static add = (swapId: string, metadata: Buffer) =>
-    SwapMetadata.create({
-      swapId,
-      data: metadata,
-    });
-
   public static set = (swapId: string, metadata: Buffer) =>
     SwapMetadata.upsert({
       swapId,

--- a/lib/db/repositories/SwapMetadataRepository.ts
+++ b/lib/db/repositories/SwapMetadataRepository.ts
@@ -7,6 +7,12 @@ class SwapMetadataRepository {
       data: metadata,
     });
 
+  public static set = (swapId: string, metadata: Buffer) =>
+    SwapMetadata.upsert({
+      swapId,
+      data: metadata,
+    });
+
   public static get = (swapId: string) =>
     SwapMetadata.findOne({
       where: {

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -4132,7 +4132,7 @@
                 "$ref": "#/components/schemas/MetadataHex"
               }
             ],
-            "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint"
+            "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the restore endpoint"
           },
           "webhook": {
             "$ref": "#/components/schemas/WebhookData"
@@ -4488,7 +4488,7 @@
                 "$ref": "#/components/schemas/MetadataHex"
               }
             ],
-            "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint"
+            "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the restore endpoint"
           },
           "webhook": {
             "$ref": "#/components/schemas/WebhookData"
@@ -4766,7 +4766,7 @@
                 "$ref": "#/components/schemas/MetadataHex"
               }
             ],
-            "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint"
+            "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the restore endpoint"
           },
           "webhook": {
             "$ref": "#/components/schemas/WebhookData"

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -159,12 +159,12 @@
         }
       }
     },
-    "/swap/submarine/{id}/metadata": {
+    "/swap/{id}/metadata": {
       "patch": {
         "tags": [
-          "Submarine Swap"
+          "Swap"
         ],
-        "description": "Set or replace the metadata stored alongside a Submarine Swap",
+        "description": "Set or replace the metadata stored alongside a Swap",
         "parameters": [
           {
             "in": "path",
@@ -173,7 +173,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "ID of the Submarine Swap"
+            "description": "ID of the Swap"
           }
         ],
         "requestBody": {
@@ -803,67 +803,6 @@
         }
       }
     },
-    "/swap/reverse/{id}/metadata": {
-      "patch": {
-        "tags": [
-          "Reverse Swap"
-        ],
-        "description": "Set or replace the metadata stored alongside a Reverse Swap",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "ID of the Reverse Swap"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetadataRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Metadata was stored successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Error that caused the request to fail",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No swap with the provided ID exists",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/swap/reverse/expiry": {
       "get": {
         "description": "Allowed invoice expiry range in seconds per Reverse Swap pair",
@@ -1101,67 +1040,6 @@
           },
           "409": {
             "description": "A swap with that preimage hash exists already",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/swap/chain/{id}/metadata": {
-      "patch": {
-        "tags": [
-          "Chain Swap"
-        ],
-        "description": "Set or replace the metadata stored alongside a Chain Swap",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "ID of the Chain Swap"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MetadataRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Metadata was stored successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Error that caused the request to fail",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No swap with the provided ID exists",
             "content": {
               "application/json": {
                 "schema": {

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -159,6 +159,67 @@
         }
       }
     },
+    "/swap/submarine/{id}/metadata": {
+      "patch": {
+        "tags": [
+          "Submarine Swap"
+        ],
+        "description": "Set or replace the metadata stored alongside a Submarine Swap",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the Submarine Swap"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Metadata was stored successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error that caused the request to fail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No swap with the provided ID exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/swap/submarine/{id}/invoice": {
       "post": {
         "tags": [
@@ -742,6 +803,67 @@
         }
       }
     },
+    "/swap/reverse/{id}/metadata": {
+      "patch": {
+        "tags": [
+          "Reverse Swap"
+        ],
+        "description": "Set or replace the metadata stored alongside a Reverse Swap",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the Reverse Swap"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Metadata was stored successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error that caused the request to fail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No swap with the provided ID exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/swap/reverse/expiry": {
       "get": {
         "description": "Allowed invoice expiry range in seconds per Reverse Swap pair",
@@ -979,6 +1101,67 @@
           },
           "409": {
             "description": "A swap with that preimage hash exists already",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/swap/chain/{id}/metadata": {
+      "patch": {
+        "tags": [
+          "Chain Swap"
+        ],
+        "description": "Set or replace the metadata stored alongside a Chain Swap",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the Chain Swap"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Metadata was stored successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error that caused the request to fail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No swap with the provided ID exists",
             "content": {
               "application/json": {
                 "schema": {
@@ -4020,6 +4203,12 @@
           }
         }
       },
+      "MetadataHex": {
+        "type": "string",
+        "pattern": "^(?:[0-9a-fA-F]{2})+$",
+        "minLength": 2,
+        "maxLength": 2048
+      },
       "SubmarineRequest": {
         "type": "object",
         "required": [
@@ -4060,10 +4249,11 @@
             "description": "Payment timeout in seconds"
           },
           "metadata": {
-            "type": "string",
-            "pattern": "^(?:[0-9a-fA-F]{2})+$",
-            "minLength": 2,
-            "maxLength": 2048,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MetadataHex"
+              }
+            ],
             "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint"
           },
           "webhook": {
@@ -4122,6 +4312,23 @@
           "referralId": {
             "type": "string",
             "description": "Referral ID used for the swap"
+          }
+        }
+      },
+      "MetadataRequest": {
+        "type": "object",
+        "required": [
+          "metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MetadataHex"
+              }
+            ],
+            "description": "Metadata to store alongside the swap encoded as HEX, replacing any metadata set previously. Returned in the restore endpoint"
           }
         }
       },
@@ -4398,10 +4605,11 @@
             "description": "Expiry of the invoice in seconds"
           },
           "metadata": {
-            "type": "string",
-            "pattern": "^(?:[0-9a-fA-F]{2})+$",
-            "minLength": 2,
-            "maxLength": 2048,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MetadataHex"
+              }
+            ],
             "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint"
           },
           "webhook": {
@@ -4675,10 +4883,11 @@
             "description": "Referral ID to be used for the Chain Swap"
           },
           "metadata": {
-            "type": "string",
-            "pattern": "^(?:[0-9a-fA-F]{2})+$",
-            "minLength": 2,
-            "maxLength": 2048,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MetadataHex"
+              }
+            ],
             "description": "Metadata the client wants to store alongside the swap encoded as HEX. Returned in the rescue endpoint"
           },
           "webhook": {
@@ -5331,10 +5540,11 @@
             "$ref": "#/components/schemas/RestoreRefundDetails"
           },
           "metadata": {
-            "type": "string",
-            "pattern": "^(?:[0-9a-fA-F]{2})+$",
-            "minLength": 2,
-            "maxLength": 2048,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MetadataHex"
+              }
+            ],
             "description": "Metadata stored alongside the swap encoded as HEX, if available"
           }
         }

--- a/test/integration/db/repositories/SwapMetadataRepository.spec.ts
+++ b/test/integration/db/repositories/SwapMetadataRepository.spec.ts
@@ -34,6 +34,18 @@ describe('SwapMetadataRepository', () => {
     expect(metadata!.createdAt).toBeInstanceOf(Date);
   });
 
+  test('should set metadata', async () => {
+    const swapId = 'swapId';
+    const first = randomBytes(32);
+    const second = randomBytes(32);
+
+    await SwapMetadataRepository.set(swapId, first);
+    expect((await SwapMetadataRepository.get(swapId))!.data).toEqual(first);
+
+    await SwapMetadataRepository.set(swapId, second);
+    expect((await SwapMetadataRepository.get(swapId))!.data).toEqual(second);
+  });
+
   test('should return null when no metadata exists', async () => {
     await expect(SwapMetadataRepository.get('notFound')).resolves.toBeNull();
   });

--- a/test/integration/db/repositories/SwapMetadataRepository.spec.ts
+++ b/test/integration/db/repositories/SwapMetadataRepository.spec.ts
@@ -21,11 +21,11 @@ describe('SwapMetadataRepository', () => {
     await database.close();
   });
 
-  test('should add and get metadata', async () => {
+  test('should set and get metadata', async () => {
     const swapId = 'swapId';
     const data = randomBytes(32);
 
-    await SwapMetadataRepository.add(swapId, data);
+    await SwapMetadataRepository.set(swapId, data);
     const metadata = await SwapMetadataRepository.get(swapId);
 
     expect(metadata).not.toBeNull();
@@ -34,7 +34,7 @@ describe('SwapMetadataRepository', () => {
     expect(metadata!.createdAt).toBeInstanceOf(Date);
   });
 
-  test('should set metadata', async () => {
+  test('should overwrite metadata', async () => {
     const swapId = 'swapId';
     const first = randomBytes(32);
     const second = randomBytes(32);

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -45,7 +45,6 @@ jest.mock('../../../../../lib/db/repositories/MarkedSwapRepository', () => ({
 }));
 
 jest.mock('../../../../../lib/db/repositories/SwapMetadataRepository', () => ({
-  add: jest.fn().mockResolvedValue(undefined),
   set: jest.fn().mockResolvedValue(undefined),
 }));
 
@@ -192,12 +191,6 @@ describe('SwapRouter', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    ReverseSwapRepository.getReverseSwap = jest.fn().mockResolvedValue({
-      swap: 'details',
-    });
-    ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
-      swap: 'details',
-    });
   });
 
   test('should get route prefix', () => {
@@ -335,6 +328,15 @@ describe('SwapRouter', () => {
   });
 
   describe('patch swap metadata', () => {
+    beforeEach(() => {
+      ReverseSwapRepository.getReverseSwap = jest.fn().mockResolvedValue({
+        swap: 'details',
+      });
+      ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
+        swap: 'details',
+      });
+    });
+
     const callPatchMetadata = async (id: string, body: any) => {
       const res = mockResponse();
       await (swapRouter as any).patchMetadata(
@@ -351,8 +353,6 @@ describe('SwapRouter', () => {
       });
 
       expect(SwapRepository.getSwap).toHaveBeenCalledWith({ id: 'swapId' });
-      expect(ReverseSwapRepository.getReverseSwap).not.toHaveBeenCalled();
-      expect(ChainSwapRepository.getChainSwap).not.toHaveBeenCalled();
       expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
         'swapId',
         validMetadataBuffer,
@@ -371,7 +371,6 @@ describe('SwapRouter', () => {
       expect(ReverseSwapRepository.getReverseSwap).toHaveBeenCalledWith({
         id: 'reverseId',
       });
-      expect(ChainSwapRepository.getChainSwap).not.toHaveBeenCalled();
       expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
         'reverseId',
         validMetadataBuffer,
@@ -692,8 +691,8 @@ describe('SwapRouter', () => {
 
     await swapRouter['createSubmarine'](mockRequest(reqBody), res);
 
-    expect(SwapMetadataRepository.add).toHaveBeenCalledTimes(1);
-    expect(SwapMetadataRepository.add).toHaveBeenCalledWith(
+    expect(SwapMetadataRepository.set).toHaveBeenCalledTimes(1);
+    expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
       'randomId',
       validMetadataBuffer,
     );
@@ -702,7 +701,7 @@ describe('SwapRouter', () => {
 
   test('should fail submarine swap creation when metadata cannot be persisted', async () => {
     const error = new Error('could not persist metadata');
-    (SwapMetadataRepository.add as jest.Mock).mockRejectedValueOnce(error);
+    (SwapMetadataRepository.set as jest.Mock).mockRejectedValueOnce(error);
 
     await expect(
       swapRouter['createSubmarine'](
@@ -1588,8 +1587,8 @@ describe('SwapRouter', () => {
 
     await swapRouter['createReverse'](mockRequest(reqBody), res);
 
-    expect(SwapMetadataRepository.add).toHaveBeenCalledTimes(1);
-    expect(SwapMetadataRepository.add).toHaveBeenCalledWith(
+    expect(SwapMetadataRepository.set).toHaveBeenCalledTimes(1);
+    expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
       'reverseId',
       validMetadataBuffer,
     );
@@ -2274,8 +2273,8 @@ describe('SwapRouter', () => {
 
     await swapRouter['createChain'](mockRequest(reqBody), res);
 
-    expect(SwapMetadataRepository.add).toHaveBeenCalledTimes(1);
-    expect(SwapMetadataRepository.add).toHaveBeenCalledWith(
+    expect(SwapMetadataRepository.set).toHaveBeenCalledTimes(1);
+    expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
       'chainId',
       validMetadataBuffer,
     );

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -327,50 +327,32 @@ describe('SwapRouter', () => {
       expect.anything(),
     );
 
-    expect(mockedRouter.patch).toHaveBeenCalledTimes(3);
+    expect(mockedRouter.patch).toHaveBeenCalledTimes(1);
     expect(mockedRouter.patch).toHaveBeenCalledWith(
-      '/submarine/:id/metadata',
-      expect.anything(),
-    );
-    expect(mockedRouter.patch).toHaveBeenCalledWith(
-      '/reverse/:id/metadata',
-      expect.anything(),
-    );
-    expect(mockedRouter.patch).toHaveBeenCalledWith(
-      '/chain/:id/metadata',
+      '/:id/metadata',
       expect.anything(),
     );
   });
 
   describe('patch swap metadata', () => {
-    const cases = [
-      {
-        name: 'submarine',
-        handler: 'patchSubmarineMetadata',
-        repository: SwapRepository,
-        method: 'getSwap',
-      },
-      {
-        name: 'reverse',
-        handler: 'patchReverseMetadata',
-        repository: ReverseSwapRepository,
-        method: 'getReverseSwap',
-      },
-      {
-        name: 'chain',
-        handler: 'patchChainMetadata',
-        repository: ChainSwapRepository,
-        method: 'getChainSwap',
-      },
-    ] as const;
-
-    test.each(cases)('should patch $name metadata', async ({ handler }) => {
+    const callPatchMetadata = async (id: string, body: any) => {
       const res = mockResponse();
-      await (swapRouter as any)[handler](
-        mockRequest({ metadata: validMetadata }, {}, { id: 'swapId' }),
+      await (swapRouter as any).patchMetadata(
+        mockRequest(body, {}, { id }),
         res,
       );
 
+      return res;
+    };
+
+    test('should patch submarine metadata', async () => {
+      const res = await callPatchMetadata('swapId', {
+        metadata: validMetadata,
+      });
+
+      expect(SwapRepository.getSwap).toHaveBeenCalledWith({ id: 'swapId' });
+      expect(ReverseSwapRepository.getReverseSwap).not.toHaveBeenCalled();
+      expect(ChainSwapRepository.getChainSwap).not.toHaveBeenCalled();
       expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
         'swapId',
         validMetadataBuffer,
@@ -379,24 +361,65 @@ describe('SwapRouter', () => {
       expect(res.json).toHaveBeenCalledWith({});
     });
 
-    test.each(cases)(
-      'should return 404 when $name swap is not found',
-      async ({ handler, repository, method }) => {
-        ((repository as any)[method] as jest.Mock).mockResolvedValueOnce(null);
+    test('should patch reverse metadata', async () => {
+      (SwapRepository.getSwap as jest.Mock).mockResolvedValueOnce(null);
 
-        const res = mockResponse();
-        await (swapRouter as any)[handler](
-          mockRequest({ metadata: validMetadata }, {}, { id: 'notFound' }),
-          res,
-        );
+      const res = await callPatchMetadata('reverseId', {
+        metadata: validMetadata,
+      });
 
-        expect(SwapMetadataRepository.set).not.toHaveBeenCalled();
-        expect(res.status).toHaveBeenCalledWith(404);
-      },
-    );
+      expect(ReverseSwapRepository.getReverseSwap).toHaveBeenCalledWith({
+        id: 'reverseId',
+      });
+      expect(ChainSwapRepository.getChainSwap).not.toHaveBeenCalled();
+      expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
+        'reverseId',
+        validMetadataBuffer,
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({});
+    });
+
+    test('should patch chain metadata', async () => {
+      (SwapRepository.getSwap as jest.Mock).mockResolvedValueOnce(null);
+      (ReverseSwapRepository.getReverseSwap as jest.Mock).mockResolvedValueOnce(
+        null,
+      );
+
+      const res = await callPatchMetadata('chainId', {
+        metadata: validMetadata,
+      });
+
+      expect(ChainSwapRepository.getChainSwap).toHaveBeenCalledWith({
+        id: 'chainId',
+      });
+      expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
+        'chainId',
+        validMetadataBuffer,
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({});
+    });
+
+    test('should return 404 when swap is not found', async () => {
+      (SwapRepository.getSwap as jest.Mock).mockResolvedValueOnce(null);
+      (ReverseSwapRepository.getReverseSwap as jest.Mock).mockResolvedValueOnce(
+        null,
+      );
+      (ChainSwapRepository.getChainSwap as jest.Mock).mockResolvedValueOnce(
+        null,
+      );
+
+      const res = await callPatchMetadata('notFound', {
+        metadata: validMetadata,
+      });
+
+      expect(SwapMetadataRepository.set).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
 
     test.each`
-      error                           | body
+      error                              | body
       ${'undefined parameter: metadata'} | ${{}}
       ${'invalid parameter: metadata'}   | ${{ metadata: 123 }}
       ${'invalid parameter: metadata'}   | ${{ metadata: '' }}
@@ -404,12 +427,7 @@ describe('SwapRouter', () => {
       ${'invalid parameter: metadata'}   | ${{ metadata: oversizedMetadata }}
       ${'invalid parameter: status'}     | ${{ metadata: validMetadata, status: 'swap.created' }}
     `('should reject $error', async ({ error, body }) => {
-      await expect(
-        (swapRouter as any).patchSubmarineMetadata(
-          mockRequest(body, {}, { id: 'swapId' }),
-          mockResponse(),
-        ),
-      ).rejects.toEqual(error);
+      await expect(callPatchMetadata('swapId', body)).rejects.toEqual(error);
 
       expect(SwapMetadataRepository.set).not.toHaveBeenCalled();
     });

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -9,6 +9,7 @@ import { OrderSide, SwapVersion } from '../../../../../lib/consts/Enums';
 import ChainSwapRepository from '../../../../../lib/db/repositories/ChainSwapRepository';
 import MarkedSwapRepository from '../../../../../lib/db/repositories/MarkedSwapRepository';
 import ReferralRepository from '../../../../../lib/db/repositories/ReferralRepository';
+import ReverseSwapRepository from '../../../../../lib/db/repositories/ReverseSwapRepository';
 import SwapMetadataRepository from '../../../../../lib/db/repositories/SwapMetadataRepository';
 import SwapRepository from '../../../../../lib/db/repositories/SwapRepository';
 import Errors from '../../../../../lib/service/Errors';
@@ -18,6 +19,7 @@ import { mockRequest, mockResponse } from '../../Utils';
 const mockedRouter = {
   get: jest.fn(),
   post: jest.fn(),
+  patch: jest.fn(),
 };
 
 jest.mock('express', () => {
@@ -44,6 +46,7 @@ jest.mock('../../../../../lib/db/repositories/MarkedSwapRepository', () => ({
 
 jest.mock('../../../../../lib/db/repositories/SwapMetadataRepository', () => ({
   add: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe('SwapRouter', () => {
@@ -189,6 +192,12 @@ describe('SwapRouter', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    ReverseSwapRepository.getReverseSwap = jest.fn().mockResolvedValue({
+      swap: 'details',
+    });
+    ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
+      swap: 'details',
+    });
   });
 
   test('should get route prefix', () => {
@@ -317,6 +326,93 @@ describe('SwapRouter', () => {
       '/chain/:id/quote',
       expect.anything(),
     );
+
+    expect(mockedRouter.patch).toHaveBeenCalledTimes(3);
+    expect(mockedRouter.patch).toHaveBeenCalledWith(
+      '/submarine/:id/metadata',
+      expect.anything(),
+    );
+    expect(mockedRouter.patch).toHaveBeenCalledWith(
+      '/reverse/:id/metadata',
+      expect.anything(),
+    );
+    expect(mockedRouter.patch).toHaveBeenCalledWith(
+      '/chain/:id/metadata',
+      expect.anything(),
+    );
+  });
+
+  describe('patch swap metadata', () => {
+    const cases = [
+      {
+        name: 'submarine',
+        handler: 'patchSubmarineMetadata',
+        repository: SwapRepository,
+        method: 'getSwap',
+      },
+      {
+        name: 'reverse',
+        handler: 'patchReverseMetadata',
+        repository: ReverseSwapRepository,
+        method: 'getReverseSwap',
+      },
+      {
+        name: 'chain',
+        handler: 'patchChainMetadata',
+        repository: ChainSwapRepository,
+        method: 'getChainSwap',
+      },
+    ] as const;
+
+    test.each(cases)('should patch $name metadata', async ({ handler }) => {
+      const res = mockResponse();
+      await (swapRouter as any)[handler](
+        mockRequest({ metadata: validMetadata }, {}, { id: 'swapId' }),
+        res,
+      );
+
+      expect(SwapMetadataRepository.set).toHaveBeenCalledWith(
+        'swapId',
+        validMetadataBuffer,
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({});
+    });
+
+    test.each(cases)(
+      'should return 404 when $name swap is not found',
+      async ({ handler, repository, method }) => {
+        ((repository as any)[method] as jest.Mock).mockResolvedValueOnce(null);
+
+        const res = mockResponse();
+        await (swapRouter as any)[handler](
+          mockRequest({ metadata: validMetadata }, {}, { id: 'notFound' }),
+          res,
+        );
+
+        expect(SwapMetadataRepository.set).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(404);
+      },
+    );
+
+    test.each`
+      error                           | body
+      ${'undefined parameter: metadata'} | ${{}}
+      ${'invalid parameter: metadata'}   | ${{ metadata: 123 }}
+      ${'invalid parameter: metadata'}   | ${{ metadata: '' }}
+      ${'invalid parameter: metadata'}   | ${{ metadata: 'notHex' }}
+      ${'invalid parameter: metadata'}   | ${{ metadata: oversizedMetadata }}
+      ${'invalid parameter: status'}     | ${{ metadata: validMetadata, status: 'swap.created' }}
+    `('should reject $error', async ({ error, body }) => {
+      await expect(
+        (swapRouter as any).patchSubmarineMetadata(
+          mockRequest(body, {}, { id: 'swapId' }),
+          mockResponse(),
+        ),
+      ).rejects.toEqual(error);
+
+      expect(SwapMetadataRepository.set).not.toHaveBeenCalled();
+    });
   });
 
   describe('getSwapStatusMultiple', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `PATCH /swap/{id}/metadata` to set or replace swap metadata.
* **Bug Fixes**
  * Improved metadata update validation (request shape and HEX/size rules) and now returns 404 when the swap can’t be found.
* **Documentation**
  * Updated Swagger to document the new endpoint and introduced reusable metadata request/HEX schemas.
* **Tests**
  * Expanded unit and integration coverage for metadata updates, including overwrite behavior and validation/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->