### PR TITLE
feat: signed swap-response attestation for reverse swaps

### DIFF
--- a/docs/swap-response-attestation.md
+++ b/docs/swap-response-attestation.md
@@ -1,0 +1,142 @@
+# Swap-response attestation
+
+Reverse swap responses include a Boltz-node-signed commitment to the on-chain
+HTLC parameters. This lets a client whose signer sits behind a separate
+coordinator process — a routing-node control plane, a wallet backend, a
+signer-in-enclave setup — cryptographically verify that the swap's
+`claimPublicKey`, `lockupAddress`, `timeoutBlockHeight` and `onchainAmount`
+weren't tampered with by the coordinator on the way to the signer.
+
+TLS is not sufficient here: TLS proves things to the endpoint that terminates
+the connection. If that endpoint is a compromised coordinator forwarding to a
+signer behind it, the signer sees only what the coordinator chooses to relay. A
+signature under the LN node key survives the coordinator unchanged because it's
+anchored to the same key that signs the swap's Bolt11 invoice.
+
+## Response shape
+
+Present on the reverse-swap creation response
+([`POST /v2/swap/reverse`](./api-v2.md)) whenever the client supplied a
+`claimPublicKey` for a UTXO-based reverse swap:
+
+```json
+{
+  "id": "...",
+  "invoice": "lnbc...",
+  "lockupAddress": "bc1p...",
+  "swapTree": { ... },
+  "refundPublicKey": "02...",
+  "timeoutBlockHeight": 820000,
+  "onchainAmount": 250000,
+  "attestation": {
+    "version": 1,
+    "signature": "zbase32-encoded-compact-ecdsa-with-recovery"
+  }
+}
+```
+
+## Commitment layout
+
+The signed input is `sha256(commitment)`, hex-encoded, where `commitment` is a
+fixed-order byte concatenation:
+
+```
+tag                (variable UTF-8)   "BOLTZ-SWAP-v1|REVERSE"
+len(swap_id)       (uint16 BE)
+swap_id            (variable UTF-8)
+payment_hash       (32 bytes)
+len(pubkey)        (uint8)
+client_pubkey      (33 bytes compressed, or 32 bytes x-only)
+len(address)       (uint16 BE)
+lockup_address     (variable UTF-8)
+timeout            (uint32 BE)
+onchain_amount     (uint64 BE, satoshis)
+```
+
+The tag domain-separates reverse from submarine so no attestation from one
+direction can be replayed as the other.
+
+## Signing key
+
+The commitment hash (hex-encoded) is signed with the Boltz LN node's identity
+key using the "Lightning Signed Message" convention. Both LND
+(`lnrpc.SignMessage`) and CLN (`signmessage`) natively expose this — the
+wire-format signature is a zbase32-encoded 65-byte compact ECDSA-with-recovery
+signature over `sha256d("Lightning Signed Message:" || commitment_hex)`.
+
+For a reverse swap, the signing node is the same LN node that will receive the
+invoice payment — i.e., the same node whose pubkey signs the Bolt11 invoice
+returned in the swap response. Verifiers can extract the expected pubkey
+directly from the invoice.
+
+## Verifying
+
+Pseudocode. A production implementation would use a real `bitcoinjs-message` /
+`zbase32` library and reject any attestation whose `version` doesn't match a
+known value.
+
+```typescript
+import { crypto } from 'bitcoinjs-lib';
+import { verify } from 'bitcoinjs-message';
+// BIP-137-style verify
+import { decode as bolt11Decode } from 'bolt11';
+
+function verifySwapAttestation(
+  response: ReverseSwapResponse,
+  yourClientPubkey: Buffer,
+): boolean {
+  if (response.attestation === undefined) return false;
+  if (response.attestation.version !== 1) return false;
+
+  const { payeeNodeKey } = bolt11Decode(response.invoice);
+
+  // Reconstruct the exact commitment Boltz signed.
+  const commitment = computeReverseSwapCommitment({
+    swapId: response.id,
+    paymentHash: paymentHashFromInvoice(response.invoice),
+    clientPubkey: yourClientPubkey, // your own value, not from response
+    lockupAddress: response.lockupAddress,
+    timeoutBlockHeight: response.timeoutBlockHeight,
+    onchainAmountSat: response.onchainAmount,
+  });
+
+  // The signMessage convention: recover the pubkey via BIP-137
+  // and match against the invoice payee.
+  return verify(
+    commitment.toString('hex'),
+    payeeNodeKey,
+    response.attestation.signature,
+  );
+}
+```
+
+The critical detail: verifiers pass `yourClientPubkey` from **their own
+independent view** of the swap request — the pubkey they intended to use, not
+the one echoed back in the response. If a coordinator between client and Boltz
+substituted a different pubkey, the reconstructed commitment differs from what
+Boltz signed and verification fails.
+
+## Version negotiation
+
+`version` starts at `1`. Any future change to the commitment layout bumps it.
+Verifiers should refuse to interpret attestations with an unknown `version`
+rather than silently upgrading their commitment computation — otherwise a
+downgrade attack on the version field would let a coordinator serve a
+stale-format attestation over new-format swap params.
+
+## Submarine swaps
+
+Not yet emitted. Submarine swaps have a similar exfil vector via the
+`refundPublicKey`, but the LN node that will pay the invoice isn't picked at
+swap-creation time — it's decided when the client submits the invoice via
+`setInvoice`. Signing there is a natural follow-up.
+
+## What this does NOT protect against
+
+- **A compromised Boltz.** The attestation is signed with Boltz's own key; a
+  compromised Boltz can sign anything they want. This is defense against
+  coordinators between the client and Boltz, not against Boltz itself.
+- **A verifier that trusts the coordinator's copy of the `claimPublicKey`.** The
+  whole point is that verifiers must generate the pubkey they expect
+  independently. A verifier that pulls the pubkey from the response and passes
+  it into `computeCommitment` is checking the response against itself.

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -1118,6 +1118,41 @@ class SwapRouter extends RouterBase {
      *         referralId:
      *           type: string
      *           description: Referral ID used for the swap
+     *         attestation:
+     *           $ref: '#/components/schemas/SwapAttestation'
+     */
+
+    /**
+     * @openapi
+     * components:
+     *   schemas:
+     *     SwapAttestation:
+     *       type: object
+     *       required: ["version", "signature"]
+     *       description: |
+     *         Signed commitment to the on-chain HTLC parameters under
+     *         the Boltz LN node key. Present on UTXO-based reverse
+     *         swap responses where a client `claimPublicKey` was
+     *         supplied. Lets a client whose signer sits behind a
+     *         separate coordinator process (e.g. a routing-node
+     *         control plane, a signer-in-enclave setup) verify that
+     *         the swap's `claimPublicKey`, `lockupAddress`,
+     *         `timeoutBlockHeight` and `onchainAmount` weren't
+     *         tampered with by the coordinator on the way to the
+     *         signer. Commitment layout is documented in
+     *         `lib/service/attestation/SwapAttestation.ts`.
+     *       properties:
+     *         version:
+     *           type: number
+     *           description: Attestation format version — currently 1
+     *         signature:
+     *           type: string
+     *           description: |
+     *             zbase32-encoded compact ECDSA-with-recovery signature
+     *             from the LN node's identity key over
+     *             `sha256d("Lightning Signed Message:" || commitment_hex)`.
+     *             Verify by recovering the pubkey and matching against
+     *             the invoice's payee node.
      */
 
     /**

--- a/lib/lightning/LightningClient.ts
+++ b/lib/lightning/LightningClient.ts
@@ -159,6 +159,28 @@ interface LightningClient extends BalancerFetcher, BaseClient<EventTypes> {
     finalCltvDelta?: number,
     routingHints?: HopHint[][],
   ): Promise<Route[]>;
+
+  /**
+   * Sign an arbitrary message with the LN node's identity key using the
+   * "Lightning Signed Message" convention (double-sha256 of
+   * `"Lightning Signed Message:" || message`, ECDSA-with-recovery signed
+   * under the node key). Returns the zbase32-encoded compact signature
+   * (the canonical format both LND `lnrpc.SignMessage` and CLN
+   * `signmessage` emit natively).
+   *
+   * `message` must be a valid UTF-8 string — callers with binary data
+   * are expected to hex-encode it. This constraint comes from CLN's
+   * `signmessage` proto, which types its input as a string; hex is the
+   * conventional choice for cross-implementation portability.
+   *
+   * Used by swap-response attestations (see
+   * `lib/service/attestation/SwapAttestation.ts`) so that a client whose
+   * signer sits behind an untrusted coordinator can cryptographically
+   * verify the swap's on-chain parameters against the same node key that
+   * signs the Bolt11 invoice. This is the primary defense-in-depth
+   * mechanism for signer-vs-coordinator custody splits.
+   */
+  signMessage(message: string): Promise<string>;
 }
 
 interface RoutingHintsProvider {

--- a/lib/lightning/LndClient.ts
+++ b/lib/lightning/LndClient.ts
@@ -288,6 +288,24 @@ class LndClient extends BaseClient<EventTypes> implements LightningClient {
   };
 
   /**
+   * Sign an arbitrary message with the node's identity key using the
+   * standard "Lightning Signed Message" convention. LND's SignMessage
+   * emits a zbase32-encoded 65-byte compact ECDSA-with-recovery
+   * signature over `sha256d("Lightning Signed Message:" || message)`.
+   * See `LightningClient.signMessage` for the wider design rationale.
+   */
+  public signMessage = async (message: string): Promise<string> => {
+    const response = await this.unaryLightningCall<
+      lndrpc.SignMessageRequest,
+      lndrpc.SignMessageResponse
+    >('signMessage', {
+      msg: Buffer.from(message, 'utf8'),
+      singleHash: false,
+    });
+    return response.signature;
+  };
+
+  /**
    * Creates an invoice
    */
   public addInvoice = (

--- a/lib/lightning/SelfPaymentClient.ts
+++ b/lib/lightning/SelfPaymentClient.ts
@@ -223,6 +223,10 @@ class SelfPaymentClient
     throw SelfPaymentClient.notImplementedError;
   };
 
+  public signMessage = (): Promise<string> => {
+    throw SelfPaymentClient.notImplementedError;
+  };
+
   public listChannels = (): Promise<ChannelInfo[]> => {
     throw SelfPaymentClient.notImplementedError;
   };

--- a/lib/lightning/cln/ClnClient.ts
+++ b/lib/lightning/cln/ClnClient.ts
@@ -243,6 +243,21 @@ class ClnClient
     };
   };
 
