### PR TITLE
refactor: WebHook hardening

### DIFF
--- a/boltzr/src/webhook/caller.rs
+++ b/boltzr/src/webhook/caller.rs
@@ -224,6 +224,13 @@ where
         let client = reqwest::Client::builder()
             .connect_timeout(self.request_timeout)
             .timeout(self.request_timeout)
+            .dns_resolver(Arc::new(super::resolver::SsrfGuardResolver::new(
+                self.allow_insecure,
+            )))
+            .redirect(super::resolver::build_redirect_policy(
+                self.allow_insecure,
+                self.block_list.clone(),
+            ))
             .build()
             .unwrap();
 
@@ -433,23 +440,7 @@ pub async fn check_ip(url: &str, allow_insecure: bool) -> Result<()> {
         .collect(),
     };
 
-    if ips.iter().any(|ip| match ip {
-        IpAddr::V4(ip) => {
-            ip.is_loopback()
-                || ip.is_link_local()
-                || ip.is_multicast()
-                || ip.is_broadcast()
-                || ip.is_private()
-                || ip.is_unspecified()
-        }
-        IpAddr::V6(ip) => {
-            ip.is_loopback()
-                || ip.is_multicast()
-                || ip.is_unicast_link_local()
-                || ip.is_unique_local()
-                || ip.is_unspecified()
-        }
-    }) {
+    if ips.iter().any(super::resolver::is_blocked_ip) {
         return Err(UrlError::InvalidHost.into());
     }
 
@@ -464,7 +455,7 @@ mod caller_test {
     use crate::webhook::types::{WebHookCallData, WebHookCallParams, WebHookEvent};
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
-    use axum::routing::post;
+    use axum::routing::{any, post};
     use axum::{Extension, Json, Router};
     use mockall::{mock, predicate};
     use rstest::rstest;
@@ -1161,9 +1152,11 @@ mod caller_test {
 
     #[rstest]
     #[case("https://8.8.8.8", true)] // Valid public IP v4
+    #[case("https://[::ffff:8.8.8.8]", true)] // Valid public IPv4-mapped IPv6
     #[case("https://[2001:4860:4860::8888]", true)] // Valid public IP v6
     #[case("https://bol.tz", true)] // Valid public domain
     #[case("https://127.0.0.1", false)] // Loopback v4
+    #[case("https://[::ffff:127.0.0.1]", false)] // Loopback IPv4-mapped IPv6
     #[case("https://192.168.1.1", false)] // Private v4
     #[case("https://10.0.0.1", false)] // Private v4
     #[case("https://172.16.0.1", false)] // Private v4
@@ -1191,6 +1184,203 @@ mod caller_test {
     async fn test_check_ip_allow_insecure(#[case] url: &str, #[case] should_pass: bool) {
         let result = check_ip(url, true).await;
         assert_eq!(result.is_ok(), should_pass, "err: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_call_webhook_follows_redirect_when_insecure() {
+        let mut web_hook_helper = make_mock_hook_state();
+        web_hook_helper
+            .expect_should_be_skipped()
+            .returning(|_, _| false);
+
+        let id = "redirect_follow";
+        let target_port = 10020;
+        let redirect_port = 10021;
+
+        let hook = WebHook {
+            id: id.to_string(),
+            url: format!("http://127.0.0.1:{redirect_port}"),
+            ..Default::default()
+        };
+
+        web_hook_helper
+            .expect_set_state()
+            .with(predicate::eq(hook.clone()), predicate::eq(WebHookState::Ok))
+            .returning(|_, _| Ok(()));
+
+        let caller = Caller::new(
+            CancellationToken::new(),
+            "test".to_string(),
+            Config {
+                max_retries: Some(5),
+                retry_interval: Some(60),
+                request_timeout: Some(10),
+                block_list: None,
+            },
+            true,
+            web_hook_helper,
+        );
+
+        let (target_cancel, received_calls, _headers) = start_server(target_port).await;
+        let redirect_cancel =
+            start_redirect_server(redirect_port, format!("http://127.0.0.1:{target_port}/")).await;
+
+        let data = WebHookCallData::SwapUpdate(SwapUpdateCallData {
+            id: id.to_string(),
+            status: "some.update".to_string(),
+        });
+
+        let res = caller.call_webhook(hook, data.clone()).await.unwrap();
+        assert_eq!(res, CallResult::Success);
+
+        // The 307 redirect preserves the POST body, so the target sees the call.
+        assert_eq!(received_calls.lock().unwrap().len(), 1);
+        assert_eq!(
+            received_calls.lock().unwrap()[0],
+            WebHookCallParams {
+                event: WebHookEvent::SwapUpdate,
+                data,
+            }
+        );
+
+        target_cancel.cancel();
+        redirect_cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_client_blocks_redirect_to_private_ip() {
+        let redirect_port = 10023;
+
+        // HTTPS target so the scheme check passes and the private literal-IP
+        // branch of the policy is what blocks the hop.
+        let redirect_cancel =
+            start_redirect_server(redirect_port, "https://10.0.0.1/".to_string()).await;
+
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(5))
+            .dns_resolver(Arc::new(crate::webhook::resolver::SsrfGuardResolver::new(
+                false,
+            )))
+            .redirect(crate::webhook::resolver::build_redirect_policy(
+                false,
+                vec![],
+            ))
+            .build()
+            .unwrap();
+
+        let res = client
+            .post(format!("http://127.0.0.1:{redirect_port}/"))
+            .json(&WebHookCallParams {
+                event: WebHookEvent::SwapUpdate,
+                data: WebHookCallData::SwapUpdate(SwapUpdateCallData {
+                    id: "blocked".to_string(),
+                    status: "some.update".to_string(),
+                }),
+            })
+            .send()
+            .await;
+
+        let err = res.expect_err("redirect to a private IP must be blocked");
+        assert!(
+            err.is_redirect(),
+            "expected a redirect-policy error (initial connect succeeded, redirect blocked), got: {err}"
+        );
+
+        redirect_cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_client_blocks_redirect_to_private_hostname() {
+        let target_port = 10024;
+        let redirect_port = 10025;
+
+        let (target_cancel, received_calls, _headers) = start_server(target_port).await;
+        // HTTPS target so the scheme check passes and the resolver (which handles
+        // hostname hops) is what blocks localhost resolving to a loopback address.
+        let redirect_cancel =
+            start_redirect_server(redirect_port, format!("https://localhost:{target_port}/")).await;
+
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(5))
+            .dns_resolver(Arc::new(crate::webhook::resolver::SsrfGuardResolver::new(
+                false,
+            )))
+            .redirect(crate::webhook::resolver::build_redirect_policy(
+                false,
+                vec![],
+            ))
+            .build()
+            .unwrap();
+
+        let res = client
+            .post(format!("http://127.0.0.1:{redirect_port}/"))
+            .json(&WebHookCallParams {
+                event: WebHookEvent::SwapUpdate,
+                data: WebHookCallData::SwapUpdate(SwapUpdateCallData {
+                    id: "blocked".to_string(),
+                    status: "some.update".to_string(),
+                }),
+            })
+            .send()
+            .await;
+
+        let err =
+            res.expect_err("redirect to a hostname resolving to a private IP must be blocked");
+
+        let mut source: Option<&(dyn Error + 'static)> = Some(&err);
+        let mut blocked_by_resolver = false;
+        while let Some(e) = source {
+            if matches!(e.downcast_ref::<UrlError>(), Some(UrlError::InvalidHost)) {
+                blocked_by_resolver = true;
+                break;
+            }
+            source = e.source();
+        }
+        assert!(
+            blocked_by_resolver,
+            "expected the resolver's InvalidHost block, got: {err:?}"
+        );
+
+        assert_eq!(
+            received_calls.lock().unwrap().len(),
+            0,
+            "the loopback redirect target must never be reached"
+        );
+
+        target_cancel.cancel();
+        redirect_cancel.cancel();
+    }
+
+    async fn start_redirect_server(port: u16, location: String) -> CancellationToken {
+        async fn redirect_handler(
+            Extension(location): Extension<Arc<String>>,
+        ) -> impl IntoResponse {
+            axum::response::Redirect::temporary(location.as_str())
+        }
+
+        let router = Router::new()
+            .route("/", any(redirect_handler))
+            .layer(Extension(Arc::new(location)));
+
+        let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}"))
+            .await
+            .unwrap();
+
+        let cancellation_token = CancellationToken::new();
+        let token = cancellation_token.clone();
+        tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move {
+                    token.cancelled().await;
+                })
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        cancellation_token
     }
 
     async fn start_server(

--- a/boltzr/src/webhook/mod.rs
+++ b/boltzr/src/webhook/mod.rs
@@ -1,5 +1,6 @@
 pub mod caller;
 pub mod invoice_caller;
+mod resolver;
 pub mod status_caller;
 mod types;
 

--- a/boltzr/src/webhook/resolver.rs
+++ b/boltzr/src/webhook/resolver.rs
@@ -1,0 +1,213 @@
+use std::error::Error;
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+
+use reqwest::Url;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+use reqwest::redirect::Policy;
+
+use crate::webhook::caller::UrlError;
+
+/// Maximum number of redirects to follow, matching reqwest's default limit
+const MAX_REDIRECTS: usize = 10;
+
+pub(crate) fn is_blocked_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            let octets = ip.octets();
+            // Ipv4Addr::is_shared and is_reserved are nightly-only
+            let is_shared = octets[0] == 100 && (octets[1] & 0b1100_0000) == 0b0100_0000;
+            let is_reserved = (octets[0] & 0b1111_0000) == 0b1111_0000;
+
+            ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_multicast()
+                || ip.is_broadcast()
+                || ip.is_private()
+                || ip.is_unspecified()
+                || is_shared
+                || is_reserved
+        }
+        IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                return is_blocked_ip(&IpAddr::V4(mapped));
+            }
+
+            ip.is_loopback()
+                || ip.is_multicast()
+                || ip.is_unicast_link_local()
+                || ip.is_unique_local()
+                || ip.is_unspecified()
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TooManyRedirects;
+
+impl fmt::Display for TooManyRedirects {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("too many redirects")
+    }
+}
+
+impl Error for TooManyRedirects {}
+
+pub(crate) struct SsrfGuardResolver {
+    allow_insecure: bool,
+}
+
+impl SsrfGuardResolver {
+    pub(crate) fn new(allow_insecure: bool) -> Self {
+        Self { allow_insecure }
+    }
+}
+
+impl Resolve for SsrfGuardResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let allow_insecure = self.allow_insecure;
+        let host = name.as_str().to_owned();
+
+        Box::pin(async move {
+            let addrs: Vec<SocketAddr> = tokio::net::lookup_host(format!("{host}:0"))
+                .await?
+                .collect();
+
+            if !allow_insecure && addrs.iter().any(|addr| is_blocked_ip(&addr.ip())) {
+                return Err(
+                    Box::new(UrlError::InvalidHost) as Box<dyn std::error::Error + Send + Sync>
+                );
+            }
+
+            Ok(Box::new(addrs.into_iter()) as Addrs)
+        })
+    }
+}
+
+pub(crate) fn build_redirect_policy(allow_insecure: bool, block_list: Vec<String>) -> Policy {
+    Policy::custom(move |attempt| {
+        if is_blocked_redirect(attempt.url(), allow_insecure, &block_list) {
+            attempt.error(UrlError::Blocked)
+        } else if attempt.previous().len() > MAX_REDIRECTS {
+            attempt.error(TooManyRedirects)
+        } else {
+            attempt.follow()
+        }
+    })
+}
+
+fn is_blocked_redirect(url: &Url, allow_insecure: bool, block_list: &[String]) -> bool {
+    if let Some(host) = url.host_str()
+        && block_list.iter().any(|blocked| host.contains(blocked))
+    {
+        return true;
+    }
+
+    if allow_insecure {
+        return false;
+    }
+
+    if url.scheme() != "https" {
+        return true;
+    }
+
+    matches!(host_as_ip(url), Some(ip) if is_blocked_ip(&ip))
+}
+
+fn host_as_ip(url: &Url) -> Option<IpAddr> {
+    let host = url.host_str()?;
+    let host = host.strip_prefix('[').unwrap_or(host);
+    let host = host.strip_suffix(']').unwrap_or(host);
+    IpAddr::from_str(host).ok()
+}
+
+#[cfg(test)]
+mod resolver_test {
+    use super::*;
+    use reqwest::dns::Name;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("8.8.8.8", false)]
+    #[case("1.1.1.1", false)]
+    #[case("127.0.0.1", true)]
+    #[case("10.0.0.1", true)]
+    #[case("192.168.1.1", true)]
+    #[case("172.16.0.1", true)]
+    #[case("169.254.1.1", true)]
+    #[case("224.0.0.1", true)]
+    #[case("255.255.255.255", true)]
+    #[case("0.0.0.0", true)]
+    #[case("100.64.0.1", true)]
+    #[case("100.127.255.255", true)]
+    #[case("100.63.255.255", false)]
+    #[case("100.128.0.0", false)]
+    #[case("240.0.0.1", true)]
+    #[case("250.1.2.3", true)]
+    #[case("239.255.255.255", true)]
+    #[case("2001:4860:4860::8888", false)]
+    #[case("::1", true)]
+    #[case("fe80::1", true)]
+    #[case("ff00::1", true)]
+    #[case("fc00::1", true)]
+    #[case("::", true)]
+    #[case("::ffff:8.8.8.8", false)]
+    #[case("::ffff:127.0.0.1", true)]
+    #[case("::ffff:10.0.0.1", true)]
+    #[case("::ffff:169.254.1.1", true)]
+    #[case("::ffff:100.64.0.1", true)]
+    #[case("::ffff:240.0.0.1", true)]
+    fn test_is_blocked_ip(#[case] ip: &str, #[case] blocked: bool) {
+        assert_eq!(is_blocked_ip(&IpAddr::from_str(ip).unwrap()), blocked);
+    }
+
+    #[rstest]
+    // configured block list applies to every hop, even in insecure mode
+    #[case("https://api.bol.tz/v2", false, Some("bol.tz"), true)]
+    #[case("https://api.bol.tz/v2", true, Some("bol.tz"), true)]
+    #[case("https://example.com/", false, Some("bol.tz"), false)]
+    // scheme downgrade to plain HTTP is blocked unless insecure
+    #[case("http://example.com/", false, None, true)]
+    #[case("http://example.com/", true, None, false)]
+    #[case("https://10.0.0.1/path", false, None, true)] // literal private IPv4
+    #[case("https://127.0.0.1/", false, None, true)] // loopback IPv4
+    #[case("https://169.254.169.254/", false, None, true)] // link-local (metadata)
+    #[case("https://[::1]/", false, None, true)] // loopback IPv6
+    #[case("https://[fc00::1]/", false, None, true)] // unique-local IPv6
+    #[case("https://[::ffff:127.0.0.1]/", false, None, true)] // IPv4-mapped loopback
+    #[case("https://[::ffff:10.0.0.1]/", false, None, true)] // IPv4-mapped private
+    #[case("https://8.8.8.8/", false, None, false)] // literal public IPv4
+    #[case("https://[::ffff:8.8.8.8]/", false, None, false)] // IPv4-mapped public
+    #[case("https://[2001:4860:4860::8888]/", false, None, false)] // literal public IPv6
+    #[case("https://example.com/", false, None, false)] // hostname -> deferred to resolver
+    #[case("https://10.0.0.1/", true, None, false)] // allow_insecure bypasses the check
+    #[case("http://127.0.0.1/", true, None, false)] // allow_insecure bypasses the check
+    fn test_is_blocked_redirect(
+        #[case] url: &str,
+        #[case] allow_insecure: bool,
+        #[case] block: Option<&str>,
+        #[case] blocked: bool,
+    ) {
+        let url = Url::parse(url).unwrap();
+        let block_list: Vec<String> = block.into_iter().map(String::from).collect();
+        assert_eq!(
+            is_blocked_redirect(&url, allow_insecure, &block_list),
+            blocked
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolver_blocks_private_hostname() {
+        let resolver = SsrfGuardResolver::new(false);
+        let res = resolver.resolve(Name::from_str("localhost").unwrap()).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_resolver_allows_private_when_insecure() {
+        let resolver = SsrfGuardResolver::new(true);
+        let res = resolver.resolve(Name::from_str("localhost").unwrap()).await;
+        assert!(res.is_ok());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook requests now follow redirects more safely, preventing redirects to unsafe destinations and limiting redirect chain length.
  * Improved protection against requests resolving to private/local or other disallowed network ranges.
  * More consistent blocking behavior for IPv4-mapped IPv6 addresses.

* **Tests**
  * Expanded coverage for IP-blocking edge cases and redirect behavior, including simulated redirect scenarios and expected failure conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->