### PR TITLE
fix: Arbitrum provider in regtest

### DIFF
--- a/docs/boltz.conf
+++ b/docs/boltz.conf
@@ -427,10 +427,8 @@ symbol = "RBTC"  # Native token (no decimals/contractAddress)
 # Number of confirmations required for lockup transactions (default: 1)
 # requiredConfirmations = 1
 #
-# L1 providers for gas estimation:
-# [[arbitrum.l1Providers]]
-# name = "Ethereum Mainnet"
-# endpoint = "https://eth.llamarpc.com"
+# Regtest only: allow falling back to the L2 block number when l1BlockNumber is missing
+# regtest = false
 #
 # [[arbitrum.contracts]]
 # etherSwap = "0x..."

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -126,7 +126,8 @@ type EthereumConfig = {
 };
 
 type ArbitrumConfig = EthereumConfig & {
-  l1Providers: ProviderConfig[];
+  // Allows falling back to the L2 block number when l1BlockNumber is missing
+  regtest?: boolean;
 };
 
 type ApiConfig = {

--- a/lib/wallet/ethereum/ArbitrumProvider.ts
+++ b/lib/wallet/ethereum/ArbitrumProvider.ts
@@ -1,11 +1,12 @@
+import { getNumber } from 'ethers';
 import type { ArbitrumConfig } from '../../Config';
 import type Logger from '../../Logger';
-import { type NetworkDetails, networks } from './EvmNetworks';
+import type { NetworkDetails } from './EvmNetworks';
 import InjectedProvider from './InjectedProvider';
 import type { BlockEvent } from './WebSocketProvider';
 
 class ArbitrumProvider extends InjectedProvider {
-  private l1Provider: InjectedProvider;
+  private readonly regtest: boolean;
 
   constructor(
     logger: Logger,
@@ -14,37 +15,42 @@ class ArbitrumProvider extends InjectedProvider {
   ) {
     super(logger, networkDetails, config);
 
-    this.l1Provider = new InjectedProvider(logger, networks.Ethereum, {
-      providers: config.l1Providers,
-    });
+    this.regtest = config.regtest === true;
   }
 
   public override async init(): Promise<void> {
     await super.init();
-    await this.l1Provider.init();
-  }
 
-  public override async destroy(): Promise<void> {
-    await this.l1Provider.destroy();
-    await super.destroy();
+    // The block poller swallows getLatestBlock errors; fail at startup instead
+    await this.getLatestBlock();
   }
 
   public getLocktimeHeight = async (): Promise<number> => {
-    return await this.l1Provider.getBlockNumber();
+    // Arbitrum contracts read block.number as the L1 height (l1BlockNumber)
+    const { number, l1BlockNumber } = await this.getLatestBlock();
+    return l1BlockNumber ?? number;
   };
 
   protected override getLatestBlock = async (): Promise<BlockEvent> => {
     const raw = await this.forwardMethod<{
-      number: string;
-      l1BlockNumber?: string;
+      number: string | number;
+      l1BlockNumber?: string | number | null;
     }>('send', 'eth_getBlockByNumber', ['latest', false]);
 
+    if (raw.l1BlockNumber == null && !this.regtest) {
+      const message =
+        'Arbitrum RPC returned no l1BlockNumber for the latest block; ' +
+        'refusing to fall back to the L2 block number. Check the Arbitrum RPC ' +
+        'endpoint (set arbitrum.regtest = true only for regtest).';
+      this.logger.error(message);
+      throw new Error(message);
+    }
+
+    // getNumber also handles the decimal l1BlockNumber anvil forks return
     return {
-      number: parseInt(raw.number, 16),
+      number: getNumber(raw.number),
       l1BlockNumber:
-        raw.l1BlockNumber !== undefined
-          ? parseInt(raw.l1BlockNumber, 16)
-          : undefined,
+        raw.l1BlockNumber != null ? getNumber(raw.l1BlockNumber) : undefined,
     };
   };
 }

--- a/lib/wallet/ethereum/InjectedProvider.ts
+++ b/lib/wallet/ethereum/InjectedProvider.ts
@@ -54,7 +54,7 @@ class InjectedProvider implements Provider {
   private static readonly blockPollIntervalMs = 2_500;
 
   constructor(
-    private readonly logger: Logger,
+    protected readonly logger: Logger,
     private readonly networkDetails: NetworkDetails,
     config: Pick<EthereumConfig, 'providers' | 'providerEndpoint'>,
   ) {
@@ -680,9 +680,8 @@ class InjectedProvider implements Provider {
       );
     });
 
-    return Promise.race([promise, timeoutPromise]).then((result) => {
+    return Promise.race([promise, timeoutPromise]).finally(() => {
       clearTimeout(timeoutHandle);
-      return result;
     });
   };
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "regtest:db:setup": "docker exec boltz-postgres sh -c \"sleep 5 && psql -U boltz -tc \\\"SELECT 1 FROM pg_database WHERE datname = 'boltz_test'\\\" | grep -q 1 || psql -U boltz -c \\\"CREATE DATABASE boltz_test\\\"\"",
     "regtest:solidity:deploy": "./tools/install-boltz-core-solidity-libs.sh && cd node_modules/boltz-core && PERMIT2_ADDRESS=0x000000000022D473030F116dDEE9F6B43aC78BA3 npm run deploy:solidity",
     "regtest:solidity:fund": "./target/debug/boltzr-cli evm -p 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d send $(./target/debug/boltzr-cli evm address) 100.0",
-    "docker:nginx": "docker run -d --rm --name boltz-nginx --network host -v ./docker/nginx.conf:/etc/nginx/conf.d/nginx.conf nginx:stable",
+    "docker:nginx": "docker run -d --rm --name boltz-nginx --network host -v ./docker/nginx.conf:/etc/nginx/conf.d/nginx.conf:z nginx:stable",
     "docker:nginx:stop": "docker stop boltz-nginx",
     "test:unit": "GRPC_NODE_VERBOSITY=NONE jest --testTimeout 10000 test/unit",
     "changelog": "git-cliff -o CHANGELOG.md",

--- a/test/integration/wallet/ethereum/ArbitrumProvider.spec.ts
+++ b/test/integration/wallet/ethereum/ArbitrumProvider.spec.ts
@@ -11,7 +11,6 @@ jest.mock(
 );
 
 const arbitrumEndpoint = 'https://arb1.arbitrum.io/rpc';
-const ethereumEndpoint = 'https://ethereum-rpc.publicnode.com';
 
 describe('ArbitrumProvider (integration)', () => {
   jest.setTimeout(60_000);
@@ -21,7 +20,6 @@ describe('ArbitrumProvider (integration)', () => {
   beforeAll(async () => {
     provider = new ArbitrumProvider(Logger.disabledLogger, networks.Arbitrum, {
       providers: [{ name: 'arb1', endpoint: arbitrumEndpoint }],
-      l1Providers: [{ name: 'eth', endpoint: ethereumEndpoint }],
     } as never);
     await provider.init();
   });
@@ -38,14 +36,6 @@ describe('ArbitrumProvider (integration)', () => {
       expect(blk.number).toBeGreaterThan(0);
       expect(typeof blk.l1BlockNumber).toEqual('number');
       expect(blk.l1BlockNumber).toBeGreaterThan(0);
-    });
-
-    test('l1BlockNumber never exceeds the live L1 tip', async () => {
-      const blk = await provider['getLatestBlock']();
-      const liveL1 = await provider['l1Provider'].getBlockNumber();
-
-      expect(blk.l1BlockNumber).toBeLessThanOrEqual(liveL1);
-      expect(liveL1 - (blk.l1BlockNumber as number)).toBeGreaterThanOrEqual(0);
     });
 
     test('agrees with the L1 ref reported by a separate eth_getBlockByNumber call', async () => {
@@ -79,9 +69,6 @@ describe('ArbitrumProvider (integration)', () => {
 
       expect(block.number).toBeGreaterThan(0);
       expect(block.l1BlockNumber).toBeGreaterThan(0);
-
-      const liveL1 = await provider['l1Provider'].getBlockNumber();
-      expect(block.l1BlockNumber as number).toBeLessThanOrEqual(liveL1);
     });
   });
 });

--- a/test/unit/wallet/ethereum/ArbitrumProvider.spec.ts
+++ b/test/unit/wallet/ethereum/ArbitrumProvider.spec.ts
@@ -1,6 +1,6 @@
-import Logger from '../../../../lib/Logger';
 import ArbitrumProvider from '../../../../lib/wallet/ethereum/ArbitrumProvider';
 import { networks } from '../../../../lib/wallet/ethereum/EvmNetworks';
+import InjectedProvider from '../../../../lib/wallet/ethereum/InjectedProvider';
 
 jest.mock('../../../../lib/ExitHandler', () => ({
   shutdownSignal: { aborted: false },
@@ -19,10 +19,23 @@ type L2Mock = {
   destroy: jest.Mock;
 };
 
-type L1Mock = {
-  getBlockNumber: jest.Mock;
-  destroy: jest.Mock;
+type LoggerMock = {
+  error: jest.Mock;
+  warn: jest.Mock;
+  info: jest.Mock;
+  verbose: jest.Mock;
+  debug: jest.Mock;
+  silly: jest.Mock;
 };
+
+const makeLogger = (): LoggerMock => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  verbose: jest.fn(),
+  debug: jest.fn(),
+  silly: jest.fn(),
+});
 
 const hexBlock = (l2: number, l1?: number) => ({
   number: `0x${l2.toString(16)}`,
@@ -41,50 +54,33 @@ const makeL2 = (
   destroy: jest.fn().mockResolvedValue(undefined),
 });
 
-const makeL1 = (height: number): L1Mock => ({
-  getBlockNumber: jest.fn().mockResolvedValue(height),
-  destroy: jest.fn().mockResolvedValue(undefined),
-});
-
 const buildProvider = (
   l2Payload: { number: string; l1BlockNumber?: string } | Error,
-  l1Height = 0,
-): { provider: ArbitrumProvider; l2: L2Mock; l1: L1Mock } => {
-  const provider = new ArbitrumProvider(
-    Logger.disabledLogger,
-    networks.Arbitrum,
-    {
-      providerEndpoint: 'http://127.0.0.1:0',
-      l1Providers: [{ name: 'mainnet', endpoint: 'http://127.0.0.1:0' }],
-    } as never,
-  );
+  regtest = false,
+): { provider: ArbitrumProvider; l2: L2Mock; logger: LoggerMock } => {
+  const logger = makeLogger();
+  const provider = new ArbitrumProvider(logger as never, networks.Arbitrum, {
+    providerEndpoint: 'http://127.0.0.1:0',
+    regtest,
+  } as never);
 
-  // Tear down the real JsonRpcProviders before replacing the maps so their
-  // internal polling timers don't outlive the test.
+  // Tear down the real JsonRpcProviders so their timers don't outlive the test
   for (const real of provider['providers'].values()) {
-    void real.destroy();
-  }
-  for (const real of provider['l1Provider']['providers'].values()) {
     void real.destroy();
   }
 
   const l2 = makeL2(l2Payload);
-  const l1 = makeL1(l1Height);
 
   provider['providers'] = new Map([['l2', l2 as any]]);
   provider['network'] = { chainId: 42161n, name: 'arbitrum' } as never;
 
-  const l1Provider = provider['l1Provider'];
-  l1Provider['providers'] = new Map([['l1', l1 as any]]);
-  l1Provider['network'] = { chainId: 1n, name: 'mainnet' } as never;
-
-  return { provider, l2, l1 };
+  return { provider, l2, logger };
 };
 
 describe('ArbitrumProvider', () => {
   describe('getLatestBlock', () => {
-    test('parses number and l1BlockNumber from the raw L2 block', async () => {
-      const { provider, l2, l1 } = buildProvider(hexBlock(2_000, 123));
+    test('parses hex number and hex l1BlockNumber from the raw L2 block', async () => {
+      const { provider, l2 } = buildProvider(hexBlock(2_000, 123));
 
       await expect(provider['getLatestBlock']()).resolves.toEqual({
         number: 2_000,
@@ -96,18 +92,130 @@ describe('ArbitrumProvider', () => {
         'latest',
         false,
       ]);
-      expect(l1.getBlockNumber).not.toHaveBeenCalled();
 
       await provider.destroy();
     });
 
-    test('returns l1BlockNumber undefined when the raw payload omits it', async () => {
-      const { provider } = buildProvider(hexBlock(2_000));
+    test('parses a decimal JSON-number l1BlockNumber (as anvil returns for mined blocks)', async () => {
+      const { provider } = buildProvider({
+        number: '0x1bc07ff8',
+        l1BlockNumber: 465_600_504,
+      } as never);
+
+      await expect(provider['getLatestBlock']()).resolves.toEqual({
+        number: 465_600_504,
+        l1BlockNumber: 465_600_504,
+      });
+
+      await provider.destroy();
+    });
+
+    test('parses a decimal string l1BlockNumber (base-10, not base-16)', async () => {
+      const { provider } = buildProvider({
+        number: '0x1bc07ff8',
+        l1BlockNumber: '465600504',
+      } as never);
+
+      await expect(provider['getLatestBlock']()).resolves.toEqual({
+        number: 465_600_504,
+        l1BlockNumber: 465_600_504,
+      });
+
+      await provider.destroy();
+    });
+
+    test('parses an uppercase 0X hex l1BlockNumber', async () => {
+      const { provider } = buildProvider({
+        number: '0x1bc07ff8',
+        l1BlockNumber: '0X1BC07FF8',
+      });
+
+      await expect(provider['getLatestBlock']()).resolves.toEqual({
+        number: 465_600_504,
+        l1BlockNumber: 465_600_504,
+      });
+
+      await provider.destroy();
+    });
+
+    test('rejects a garbage l1BlockNumber instead of producing NaN', async () => {
+      const { provider } = buildProvider({
+        number: '0x1bc07ff8',
+        l1BlockNumber: 'abc',
+      });
+
+      await expect(provider['getLatestBlock']()).rejects.toThrow(
+        /invalid numeric/,
+      );
+
+      await provider.destroy();
+    });
+
+    test('logs an error and throws (no silent fallback) when l1BlockNumber is missing outside regtest', async () => {
+      const { provider, logger } = buildProvider(hexBlock(2_000));
+
+      await expect(provider['getLatestBlock']()).rejects.toThrow(
+        /l1BlockNumber/,
+      );
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('l1BlockNumber'),
+      );
+
+      await provider.destroy();
+    });
+
+    test('falls back to the L2 number and does not log when l1BlockNumber is missing in regtest', async () => {
+      const { provider, logger } = buildProvider(hexBlock(2_000), true);
 
       await expect(provider['getLatestBlock']()).resolves.toEqual({
         number: 2_000,
         l1BlockNumber: undefined,
       });
+      expect(logger.error).not.toHaveBeenCalled();
+
+      await provider.destroy();
+    });
+
+    test('treats a null l1BlockNumber like a missing one and throws outside regtest', async () => {
+      const { provider, logger } = buildProvider({
+        number: '0x7d0',
+        l1BlockNumber: null,
+      } as never);
+
+      await expect(provider['getLatestBlock']()).rejects.toThrow(
+        /l1BlockNumber/,
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('l1BlockNumber'),
+      );
+
+      await provider.destroy();
+    });
+
+    test('treats a null l1BlockNumber like a missing one and falls back in regtest', async () => {
+      const { provider, logger } = buildProvider(
+        {
+          number: '0x7d0',
+          l1BlockNumber: null,
+        } as never,
+        true,
+      );
+
+      await expect(provider['getLatestBlock']()).resolves.toEqual({
+        number: 2_000,
+        l1BlockNumber: undefined,
+      });
+      expect(logger.error).not.toHaveBeenCalled();
+
+      await provider.destroy();
+    });
+
+    test('does not log an error when l1BlockNumber is present outside regtest', async () => {
+      const { provider, logger } = buildProvider(hexBlock(2_000, 123));
+
+      await provider['getLatestBlock']();
+      expect(logger.error).not.toHaveBeenCalled();
 
       await provider.destroy();
     });
@@ -138,7 +246,7 @@ describe('ArbitrumProvider', () => {
     });
 
     test('emits BlockEvents that carry l1BlockNumber to listeners', async () => {
-      const { provider, l2, l1 } = buildProvider(hexBlock(2_000, 123));
+      const { provider, l2 } = buildProvider(hexBlock(2_000, 123));
 
       const listener = jest.fn();
       await provider.onBlock(listener);
@@ -150,7 +258,25 @@ describe('ArbitrumProvider', () => {
         l1BlockNumber: 123,
       });
       expect(l2.send).toHaveBeenCalledTimes(1);
-      expect(l1.getBlockNumber).not.toHaveBeenCalled();
+
+      await provider.destroy();
+    });
+
+    test('delivers a decimal l1BlockNumber through the poller without misparsing it', async () => {
+      const { provider } = buildProvider({
+        number: '0x1bc07ff8',
+        l1BlockNumber: 465_600_504,
+      } as never);
+
+      const listener = jest.fn();
+      await provider.onBlock(listener);
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledWith({
+        number: 465_600_504,
+        l1BlockNumber: 465_600_504,
+      });
 
       await provider.destroy();
     });
@@ -187,25 +313,102 @@ describe('ArbitrumProvider', () => {
     });
   });
 
-  describe('getLocktimeHeight', () => {
-    test('returns the live L1 tip from the L1 provider', async () => {
-      const { provider, l1 } = buildProvider(hexBlock(2_000, 123), 999);
+  describe('init', () => {
+    let superInit: jest.SpyInstance;
 
-      await expect(provider.getLocktimeHeight()).resolves.toEqual(999);
-      expect(l1.getBlockNumber).toHaveBeenCalledTimes(1);
+    beforeEach(() => {
+      superInit = jest
+        .spyOn(InjectedProvider.prototype, 'init')
+        .mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      superInit.mockRestore();
+    });
+
+    test('fails startup when the RPC does not report l1BlockNumber outside regtest', async () => {
+      const { provider } = buildProvider(hexBlock(2_000));
+
+      await expect(provider.init()).rejects.toThrow(/l1BlockNumber/);
+      expect(superInit).toHaveBeenCalledTimes(1);
+
+      await provider.destroy();
+    });
+
+    test('succeeds when the RPC reports l1BlockNumber', async () => {
+      const { provider, l2 } = buildProvider(hexBlock(2_000, 123));
+
+      await expect(provider.init()).resolves.toBeUndefined();
+      expect(l2.send).toHaveBeenCalledWith('eth_getBlockByNumber', [
+        'latest',
+        false,
+      ]);
+
+      await provider.destroy();
+    });
+
+    test('succeeds in regtest when l1BlockNumber is missing', async () => {
+      const { provider } = buildProvider(hexBlock(2_000), true);
+
+      await expect(provider.init()).resolves.toBeUndefined();
+
+      await provider.destroy();
+    });
+  });
+
+  describe('getLocktimeHeight', () => {
+    test('returns the Arbitrum block l1BlockNumber, not the L2 number', async () => {
+      const { provider, l2 } = buildProvider(hexBlock(2_000, 123));
+
+      await expect(provider.getLocktimeHeight()).resolves.toEqual(123);
+      expect(l2.send).toHaveBeenCalledWith('eth_getBlockByNumber', [
+        'latest',
+        false,
+      ]);
+
+      await provider.destroy();
+    });
+
+    test('falls back to the L2 block number when l1BlockNumber is absent in regtest', async () => {
+      const { provider } = buildProvider(hexBlock(2_000), true);
+
+      await expect(provider.getLocktimeHeight()).resolves.toEqual(2_000);
+
+      await provider.destroy();
+    });
+
+    test('throws (and logs) outside regtest when l1BlockNumber is absent', async () => {
+      const { provider, logger } = buildProvider(hexBlock(2_000));
+
+      await expect(provider.getLocktimeHeight()).rejects.toThrow(
+        /l1BlockNumber/,
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('l1BlockNumber'),
+      );
+
+      await provider.destroy();
+    });
+
+    test('matches getLatestBlock, the height expiry is judged against', async () => {
+      const { provider } = buildProvider(hexBlock(2_000, 123));
+
+      const block = await provider['getLatestBlock']();
+      await expect(provider.getLocktimeHeight()).resolves.toEqual(
+        block.l1BlockNumber ?? block.number,
+      );
 
       await provider.destroy();
     });
   });
 
   describe('destroy', () => {
-    test('tears down the L1 provider in addition to the L2 one', async () => {
-      const { provider, l2, l1 } = buildProvider(hexBlock(2_000, 123));
+    test('tears down the provider', async () => {
+      const { provider, l2 } = buildProvider(hexBlock(2_000, 123));
 
       await provider.destroy();
 
       expect(l2.destroy).toHaveBeenCalledTimes(1);
-      expect(l1.destroy).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a regtest mode for Arbitrum behavior, with safer fallback handling when L1 block data is unavailable.

* **Bug Fixes**
  * Improved block-height handling and parsing for more input formats.
  * Prevented silent fallback when required block data is missing outside regtest mode.
  * Cleaned up timeout handling and provider startup/shutdown behavior.

* **Tests**
  * Expanded coverage for Arbitrum block parsing, regtest fallback, and lifecycle behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->