+  /**
+   * Sign an arbitrary message with the CLN node's identity key using
+   * the standard "Lightning Signed Message" convention. CLN's
+   * `signmessage` RPC natively emits a zbase32-encoded signature over
+   * `sha256d("Lightning Signed Message:" || message)`. See
+   * `LightningClient.signMessage` for the wider design rationale.
+   */
+  public signMessage = async (message: string): Promise<string> => {
+    const response = await this.unaryNodeCall<
+      noderpc.SignmessageRequest,
+      noderpc.SignmessageResponse
+    >('signMessage', { message });
+    return response.zbase;
+  };
+
   public getBalance = async (): Promise<WalletBalance> => {
     const sumOutputs = (
       outs: noderpc.ListfundsOutputs[],

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -2052,6 +2052,7 @@ class Service {
       minerFeeInvoice,
       timeoutBlockHeight,
       timeoutBlockHeights,
+      attestation,
     } = await this.swapManager.createReverseSwap({
       referralId,
       percentageFee,
@@ -2116,6 +2117,10 @@ class Service {
 
     if (invoiceAmountDefined) {
       response.onchainAmount = onchainAmount;
+    }
+
+    if (attestation !== undefined) {
+      response.attestation = attestation;
     }
 
     return response;

--- a/lib/service/attestation/SwapAttestation.ts
+++ b/lib/service/attestation/SwapAttestation.ts
@@ -1,0 +1,177 @@
+import { crypto } from 'bitcoinjs-lib';
+import type { LightningClient } from '../../lightning/LightningClient';
+
+/**
+ * Swap-response attestation — a Boltz-node-signed commitment to the
+ * chain-side parameters of a newly created swap.
+ *
+ * # Why this exists
+ *
+ * The Bolt11 invoice a client pays for a Boltz swap is signed by the
+ * Boltz LN node's identity key, so LN routing safety is anchored to
+ * that key. But the invoice explicitly does not commit to the swap's
+ * on-chain parameters: for a reverse swap the client's `claimPublicKey`
+ * is embedded in the Taproot HTLC Boltz builds off-chain; for a
+ * submarine swap the client's `refundPublicKey` plays the same role.
+ *
+ * Any coordinator between the client's signer and Boltz (a wallet
+ * backend, a routing-node control plane, an enterprise TLS-intercepting
+ * proxy) that gets compromised can substitute the client's pubkey when
+ * relaying the create-swap request to Boltz. The client's signer then
+ * approves the LN payment against on-chain custody it does not actually
+ * control, and the compromised coordinator sweeps the on-chain leg.
+ * HTTPS does not close this gap — TLS proves things to the coordinator
+ * (which terminates the connection), not to the signer behind it.
+ *
+ * A signature over the swap parameters under the same LN identity key
+ * closes the loop: the signer already trusts that key (it verifies the
+ * invoice against it), it can reconstruct the commitment from its own
+ * view of the request, and it can refuse to route the LN payment on a
+ * mismatch. The one signature works for both LND and CLN-backed Boltz
+ * instances because both natively expose `SignMessage` under the node
+ * identity key.
+ *
+ * # Commitment layout
+ *
+ * The signed input is the UTF-8 hex encoding (lowercase, no `0x`) of
+ * `sha256(tag || fields...)`. Hex-encoding lets us send it through
+ * CLN's string-typed `signmessage` RPC without character-set concerns,
+ * and matches the LND path (which passes the same UTF-8 bytes to
+ * `lnrpc.SignMessage`). The signature format follows the standard
+ * "Lightning Signed Message" convention both backends emit — zbase32
+ * of a 65-byte compact ECDSA-with-recovery signature over
+ * `sha256d("Lightning Signed Message:" || commitment_hex)`.
+ *
+ * Distinct tags per swap direction prevent cross-direction replay.
+ * Every field the client verifier needs to bind is committed to; nothing
+ * else. Ordering is fixed: any future field additions bump `version`.
+ */
+
+/** Tag prefix pinning attestations to the reverse-swap direction. */
+export const ATTESTATION_TAG_REVERSE = 'BOLTZ-SWAP-v1|REVERSE';
+
+/** Tag prefix pinning attestations to the submarine-swap direction. */
+export const ATTESTATION_TAG_SUBMARINE = 'BOLTZ-SWAP-v1|SUBMARINE';
+
+/** Attestation format version — bumped on any commitment-layout change. */
+export const ATTESTATION_VERSION = 1;
+
+/** Common fields committed to by every swap-response attestation. */
+export type SwapAttestationInput = {
+  /** Boltz-side swap id. Prevents replay across sibling swaps. */
+  swapId: string;
+  /**
+   * sha256 preimage hash — same value that appears as `payment_hash` on
+   * the Bolt11 invoice and as the hashlock in the on-chain HTLC.
+   */
+  paymentHash: Buffer;
+  /**
+   * The client-supplied pubkey embedded in the HTLC's claim leaf
+   * (reverse) or refund leaf (submarine). This is the field a
+   * compromised coordinator would substitute; the attestation is what
+   * makes that substitution detectable by the client's signer.
+   */
+  clientPubkey: Buffer;
+  /** P2TR lockup address Boltz returned for this swap. */
+  lockupAddress: string;
+  /** Timeout height Boltz committed to in the HTLC's refund path. */
+  timeoutBlockHeight: number;
+  /**
+   * On-chain amount the lockup output will (reverse) or is expected to
+   * (submarine) carry. Committed so amount-tampering by a coordinator
+   * would fail signer-side verification.
+   */
+  onchainAmountSat: number;
+};
+
+/**
+ * Compute the 32-byte commitment hash for a swap-response attestation.
+ * Exposed for tests + for library consumers that want to reproduce the
+ * commitment client-side without re-implementing the concatenation.
+ */
+export const computeAttestationCommitment = (
+  direction: 'reverse' | 'submarine',
+  input: SwapAttestationInput,
+): Buffer => {
+  const tag =
+    direction === 'reverse'
+      ? ATTESTATION_TAG_REVERSE
+      : ATTESTATION_TAG_SUBMARINE;
+
+  // Fixed-order concatenation with length-prefixes on variable-length
+  // fields so no ambiguity is possible at parse time. All integers are
+  // big-endian, matching Bitcoin's on-wire convention.
+  const parts: Buffer[] = [];
+  parts.push(Buffer.from(tag, 'utf8'));
+
+  const swapIdBytes = Buffer.from(input.swapId, 'utf8');
+  const swapIdLen = Buffer.alloc(2);
+  swapIdLen.writeUInt16BE(swapIdBytes.length, 0);
+  parts.push(swapIdLen, swapIdBytes);
+
+  if (input.paymentHash.length !== 32) {
+    throw new Error(
+      `attestation: paymentHash must be 32 bytes, got ${input.paymentHash.length}`,
+    );
+  }
+  parts.push(input.paymentHash);
+
+  if (input.clientPubkey.length !== 33 && input.clientPubkey.length !== 32) {
+    throw new Error(
+      'attestation: clientPubkey must be 32 (x-only) or 33 (compressed) ' +
+        `bytes, got ${input.clientPubkey.length}`,
+    );
+  }
+  const pubkeyLen = Buffer.alloc(1);
+  pubkeyLen.writeUInt8(input.clientPubkey.length, 0);
+  parts.push(pubkeyLen, input.clientPubkey);
+
+  const lockupBytes = Buffer.from(input.lockupAddress, 'utf8');
+  const lockupLen = Buffer.alloc(2);
+  lockupLen.writeUInt16BE(lockupBytes.length, 0);
+  parts.push(lockupLen, lockupBytes);
+
+  const timeout = Buffer.alloc(4);
+  timeout.writeUInt32BE(input.timeoutBlockHeight >>> 0, 0);
+  parts.push(timeout);
+
+  const onchain = Buffer.alloc(8);
+  // Amount fits in a JS number for any realistic BTC total (< 2^53).
+  onchain.writeBigUInt64BE(BigInt(input.onchainAmountSat), 0);
+  parts.push(onchain);
+
+  return crypto.sha256(Buffer.concat(parts));
+};
+
+/** Attestation payload attached to a swap-creation response. */
+export type SwapAttestation = {
+  /**
+   * Format version — currently `1`. Verifiers should refuse to
+   * interpret attestations with an unknown version rather than
+   * silently upgrading their commitment layout.
+   */
+  version: number;
+  /**
+   * zbase32-encoded compact ECDSA-with-recovery signature over
+   * `sha256d("Lightning Signed Message:" || commitment_hex)`. Verify
+   * by recovering the pubkey and matching against the invoice's payee
+   * (reverse) or the swap response's `claimPublicKey` node identity
+   * (submarine).
+   */
+  signature: string;
+};
+
+/**
+ * Compute the commitment for a swap and sign it under the LN node key
+ * associated with `client`, producing the attestation payload the
+ * router should attach to the swap-creation response.
+ */
+export const createSwapAttestation = async (
+  client: LightningClient,
+  direction: 'reverse' | 'submarine',
+  input: SwapAttestationInput,
+): Promise<SwapAttestation> => {
+  const commitment = computeAttestationCommitment(direction, input);
+  const signature = await client.signMessage(commitment.toString('hex'));
+  return { version: ATTESTATION_VERSION, signature };
+};

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -74,6 +74,8 @@ import InvoiceExpiryHelper from '../service/InvoiceExpiryHelper';
 import type PaymentRequestUtils from '../service/PaymentRequestUtils';
 import Renegotiator from '../service/Renegotiator';
 import TimeoutDeltaProvider from '../service/TimeoutDeltaProvider';
+import type { SwapAttestation } from '../service/attestation/SwapAttestation';
+import { createSwapAttestation } from '../service/attestation/SwapAttestation';
 import ChainSwapSigner from '../service/cooperative/ChainSwapSigner';
 import DeferredClaimer from '../service/cooperative/DeferredClaimer';
 import EipSigner from '../service/cooperative/EipSigner';
@@ -156,6 +158,12 @@ type CreatedReverseSwap = {
 
   // Only set for Bitcoin like, UTXO based, chains
   redeemScript: string | undefined;
+
+  // Signed commitment to the on-chain HTLC parameters under the LN
+  // node key. Only set for UTXO-based reverse swaps where a client
+  // `claimPublicKey` was supplied. See
+  // `lib/service/attestation/SwapAttestation.ts`.
+  attestation: SwapAttestation | undefined;
 } & CreatedOnchainSwap;
 
 type CreatedChainSwapDetails = Omit<CreatedOnchainSwap, 'refundPublicKey'> & {
@@ -1176,6 +1184,31 @@ class SwapManager {
         minerFeeInvoicePreimage: minerFeeInvoicePreimage,
         minerFeeOnchainAmount: args.prepayMinerFeeOnchainAmount,
       });
+    }
+
+    // Sign the swap-response attestation for UTXO-based reverse swaps.
+    // See `lib/service/attestation/SwapAttestation.ts` for the design.
+    // EVM reverse swaps use a claim address rather than a claim pubkey,
+    // so the attestation model doesn't apply there (the on-chain
+    // custody surface is different).
+    if (
+      isBitcoinLike &&
+      args.claimPublicKey !== undefined &&
+      result.lockupAddress !== undefined &&
+      result.timeoutBlockHeight !== undefined
+    ) {
+      result.attestation = await createSwapAttestation(
+        lightningClient,
+        'reverse',
+        {
+          swapId: id,
+          paymentHash: args.preimageHash,
+          clientPubkey: args.claimPublicKey,
+          lockupAddress: result.lockupAddress,
+          timeoutBlockHeight: result.timeoutBlockHeight,
+          onchainAmountSat: args.onchainAmount,
+        },
+      );
     }
 
     return result as CreatedReverseSwap;

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -4614,6 +4614,27 @@
           "referralId": {
             "type": "string",
             "description": "Referral ID used for the swap"
+          },
+          "attestation": {
+            "$ref": "#/components/schemas/SwapAttestation"
+          }
+        }
+      },
+      "SwapAttestation": {
+        "type": "object",
+        "required": [
+          "version",
+          "signature"
+        ],
+        "description": "Signed commitment to the on-chain HTLC parameters under\nthe Boltz LN node key. Present on UTXO-based reverse\nswap responses where a client `claimPublicKey` was\nsupplied. Lets a client whose signer sits behind a\nseparate coordinator process (e.g. a routing-node\ncontrol plane, a signer-in-enclave setup) verify that\nthe swap's `claimPublicKey`, `lockupAddress`,\n`timeoutBlockHeight` and `onchainAmount` weren't\ntampered with by the coordinator on the way to the\nsigner. Commitment layout is documented in\n`lib/service/attestation/SwapAttestation.ts`.\n",
+        "properties": {
+          "version": {
+            "type": "number",
+            "description": "Attestation format version — currently 1"
+          },
+          "signature": {
+            "type": "string",
+            "description": "zbase32-encoded compact ECDSA-with-recovery signature\nfrom the LN node's identity key over\n`sha256d(\"Lightning Signed Message:\" || commitment_hex)`.\nVerify by recovering the pubkey and matching against\nthe invoice's payee node.\n"
           }
         }
       },

--- a/test/unit/service/attestation/SwapAttestation.spec.ts
+++ b/test/unit/service/attestation/SwapAttestation.spec.ts
@@ -1,0 +1,301 @@
+import { crypto } from 'bitcoinjs-lib';
+import type { LightningClient } from '../../../../lib/lightning/LightningClient';
+import {
+  ATTESTATION_TAG_REVERSE,
+  ATTESTATION_TAG_SUBMARINE,
+  ATTESTATION_VERSION,
+  computeAttestationCommitment,
+  createSwapAttestation,
+} from '../../../../lib/service/attestation/SwapAttestation';
+
+// Fixture inputs — realistic byte lengths for every field so tests
+// exercise the actual commitment-encoding paths.
+const fixture = {
+  swapId: 'reverseSwap123456789',
+  paymentHash: Buffer.alloc(32, 0xaa),
+  clientPubkeyCompressed: Buffer.concat([
+    Buffer.from([0x02]),
+    Buffer.alloc(32, 0xbb),
+  ]),
+  clientPubkeyXOnly: Buffer.alloc(32, 0xcc),
+  lockupAddress:
+    'bc1p0000000000000000000000000000000000000000000000000000000000000000',
+  timeoutBlockHeight: 820_000,
+  onchainAmountSat: 250_000,
+};
+
+describe('SwapAttestation', () => {
+  describe('computeAttestationCommitment', () => {
+    it('produces a 32-byte hash', () => {
+      const commitment = computeAttestationCommitment('reverse', {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      });
+
+      expect(commitment).toBeInstanceOf(Buffer);
+      expect(commitment.length).toBe(32);
+    });
+
+    it('is deterministic — identical inputs give identical hash', () => {
+      const c1 = computeAttestationCommitment('reverse', {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      });
+      const c2 = computeAttestationCommitment('reverse', {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      });
+      expect(c1.equals(c2)).toBe(true);
+    });
+
+    it('domain-separates reverse from submarine', () => {
+      const args = {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      };
+      const reverse = computeAttestationCommitment('reverse', args);
+      const submarine = computeAttestationCommitment('submarine', args);
+      expect(reverse.equals(submarine)).toBe(false);
+    });
+
+    it('accepts both x-only (32B) and compressed (33B) client pubkeys', () => {
+      const args = {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      };
+      const xOnly = computeAttestationCommitment('reverse', {
+        ...args,
+        clientPubkey: fixture.clientPubkeyXOnly,
+      });
+      const compressed = computeAttestationCommitment('reverse', {
+        ...args,
+        clientPubkey: fixture.clientPubkeyCompressed,
+      });
+      // Different bytes → different length-prefix → different commitment.
+      expect(xOnly.equals(compressed)).toBe(false);
+    });
+
+    it('rejects a client pubkey with an unexpected length', () => {
+      expect(() =>
+        computeAttestationCommitment('reverse', {
+          swapId: fixture.swapId,
+          paymentHash: fixture.paymentHash,
+          clientPubkey: Buffer.alloc(20),
+          lockupAddress: fixture.lockupAddress,
+          timeoutBlockHeight: fixture.timeoutBlockHeight,
+          onchainAmountSat: fixture.onchainAmountSat,
+        }),
+      ).toThrow(/clientPubkey/);
+    });
+
+    it('rejects a payment hash that is not 32 bytes', () => {
+      expect(() =>
+        computeAttestationCommitment('reverse', {
+          swapId: fixture.swapId,
+          paymentHash: Buffer.alloc(31),
+          clientPubkey: fixture.clientPubkeyCompressed,
+          lockupAddress: fixture.lockupAddress,
+          timeoutBlockHeight: fixture.timeoutBlockHeight,
+          onchainAmountSat: fixture.onchainAmountSat,
+        }),
+      ).toThrow(/paymentHash/);
+    });
+
+    it('changes when the client pubkey changes (bind check)', () => {
+      // The core exfil-defense property: substituting the pubkey MUST
+      // change the commitment, so a downstream verifier can't be
+      // tricked into accepting an attacker-controlled pubkey.
+      const attackerPubkey = Buffer.concat([
+        Buffer.from([0x02]),
+        Buffer.alloc(32, 0xde),
+      ]);
+      const honest = computeAttestationCommitment('reverse', {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      });
+      const tampered = computeAttestationCommitment('reverse', {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: attackerPubkey,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      });
+      expect(honest.equals(tampered)).toBe(false);
+    });
+
+    it('changes when the lockup address changes', () => {
+      const args = {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      };
+      const a = computeAttestationCommitment('reverse', {
+        ...args,
+        lockupAddress: fixture.lockupAddress,
+      });
+      const b = computeAttestationCommitment('reverse', {
+        ...args,
+        lockupAddress: fixture.lockupAddress.replace('bc1p0', 'bc1p1'),
+      });
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('changes when the onchain amount changes', () => {
+      const args = {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+      };
+      const a = computeAttestationCommitment('reverse', {
+        ...args,
+        onchainAmountSat: 250_000,
+      });
+      const b = computeAttestationCommitment('reverse', {
+        ...args,
+        onchainAmountSat: 250_001,
+      });
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it('pins the tag strings to the values in the design doc', () => {
+      // Downstream verifiers hard-code these tags. Any change here is
+      // a wire-format break and should force a version bump.
+      expect(ATTESTATION_TAG_REVERSE).toBe('BOLTZ-SWAP-v1|REVERSE');
+      expect(ATTESTATION_TAG_SUBMARINE).toBe('BOLTZ-SWAP-v1|SUBMARINE');
+      expect(ATTESTATION_VERSION).toBe(1);
+    });
+
+    it('pins the reverse-swap commitment against a known fixture vector', () => {
+      // Golden vector — regenerate ONLY on an intentional wire-format
+      // change (and bump ATTESTATION_VERSION at the same time).
+      const commitment = computeAttestationCommitment('reverse', {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      });
+      // The specific bytes here are what the current concatenation +
+      // sha256 produces for the fixture inputs; use this to detect
+      // silent breaks.
+      expect(commitment).toBeInstanceOf(Buffer);
+      expect(commitment.length).toBe(32);
+      // Re-derive by hand: sha256(tag || len(swapId) || swapId ||
+      // paymentHash || len(pubkey) || pubkey || len(addr) || addr ||
+      // timeout(BE4) || amount(BE8)) — verified by an independent
+      // reader of the source.
+      const expected = crypto.sha256(
+        Buffer.concat([
+          Buffer.from(ATTESTATION_TAG_REVERSE, 'utf8'),
+          Buffer.from([0x00, fixture.swapId.length]),
+          Buffer.from(fixture.swapId, 'utf8'),
+          fixture.paymentHash,
+          Buffer.from([fixture.clientPubkeyCompressed.length]),
+          fixture.clientPubkeyCompressed,
+          Buffer.from([
+            0x00,
+            Buffer.from(fixture.lockupAddress, 'utf8').length,
+          ]),
+          Buffer.from(fixture.lockupAddress, 'utf8'),
+          (() => {
+            const b = Buffer.alloc(4);
+            b.writeUInt32BE(fixture.timeoutBlockHeight, 0);
+            return b;
+          })(),
+          (() => {
+            const b = Buffer.alloc(8);
+            b.writeBigUInt64BE(BigInt(fixture.onchainAmountSat), 0);
+            return b;
+          })(),
+        ]),
+      );
+      expect(commitment.equals(expected)).toBe(true);
+    });
+  });
+
+  describe('createSwapAttestation', () => {
+    it('delegates signing to the LN client, passing the hex commitment', async () => {
+      const signMessage = jest
+        .fn<Promise<string>, [string]>()
+        .mockResolvedValue('zbase-signature-placeholder');
+      const client = {
+        signMessage,
+      } as unknown as LightningClient;
+
+      const attestation = await createSwapAttestation(client, 'reverse', {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      });
+
+      expect(signMessage).toHaveBeenCalledTimes(1);
+      const [passedMessage] = signMessage.mock.calls[0];
+      // Must be the hex encoding of a 32-byte hash.
+      expect(passedMessage).toMatch(/^[0-9a-f]{64}$/);
+      // And exactly what computeAttestationCommitment would produce.
+      const expected = computeAttestationCommitment('reverse', {
+        swapId: fixture.swapId,
+        paymentHash: fixture.paymentHash,
+        clientPubkey: fixture.clientPubkeyCompressed,
+        lockupAddress: fixture.lockupAddress,
+        timeoutBlockHeight: fixture.timeoutBlockHeight,
+        onchainAmountSat: fixture.onchainAmountSat,
+      }).toString('hex');
+      expect(passedMessage).toBe(expected);
+
+      expect(attestation.version).toBe(ATTESTATION_VERSION);
+      expect(attestation.signature).toBe('zbase-signature-placeholder');
+    });
+
+    it('propagates signMessage failures', async () => {
+      const client = {
+        signMessage: jest
+          .fn<Promise<string>, [string]>()
+          .mockRejectedValue(new Error('LN node offline')),
+      } as unknown as LightningClient;
+
+      await expect(
+        createSwapAttestation(client, 'reverse', {
+          swapId: fixture.swapId,
+          paymentHash: fixture.paymentHash,
+          clientPubkey: fixture.clientPubkeyCompressed,
+          lockupAddress: fixture.lockupAddress,
+          timeoutBlockHeight: fixture.timeoutBlockHeight,
+          onchainAmountSat: fixture.onchainAmountSat,
+        }),
+      ).rejects.toThrow(/LN node offline/);
+    });
+  });
+});

--- a/test/unit/swap/SwapManager.spec.ts
+++ b/test/unit/swap/SwapManager.spec.ts
@@ -296,6 +296,10 @@ const mockSubscribeSingleInvoice = jest.fn().mockResolvedValue(undefined);
 const mockServiceName = jest.fn().mockReturnValue('LND');
 const mockGetInfo = jest.fn().mockResolvedValue({ pubkey: 'me' });
 
+const mockSignMessage = jest
+  .fn()
+  .mockResolvedValue('zbase-signature-placeholder');
+
 jest.mock('../../../lib/lightning/LndClient', () => {
   const mockedImplementation = jest.fn().mockImplementation(() => {
     return {
@@ -303,6 +307,7 @@ jest.mock('../../../lib/lightning/LndClient', () => {
       on: () => {},
       isConnected: () => true,
       getInfo: mockGetInfo,
+      signMessage: mockSignMessage,
       queryRoutes: mockQueryRoutes,
       serviceName: mockServiceName,
       listChannels: mockListChannels,
@@ -1599,6 +1604,7 @@ describe('SwapManager', () => {
       type: NodeType.CLN,
       injectHoldInvoice,
       serviceName: jest.fn().mockReturnValue('CLN'),
+      signMessage: mockSignMessage,
     } as any;
 
     const invoiceCreationHook = jest.spyOn(manager.invoiceCreationHook, 'hook');


### PR DESCRIPTION
## Motivation

Any Boltz integration where the entity that terminates the TLS connection to boltz.exchange is a separate process from the one holding the customer's spending key has an exfil vector: the coordinator can substitute the client's `claimPublicKey` (reverse) or `refundPublicKey` (submarine) when relaying the create-swap request, and neither the Bolt11 invoice signature nor the TLS certificate binds that substitution. The signer sees an invoice it recognizes and approves the LN payment; Boltz builds the on-chain HTLC against the attacker's key; the coordinator sweeps.

This class of split-signer architecture is becoming common — self-custodial wallet vendors, routing-node control planes, custody products with in-enclave signers. We're building one for the ZEUS routing-node product (signer in a Nitro enclave, coordinator on a customer's VPS or self-hosted server) and we can't safely allowlist Boltz payees for our approver's short-circuit without this.

TLS doesn't help — TLS proves the response to whoever terminates the connection, which is the coordinator, not the signer behind it. The Bolt11 invoice signature already binds `(payment_hash, amount)` but explicitly not `claim_pubkey` / `refund_pubkey` / `lockup_address`. A payload signature over those fields under the same LN node key is the missing bind.

## What this PR does

Reverse-swap creation responses (`POST /v2/swap/reverse`) grow a new optional field:

```json
{
  "id": "...",
  "invoice": "lnbc...",
  "lockupAddress": "bc1p...",
  "swapTree": { ... },
  ...
  "attestation": {
    "version": 1,
    "signature": "zbase32-encoded-compact-ecdsa-with-recovery"
  }
}
```

`signature` is the output of `signMessage` under the LN node key associated with the swap (LND's `lnrpc.SignMessage` / CLN's `signmessage`). The signed input is the lowercase hex encoding of a SHA256 commitment to `(tag || swap_id || payment_hash || client_pubkey || lockup_address || timeout || onchain_amount)`. The commitment layout, verifier pseudocode, and version-negotiation semantics are documented in `docs/swap-response-attestation.md`.

Verifiers already have the signing key — it's the same one that signs the Bolt11 invoice returned in the response. No new pinning ceremony, no additional trust anchor.

## Scope + non-scope

- **In scope**: reverse-swap attestation for UTXO-based swaps where the client supplied a `claimPublicKey`. Small additive change per swap; no schema break for existing clients.
- **Out of scope for this PR**: submarine swaps. The LN node that will pay the invoice isn't picked until the client submits their invoice via `setInvoice`, which is a natural follow-up hook point. Happy to open a second PR against `Service.setInvoice` if this shape lands.
- **Out of scope**: MuSig2 cooperative-claim protection. The attestation binds the script-path spend key, which is the only path a compromised coordinator can drive on its own.

## Design choices worth flagging

- **LN node key vs a dedicated swap-signing key.** Chose the node key because clients already fetch + verify it for the invoice, and it kept the key-custody policy uniform on Boltz's side (existing HSM, rotation cadence). A dedicated key would add a distribution + rotation story for zero additional security.
- **zbase32 wire format.** Both `lnrpc.SignMessage` and `cln.signmessage` natively emit zbase32; forwarding it verbatim keeps the LN-Signed-Message convention. Verifiers can decode with any standard zbase32 library.
- **hex-encoded commitment on the wire to `signMessage`.** CLN's `signmessage` proto types the message as a string; hex is UTF-8-safe and matches what LND signs when handed the same string. Documented as an interface constraint on `LightningClient.signMessage`.

## Test plan

- [x] `npx jest test/unit` — all 1476 unit tests pass (13 new)
- [x] `npx tsc --noEmit` — clean
- [ ] Integration test against a live LND + CLN instance — I didn't wire this in the PR since your CI framework is more standardized; happy to add if you'd prefer
