### PR TITLE
fix: confirm vHTLC refunds via RefundWatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a121ccf1177a09084bd6ce97c52119919aac08ea3649967958eae41beceebf"
 dependencies = [
  "base58ck",
+ "base64 0.21.7",
  "bech32 0.11.1",
  "bitcoin-io",
  "bitcoin-units",

--- a/boltzr-cli/Cargo.toml
+++ b/boltzr-cli/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 alloy = { workspace = true }
-bitcoin = { workspace = true }
+bitcoin = { workspace = true, features = ["base64"] }
 bitcoin_hashes = { workspace = true }
 boltz-core = { path = "../boltz-core" }
 boltz-evm = { path = "../boltz-evm" }

--- a/boltzr-cli/src/ark/decode.rs
+++ b/boltzr-cli/src/ark/decode.rs
@@ -1,0 +1,442 @@
+use anyhow::{Result, anyhow};
+use bitcoin::Script;
+use bitcoin::opcodes::all as opcodes;
+use bitcoin::psbt::Psbt;
+use bitcoin::script::Instruction;
+use serde::Serialize;
+use std::str::FromStr;
+
+/// Key data of the proprietary PSBT input field Ark uses to embed the VTXO script tree
+const ARK_TAPTREE_KEY: &[u8] = b"taptree";
+
+const P2A_SCRIPT: &[u8] = &[0x51, 0x02, 0x4e, 0x73];
+
+#[derive(Serialize)]
+pub struct DecodedTransaction {
+    txid: String,
+    version: i32,
+    locktime: u32,
+    inputs: Vec<DecodedInput>,
+    outputs: Vec<DecodedOutput>,
+}
+
+#[derive(Serialize)]
+struct DecodedInput {
+    txid: String,
+    vout: u32,
+    sequence: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    witness_utxo: Option<WitnessUtxo>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tap_leaf_scripts: Vec<TapLeafScript>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tap_script_sigs: Vec<TapScriptSig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    taptree: Option<Vec<TapTreeLeaf>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    taptree_parse_error: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    unknown_fields: Vec<UnknownField>,
+}
+
+#[derive(Serialize)]
+struct WitnessUtxo {
+    amount: u64,
+    script: String,
+}
+
+#[derive(Serialize)]
+struct TapLeafScript {
+    leaf_version: u8,
+    internal_key: String,
+    merkle_path: Vec<String>,
+    script_asm: String,
+    script_hex: String,
+    looks_like: &'static str,
+}
+
+#[derive(Serialize)]
+struct TapScriptSig {
+    pubkey: String,
+    leaf_hash: String,
+    signature: String,
+}
+
+#[derive(Serialize)]
+struct TapTreeLeaf {
+    depth: u8,
+    leaf_version: u8,
+    script_asm: String,
+    script_hex: String,
+    looks_like: &'static str,
+}
+
+#[derive(Serialize)]
+struct UnknownField {
+    key_type: String,
+    key: String,
+    value: String,
+}
+
+#[derive(Serialize)]
+struct DecodedOutput {
+    amount: u64,
+    script_asm: String,
+    script_hex: String,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tap_tree: Option<Vec<TapTreeLeaf>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    unknown_fields: Vec<UnknownField>,
+}
+
+/// Decodes an Ark virtual transaction from its base64 encoded PSBT
+pub fn decode_transaction(transaction: &str) -> Result<DecodedTransaction> {
+    let psbt = Psbt::from_str(transaction.trim())?;
+    let tx = &psbt.unsigned_tx;
+
+    let inputs = tx
+        .input
+        .iter()
+        .zip(&psbt.inputs)
+        .map(|(tx_in, input)| {
+            let mut taptree = None;
+            let mut taptree_parse_error = None;
+            let mut unknown_fields = Vec::new();
+            for (key, value) in &input.unknown {
+                if key.key == ARK_TAPTREE_KEY {
+                    match parse_ark_taptree(value) {
+                        Ok(leaves) => {
+                            taptree = Some(leaves);
+                            continue;
+                        }
+                        Err(err) => taptree_parse_error = Some(err.to_string()),
+                    }
+                }
+                unknown_fields.push(unknown_field(key, value));
+            }
+
+            DecodedInput {
+                txid: tx_in.previous_output.txid.to_string(),
+                vout: tx_in.previous_output.vout,
+                sequence: format!("{:#x}", tx_in.sequence.0),
+                witness_utxo: input.witness_utxo.as_ref().map(|utxo| WitnessUtxo {
+                    amount: utxo.value.to_sat(),
+                    script: utxo.script_pubkey.to_hex_string(),
+                }),
+                tap_leaf_scripts: input
+                    .tap_scripts
+                    .iter()
+                    .map(|(control_block, (script, leaf_version))| TapLeafScript {
+                        leaf_version: leaf_version.to_consensus(),
+                        internal_key: control_block.internal_key.to_string(),
+                        merkle_path: control_block
+                            .merkle_branch
+                            .iter()
+                            .map(|hash| hash.to_string())
+                            .collect(),
+                        script_asm: script.to_asm_string(),
+                        script_hex: script.to_hex_string(),
+                        looks_like: classify_leaf(script),
+                    })
+                    .collect(),
+                tap_script_sigs: input
+                    .tap_script_sigs
+                    .iter()
+                    .map(|((pubkey, leaf_hash), signature)| TapScriptSig {
+                        pubkey: pubkey.to_string(),
+                        leaf_hash: leaf_hash.to_string(),
+                        signature: alloy::hex::encode(signature.to_vec()),
+                    })
+                    .collect(),
+                taptree,
+                taptree_parse_error,
+                unknown_fields,
+            }
+        })
+        .collect();
+
+    let outputs = tx
+        .output
+        .iter()
+        .zip(&psbt.outputs)
+        .map(|(tx_out, output)| {
+            let script = &tx_out.script_pubkey;
+            DecodedOutput {
+                amount: tx_out.value.to_sat(),
+                script_asm: script.to_asm_string(),
+                script_hex: script.to_hex_string(),
+                kind: if script.as_bytes() == P2A_SCRIPT {
+                    "p2a ephemeral anchor"
+                } else if script.is_p2tr() {
+                    "p2tr"
+                } else {
+                    "unknown"
+                },
+                tap_tree: output.tap_tree.as_ref().map(|tree| {
+                    tree.node_info()
+                        .leaf_nodes()
+                        .filter_map(|node| {
+                            node.leaf().as_script().map(|(script, leaf_version)| {
+                                tap_tree_leaf(
+                                    node.merkle_branch().len() as u8,
+                                    leaf_version.to_consensus(),
+                                    script,
+                                )
+                            })
+                        })
+                        .collect()
+                }),
+                unknown_fields: output
+                    .unknown
+                    .iter()
+                    .map(|(key, value)| unknown_field(key, value))
+                    .collect(),
+            }
+        })
+        .collect();
+
+    Ok(DecodedTransaction {
+        txid: tx.compute_txid().to_string(),
+        version: tx.version.0,
+        locktime: tx.lock_time.to_consensus_u32(),
+        inputs,
+        outputs,
+    })
+}
+
+fn unknown_field(key: &bitcoin::psbt::raw::Key, value: &[u8]) -> UnknownField {
+    UnknownField {
+        key_type: format!("{:#x}", key.type_value),
+        key: alloy::hex::encode(&key.key),
+        value: alloy::hex::encode(value),
+    }
+}
+
+fn tap_tree_leaf(depth: u8, leaf_version: u8, script: &Script) -> TapTreeLeaf {
+    TapTreeLeaf {
+        depth,
+        leaf_version,
+        script_asm: script.to_asm_string(),
+        script_hex: script.to_hex_string(),
+        looks_like: classify_leaf(script),
+    }
+}
+
+/// Parses Ark's proprietary "taptree" field: concatenated leaves of
+/// depth (1 byte) | leaf version (1 byte) | script length (compact size) | script
+fn parse_ark_taptree(value: &[u8]) -> Result<Vec<TapTreeLeaf>> {
+    let mut leaves = Vec::new();
+    let mut offset = 0;
+
+    while offset < value.len() {
+        if value.len() - offset < 3 {
+            return Err(anyhow!("truncated taptree leaf header"));
+        }
+
+        let depth = value[offset];
+        let leaf_version = value[offset + 1];
+        offset += 2;
+
+        let (length, length_size) = read_compact_size(&value[offset..])?;
+        offset += length_size;
+
+        let script = value
+            .get(offset..offset + length)
+            .ok_or_else(|| anyhow!("truncated taptree leaf script"))?;
+        offset += length;
+
+        leaves.push(tap_tree_leaf(
+            depth,
+            leaf_version,
+            Script::from_bytes(script),
+        ));
+    }
+
+    Ok(leaves)
+}
+
+fn read_compact_size(data: &[u8]) -> Result<(usize, usize)> {
+    let err = || anyhow!("truncated compact size");
+    match *data.first().ok_or_else(err)? {
+        0xfd => {
+            let bytes: [u8; 2] = data.get(1..3).ok_or_else(err)?.try_into()?;
+            Ok((u16::from_le_bytes(bytes) as usize, 3))
+        }
+        0xfe => {
+            let bytes: [u8; 4] = data.get(1..5).ok_or_else(err)?.try_into()?;
+            Ok((u32::from_le_bytes(bytes) as usize, 5))
+        }
+        0xff => Err(anyhow!("taptree leaf script too large")),
+        length => Ok((length as usize, 1)),
+    }
+}
+
+fn classify_leaf(script: &Script) -> &'static str {
+    let mut has_hash = false;
+    let mut has_csv = false;
+    let mut has_cltv = false;
+    let mut sig_ops = 0;
+
+    for instruction in script.instructions().flatten() {
+        if let Instruction::Op(op) = instruction {
+            match op {
+                opcodes::OP_HASH160 | opcodes::OP_SHA256 | opcodes::OP_RIPEMD160 => has_hash = true,
+                opcodes::OP_CSV => has_csv = true,
+                opcodes::OP_CLTV => has_cltv = true,
+                opcodes::OP_CHECKSIG | opcodes::OP_CHECKSIGVERIFY | opcodes::OP_CHECKSIGADD => {
+                    sig_ops += 1
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if has_hash {
+        "claim (preimage + signature)"
+    } else if has_csv {
+        "unilateral (CSV delay)"
+    } else if has_cltv {
+        "refund (CLTV timeout)"
+    } else if sig_ops >= 2 {
+        "cooperative (multiple signatures)"
+    } else {
+        "unknown"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VHTLC_LOCKUP_TX: &str = "cHNidP8BAGsDAAAAAUcTLvCg9+Wn6t8YYFSYMoFhuvnvPKtCfAGcqAecWKHMAAAAAAD/////AnUeAAAAAAAAIlEgF9f2hdVeNVKJSS8sW5eN8T46WfJjk6KKk6bBHmMlDrAAAAAAAAAAAARRAk5zAAAAAAABASt1HgAAAAAAACJRIFVCQjt4l6tugmTSRnr0eT+AvvqzTC3YEdxHCPUM+/67QRQebYkyfEpNlSckwvINxnrOERkzL++NdXTKrqO5jYWr9QMAr0aGUVLK4yQtq+VM6552nxK7UVfssxvwVUauzjxPQKznOsp/oO/PVfTQ4Hbc3p+m3YSI21ktrBD6cqAKmumJZhKhdeByhgGbPuYx1vfplQBZixz9h6Xut0otkQJUhypBFPBrY67ZZDw6cm85c8O/uvKsGlvtYYlm4U8R3hl0aIWgAwCvRoZRUsrjJC2r5UzrnnafErtRV+yzG/BVRq7OPE9A15qc89NLHBZBG+zydryvkn1vqyfKONewNYmNmHMTTTQ/+QJUns1+GzCSkqkZCW1mqwqFicABj0apRi/8ljX3wkEUMBB4gI5Pe8Da3+KeNLHfjq8BCO8GsXIidAdevBB6EnoDAK9GhlFSyuMkLavlTOuedp8Su1FX7LMb8FVGrs48T0CeVTTz1lNDu0RIA5chHUyLfyqU2/FEQZdDWTCOCigrvpvUqgKWiwGeJVh4nd0kxlbSrqrTFi4/K8tzDOlw+S5DQhXBUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsAQ+zdj4ChlPS28dM/F1RzZZNxo1lbSHUYYUNF5w6iyr2cgHm2JMnxKTZUnJMLyDcZ6zhEZMy/vjXV0yq6juY2Fq/WtIPBrY67ZZDw6cm85c8O/uvKsGlvtYYlm4U8R3hl0aIWgrSAwEHiAjk97wNrf4p40sd+OrwEI7waxciJ0B168EHoSeqzACN50YXB0cmVllAHAKAMIAECydSDfyuxVjH54zz44uJi6ikPPtXJyZrrjLFxbOusyxViqC6wBwGYgHm2JMnxKTZUnJMLyDcZ6zhEZMy/vjXV0yq6juY2Fq/WtIPBrY67ZZDw6cm85c8O/uvKsGlvtYYlm4U8R3hl0aIWgrSAwEHiAjk97wNrf4p40sd+OrwEI7waxciJ0B168EHoSeqwAAAA=";
+
+    #[test]
+    fn test_decode_transaction() {
+        let decoded = decode_transaction(VHTLC_LOCKUP_TX).unwrap();
+
+        assert_eq!(
+            decoded.txid,
+            "7e385a2b0ebb6866bcb6ed77da14045f3028cf271a670017f7b0fb6d32a56113"
+        );
+        assert_eq!(decoded.version, 3);
+        assert_eq!(decoded.locktime, 0);
+
+        assert_eq!(decoded.inputs.len(), 1);
+        let input = &decoded.inputs[0];
+        assert_eq!(
+            input.txid,
+            "cca1589c07a89c017c42ab3ceff9ba61813298546018dfeaa7e5f7a0f02e1347"
+        );
+        assert_eq!(input.vout, 0);
+        assert_eq!(input.witness_utxo.as_ref().unwrap().amount, 7797);
+        assert_eq!(input.tap_leaf_scripts.len(), 1);
+        assert_eq!(
+            input.tap_leaf_scripts[0].looks_like,
+            "cooperative (multiple signatures)"
+        );
+        assert_eq!(input.tap_script_sigs.len(), 3);
+
+        let taptree = input.taptree.as_ref().unwrap();
+        assert_eq!(taptree.len(), 2);
+        assert_eq!(taptree[0].looks_like, "unilateral (CSV delay)");
+        assert_eq!(taptree[1].looks_like, "cooperative (multiple signatures)");
+        assert!(input.unknown_fields.is_empty());
+
+        assert_eq!(decoded.outputs.len(), 2);
+        assert_eq!(decoded.outputs[0].amount, 7797);
+        assert_eq!(decoded.outputs[0].kind, "p2tr");
+        assert_eq!(decoded.outputs[1].amount, 0);
+        assert_eq!(decoded.outputs[1].kind, "p2a ephemeral anchor");
+    }
+
+    #[test]
+    fn test_decode_transaction_invalid_base64() {
+        assert!(decode_transaction("not a psbt").is_err());
+    }
+
+    #[test]
+    fn test_read_compact_size_single_byte() {
+        assert_eq!(read_compact_size(&[0x00]).unwrap(), (0, 1));
+        assert_eq!(read_compact_size(&[0xfc]).unwrap(), (0xfc, 1));
+    }
+
+    #[test]
+    fn test_read_compact_size_u16() {
+        assert_eq!(read_compact_size(&[0xfd, 0x34, 0x12]).unwrap(), (0x1234, 3));
+    }
+
+    #[test]
+    fn test_read_compact_size_u32() {
+        assert_eq!(
+            read_compact_size(&[0xfe, 0x78, 0x56, 0x34, 0x12]).unwrap(),
+            (0x1234_5678, 5)
+        );
+    }
+
+    #[test]
+    fn test_read_compact_size_u64_rejected() {
+        assert!(read_compact_size(&[0xff, 0, 0, 0, 0, 0, 0, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn test_read_compact_size_truncated() {
+        assert!(read_compact_size(&[]).is_err());
+        assert!(read_compact_size(&[0xfd, 0x01]).is_err());
+        assert!(read_compact_size(&[0xfe, 0x01, 0x02, 0x03]).is_err());
+    }
+
+    #[test]
+    fn test_parse_ark_taptree_empty_script() {
+        let leaves = parse_ark_taptree(&[1, 0xc0, 0]).unwrap();
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].depth, 1);
+        assert_eq!(leaves[0].leaf_version, 0xc0);
+        assert_eq!(leaves[0].script_hex, "");
+        assert_eq!(leaves[0].looks_like, "unknown");
+    }
+
+    #[test]
+    fn test_parse_ark_taptree_truncated_header() {
+        assert!(parse_ark_taptree(&[1]).is_err());
+        assert!(parse_ark_taptree(&[1, 0xc0]).is_err());
+    }
+
+    #[test]
+    fn test_parse_ark_taptree_truncated_script() {
+        assert!(parse_ark_taptree(&[1, 0xc0, 2, 0x51]).is_err());
+    }
+
+    #[test]
+    fn test_classify_leaf_empty_script() {
+        assert_eq!(classify_leaf(Script::from_bytes(&[])), "unknown");
+    }
+
+    #[test]
+    fn test_classify_leaf_csv_takes_precedence_over_cltv() {
+        let script = [
+            opcodes::OP_CLTV.to_u8(),
+            opcodes::OP_CSV.to_u8(),
+            opcodes::OP_CHECKSIG.to_u8(),
+        ];
+        assert_eq!(
+            classify_leaf(Script::from_bytes(&script)),
+            "unilateral (CSV delay)"
+        );
+    }
+
+    #[test]
+    fn test_classify_leaf_hash_takes_precedence_over_timelocks() {
+        let script = [
+            opcodes::OP_SHA256.to_u8(),
+            opcodes::OP_CSV.to_u8(),
+            opcodes::OP_CLTV.to_u8(),
+            opcodes::OP_CHECKSIG.to_u8(),
+        ];
+        assert_eq!(
+            classify_leaf(Script::from_bytes(&script)),
+            "claim (preimage + signature)"
+        );
+    }
+}

--- a/boltzr-cli/src/ark/mod.rs
+++ b/boltzr-cli/src/ark/mod.rs
@@ -6,6 +6,8 @@ use tonic::metadata::MetadataValue;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 
+pub mod decode;
+
 #[allow(dead_code)]
 #[allow(clippy::enum_variant_names)]
 mod ark_rpc {

--- a/boltzr-cli/src/main.rs
+++ b/boltzr-cli/src/main.rs
@@ -260,6 +260,11 @@ enum ArkCommands {
         #[arg(long, value_parser = parsers::parse_bitcoin_outpoint)]
         outpoint: Option<bitcoin::OutPoint>,
     },
+    #[command(about = "Decodes an ARK virtual transaction")]
+    Decode {
+        #[arg(help = "Base64 encoded PSBT or path to a file containing it")]
+        transaction: String,
+    },
 }
 
 #[derive(Clone, Subcommand)]
@@ -813,6 +818,14 @@ async fn run_command(cli: Cli) -> Result<()> {
                     )
                     .await?;
                 println!("{}", response);
+            }
+            ArkCommands::Decode { transaction } => {
+                let transaction = if std::path::Path::new(transaction).is_file() {
+                    std::fs::read_to_string(transaction)?
+                } else {
+                    transaction.clone()
+                };
+                print_pretty(&ark::decode::decode_transaction(&transaction)?)?;
             }
         },
         Commands::Tools { ref command } => match command {

--- a/boltzr/src/chain/mrh_watcher.rs
+++ b/boltzr/src/chain/mrh_watcher.rs
@@ -38,7 +38,7 @@ impl MrhWatcher {
         // Spawn one task for each currency and collect their handles
         let mut handles = Vec::new();
 
-        for (_, currency) in currencies.iter() {
+        for currency in currencies.values() {
             if let Some(chain_client) = currency.chain.as_ref() {
                 if chain_client.symbol() != elements_client::SYMBOL {
                     continue;

--- a/boltzr/src/notifications/mattermost.rs
+++ b/boltzr/src/notifications/mattermost.rs
@@ -376,7 +376,7 @@ where
     }
 
     fn format_auth_header(&self) -> String {
-        format!("{} {}", HEADER_BEARER, &self.token)
+        format!("{} {}", HEADER_BEARER, self.token)
     }
 
     fn find_channel<'a>(name: &str, channels: &'a [Channel]) -> Option<&'a Channel> {

--- a/boltzr/src/swap/utxo_nursery.rs
+++ b/boltzr/src/swap/utxo_nursery.rs
@@ -60,7 +60,7 @@ impl UtxoNursery {
     pub async fn start(self) {
         let mut handles = Vec::new();
 
-        for (_, currency) in self.currencies.iter() {
+        for currency in self.currencies.values() {
             if let Some(chain_client) = currency.chain.as_ref() {
                 let nursery = self.clone();
                 let chain_client = chain_client.clone();

--- a/lib/db/repositories/RefundTransactionRepository.ts
+++ b/lib/db/repositories/RefundTransactionRepository.ts
@@ -33,6 +33,15 @@ class RefundTransactionRepository {
     await RefundTransaction.update({ status }, { where: { swapId } });
   };
 
+  public static setStatusConfirmedIfPending = async (swapId: string) => {
+    const [updated] = await RefundTransaction.update(
+      { status: RefundStatus.Confirmed },
+      { where: { swapId, status: RefundStatus.Pending } },
+    );
+
+    return updated > 0;
+  };
+
   public static getTransactionForSwap = async (swapId: string) => {
     return await RefundTransaction.findOne({ where: { swapId } });
   };

--- a/lib/swap/RefundWatcher.ts
+++ b/lib/swap/RefundWatcher.ts
@@ -4,7 +4,6 @@ import { formatError } from '../Utils';
 import { CurrencyType, swapTypeToPrettyString } from '../consts/Enums';
 import TypedEventEmitter from '../consts/TypedEventEmitter';
 import type RefundTransaction from '../db/models/RefundTransaction';
-import { RefundStatus } from '../db/models/RefundTransaction';
 import type ReverseSwap from '../db/models/ReverseSwap';
 import type { ChainSwapInfo } from '../db/repositories/ChainSwapRepository';
 import RefundTransactionRepository from '../db/repositories/RefundTransactionRepository';
@@ -52,16 +51,23 @@ class RefundWatcher extends TypedEventEmitter<{
         const txs = await RefundTransactionRepository.getPendingTransactions();
 
         for (const { tx, swap } of txs) {
-          try {
-            await this.checkRefund(tx, swap);
-          } catch (error) {
-            this.logger.error(
-              `Error checking refund transaction of ${swapTypeToPrettyString(swap.type)} ${swap.id}: ${formatError(error)}`,
-            );
-          }
+          await this.checkTransaction(tx, swap);
         }
       },
     );
+  };
+
+  public checkTransaction = async (
+    tx: RefundTransaction,
+    swap: ReverseSwap | ChainSwapInfo,
+  ) => {
+    try {
+      await this.checkRefund(tx, swap);
+    } catch (error) {
+      this.logger.error(
+        `Error checking refund transaction of ${swapTypeToPrettyString(swap.type)} ${swap.id}: ${formatError(error)}`,
+      );
+    }
   };
 
   private checkRefund = async (
@@ -81,14 +87,16 @@ class RefundWatcher extends TypedEventEmitter<{
       return;
     }
 
+    const confirmed =
+      await RefundTransactionRepository.setStatusConfirmedIfPending(swap.id);
+    if (!confirmed) {
+      return;
+    }
+
     this.logger.debug(
       `Refund transaction of ${swapTypeToPrettyString(swap.type)} swap ${swap.id} confirmed: ${tx.id}`,
     );
 
-    await RefundTransactionRepository.setStatus(
-      swap.id,
-      RefundStatus.Confirmed,
-    );
     this.emit('refund.confirmed', {
       swap,
       refundTransaction: tx.id,

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -53,7 +53,6 @@ import type {
   ERC20SwapValues,
   EtherSwapValues,
 } from '../consts/Types';
-import { RefundStatus } from '../db/models/RefundTransaction';
 import type ReverseSwap from '../db/models/ReverseSwap';
 import type SendApprovalHold from '../db/models/SendApprovalHold';
 import type Swap from '../db/models/Swap';
@@ -2536,24 +2535,31 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       } in: ${txId}`,
     );
 
-    await RefundTransactionRepository.addTransaction({
+    const refundTransaction = await RefundTransactionRepository.addTransaction({
       swapId: swap.id,
       symbol: chainCurrency.symbol,
       id: txId,
       vin: null,
-      status: RefundStatus.Confirmed,
     });
 
+    const refundedSwap = await WrappedSwapRepository.setTransactionRefunded(
+      swap,
+      0,
+      Errors.REFUNDED_COINS(txId).message,
+    );
+
     this.emit('refund', {
-      confirmed: true,
+      confirmed: false,
       emitFailure: true,
       refundTransaction: txId,
-      swap: await WrappedSwapRepository.setTransactionRefunded(
-        swap,
-        0,
-        Errors.REFUNDED_COINS(txId).message,
-      ),
+      swap: refundedSwap,
     });
+
+    // Ark transactions are final instantly, so confirm via the watcher directly
+    // instead of waiting on the global pending sweep. The refund must still flow
+    // through RefundWatcher so downstream handlers (e.g. invoice cancellation on
+    // refund.confirmed) run on the same path as other chains.
+    await this.refundWatcher.checkTransaction(refundTransaction, refundedSwap);
   };
 
   private refundEther = async (

--- a/test/integration/db/repositories/RefundTransactionRepository.spec.ts
+++ b/test/integration/db/repositories/RefundTransactionRepository.spec.ts
@@ -95,6 +95,29 @@ describe('RefundTransactionRepository', () => {
     expect(tx!.status).toEqual(RefundStatus.Confirmed);
   });
 
+  test('should only confirm a pending refund transaction once', async () => {
+    const swapId = 'swapId';
+    await RefundTransactionRepository.addTransaction({
+      symbol: 'BTC',
+      id: 'test',
+      vin: 123,
+      swapId,
+    });
+
+    await expect(
+      RefundTransactionRepository.setStatusConfirmedIfPending(swapId),
+    ).resolves.toEqual(true);
+    await expect(
+      RefundTransactionRepository.setStatusConfirmedIfPending(swapId),
+    ).resolves.toEqual(false);
+  });
+
+  test('should not confirm a refund transaction that does not exist', async () => {
+    await expect(
+      RefundTransactionRepository.setStatusConfirmedIfPending('does-not-exist'),
+    ).resolves.toEqual(false);
+  });
+
   describe('getTransactionForSwap', () => {
     test('should get transaction for swap', async () => {
       const swapId = 'swapId';

--- a/test/integration/swap/RefundWatcher.spec.ts
+++ b/test/integration/swap/RefundWatcher.spec.ts
@@ -28,7 +28,9 @@ const mockedExitHandler = jest.requireMock('../../../lib/ExitHandler') as {
   shutdownSignal: { aborted: boolean };
 };
 
-RefundTransactionRepository.setStatus = jest.fn();
+RefundTransactionRepository.setStatusConfirmedIfPending = jest
+  .fn()
+  .mockResolvedValue(true);
 RefundTransactionRepository.getPendingTransactions = jest
   .fn()
   .mockResolvedValue([]);
@@ -85,6 +87,9 @@ describe('RefundWatcher', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (
+      RefundTransactionRepository.setStatusConfirmedIfPending as jest.Mock
+    ).mockResolvedValue(true);
     mockedExitHandler.shutdownSignal.aborted = false;
     bitcoinClient.getRawTransactionVerbose = jest.fn();
     currencies.get('RBTC')!.requiredConfirmations = undefined;
@@ -146,10 +151,9 @@ describe('RefundWatcher', () => {
       expect(swap.id).toEqual(swapId);
       expect(refundTransaction).toEqual(btcRefundTxId);
 
-      expect(RefundTransactionRepository.setStatus).toHaveBeenCalledWith(
-        swapId,
-        RefundStatus.Confirmed,
-      );
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).toHaveBeenCalledWith(swapId);
     });
   });
 
@@ -172,7 +176,9 @@ describe('RefundWatcher', () => {
         } as unknown as ReverseSwap,
       );
 
-      expect(RefundTransactionRepository.setStatus).not.toHaveBeenCalled();
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).not.toHaveBeenCalled();
     });
 
     test('should handle confirmed refund transactions', async () => {
@@ -208,10 +214,124 @@ describe('RefundWatcher', () => {
       expect(swap.id).toEqual(swapId);
       expect(refundTransaction).toEqual(btcRefundTxId);
 
-      expect(RefundTransactionRepository.setStatus).toHaveBeenCalledWith(
-        swapId,
-        RefundStatus.Confirmed,
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).toHaveBeenCalledWith(swapId);
+    });
+
+    test('should confirm ARK refunds on the first check', async () => {
+      const swapId = 'ark-refund';
+      const refundTxId = 'ark-refund-tx';
+
+      const emitPromise = new Promise<{
+        swap: ReverseSwap | ChainSwapInfo;
+        refundTransaction: string;
+      }>((resolve) => {
+        watcher.on('refund.confirmed', (args) => {
+          resolve(args);
+          watcher.removeAllListeners('refund.confirmed');
+        });
+      });
+
+      await watcher.checkTransaction(
+        {
+          id: refundTxId,
+          status: RefundStatus.Pending,
+        } as unknown as RefundTransaction,
+        {
+          id: swapId,
+          type: SwapType.ReverseSubmarine,
+          refundCurrency: ArkClient.symbol,
+        } as unknown as ReverseSwap,
       );
+
+      await expect(emitPromise).resolves.toMatchObject({
+        swap: { id: swapId },
+        refundTransaction: refundTxId,
+      });
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).toHaveBeenCalledWith(swapId);
+      expect(
+        RefundTransactionRepository.getPendingTransactions,
+      ).not.toHaveBeenCalled();
+    });
+
+    test('should not emit confirmation when another check confirmed it first', async () => {
+      (
+        RefundTransactionRepository.setStatusConfirmedIfPending as jest.Mock
+      ).mockResolvedValue(false);
+      const confirmedListener = jest.fn();
+      watcher.on('refund.confirmed', confirmedListener);
+
+      await watcher.checkTransaction(
+        {
+          id: 'ark-refund-tx',
+          status: RefundStatus.Pending,
+        } as unknown as RefundTransaction,
+        {
+          id: 'ark-refund',
+          type: SwapType.ReverseSubmarine,
+          refundCurrency: ArkClient.symbol,
+        } as unknown as ReverseSwap,
+      );
+
+      expect(confirmedListener).not.toHaveBeenCalled();
+      watcher.removeListener('refund.confirmed', confirmedListener);
+    });
+
+    test('should not wait for an unrelated pending transaction check', async () => {
+      const btcSwap = {
+        id: 'slow-btc-refund',
+        type: SwapType.ReverseSubmarine,
+        refundCurrency: 'BTC',
+      } as unknown as ReverseSwap;
+      RefundTransactionRepository.getPendingTransactions = jest
+        .fn()
+        .mockResolvedValue([
+          {
+            tx: {
+              id: btcRefundTxId,
+              status: RefundStatus.Pending,
+            } as unknown as RefundTransaction,
+            swap: btcSwap,
+          },
+        ]);
+
+      let resolveRpcStarted!: () => void;
+      const rpcStarted = new Promise<void>((resolve) => {
+        resolveRpcStarted = resolve;
+      });
+      let resolveRpc!: (result: { confirmations: number }) => void;
+      bitcoinClient.getRawTransactionVerbose = jest.fn().mockImplementation(
+        () =>
+          new Promise<{ confirmations: number }>((resolve) => {
+            resolveRpc = resolve;
+            resolveRpcStarted();
+          }),
+      );
+
+      const pendingCheck = watcher['checkPendingTransactions']();
+      await rpcStarted;
+
+      await watcher.checkTransaction(
+        {
+          id: 'ark-refund-tx',
+          status: RefundStatus.Pending,
+        } as unknown as RefundTransaction,
+        {
+          id: 'ark-refund',
+          type: SwapType.ReverseSubmarine,
+          refundCurrency: ArkClient.symbol,
+        } as unknown as ReverseSwap,
+      );
+
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).toHaveBeenCalledWith('ark-refund');
+
+      resolveRpc({ confirmations: 0 });
+      await pendingCheck;
     });
 
     test('should use configured required confirmations for EVM refunds', async () => {
@@ -242,7 +362,9 @@ describe('RefundWatcher', () => {
 
       await checkRefund(refundTx, swap);
 
-      expect(RefundTransactionRepository.setStatus).not.toHaveBeenCalled();
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).not.toHaveBeenCalled();
 
       const emitPromise = new Promise<{
         swap: ReverseSwap | ChainSwapInfo;
@@ -260,12 +382,84 @@ describe('RefundWatcher', () => {
         swap: { id: swap.id },
         refundTransaction: refundTx.id,
       });
-      expect(RefundTransactionRepository.setStatus).toHaveBeenCalledWith(
-        swap.id,
-        RefundStatus.Confirmed,
-      );
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).toHaveBeenCalledWith(swap.id);
 
       getConfirmationsSpy.mockRestore();
+    });
+  });
+
+  describe('checkTransaction', () => {
+    test('should swallow errors when checking a transaction', async () => {
+      const errorLogger = jest.spyOn(watcher['logger'], 'error');
+
+      await expect(
+        watcher.checkTransaction(
+          {
+            id: 'unknown-currency-tx',
+            status: RefundStatus.Pending,
+          } as unknown as RefundTransaction,
+          {
+            id: 'unknown-currency-swap',
+            type: SwapType.ReverseSubmarine,
+            refundCurrency: 'NOT_A_CURRENCY',
+          } as unknown as ReverseSwap,
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(errorLogger).toHaveBeenCalledTimes(1);
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).not.toHaveBeenCalled();
+
+      errorLogger.mockRestore();
+    });
+
+    test('should keep checking pending transactions when one check fails', async () => {
+      const btcSwapId = 'btc-after-failure';
+      bitcoinClient.getRawTransactionVerbose = jest.fn().mockResolvedValue({
+        confirmations: 1,
+      });
+      RefundTransactionRepository.getPendingTransactions = jest
+        .fn()
+        .mockResolvedValue([
+          {
+            tx: {
+              id: 'failing-tx',
+              status: RefundStatus.Pending,
+            } as unknown as RefundTransaction,
+            swap: {
+              id: 'failing-swap',
+              type: SwapType.ReverseSubmarine,
+              refundCurrency: 'NOT_A_CURRENCY',
+            } as unknown as ReverseSwap,
+          },
+          {
+            tx: {
+              id: btcRefundTxId,
+              status: RefundStatus.Pending,
+            } as unknown as RefundTransaction,
+            swap: {
+              id: btcSwapId,
+              type: SwapType.ReverseSubmarine,
+              refundCurrency: 'BTC',
+            } as unknown as ReverseSwap,
+          },
+        ]);
+
+      await watcher['checkPendingTransactions']();
+
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        RefundTransactionRepository.setStatusConfirmedIfPending,
+      ).toHaveBeenCalledWith(btcSwapId);
+
+      RefundTransactionRepository.getPendingTransactions = jest
+        .fn()
+        .mockResolvedValue([]);
     });
   });
 

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -83,7 +83,11 @@ jest.mock('../../../lib/swap/PaymentHandler', () =>
   jest.fn().mockImplementation(() => ({ selfPaymentClient: {} })),
 );
 jest.mock('../../../lib/swap/RefundWatcher', () =>
-  jest.fn().mockImplementation(() => ({ on: jest.fn(), init: jest.fn() })),
+  jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    init: jest.fn(),
+    checkTransaction: jest.fn().mockResolvedValue(undefined),
+  })),
 );
 
 jest.mock('../../../lib/swap/LightningNursery', () => {
@@ -2424,6 +2428,235 @@ describe('SwapNursery', () => {
       expect(swapNursery.emit).not.toHaveBeenCalledWith(
         'claim',
         expect.anything(),
+      );
+    });
+  });
+
+  describe('refundVtxo', () => {
+    const refundTxId = 'ark-refund-tx';
+
+    const mockArkClient = {
+      refundVHtlc: jest.fn().mockResolvedValue('ark-refund-tx'),
+      pubkey: Buffer.from('03'.repeat(33), 'hex'),
+      symbol: 'ARK',
+    } as any;
+
+    const mockArkCurrency = {
+      symbol: 'ARK',
+      arkNode: mockArkClient,
+    } as any;
+
+    beforeEach(() => {
+      (
+        WrappedSwapRepository.setTransactionRefunded as jest.Mock
+      ).mockImplementation(async (swap) => swap);
+      (
+        RefundTransactionRepository.addTransaction as jest.Mock
+      ).mockImplementation(async (transaction) => transaction);
+      jest.spyOn(swapNursery, 'emit');
+    });
+
+    test('should refund reverse ARK swaps and let the RefundWatcher confirm', async () => {
+      const swap = {
+        id: 'reverse-ark-swap',
+        type: SwapType.ReverseSubmarine,
+        preimageHash: 'aa'.repeat(32),
+        claimPublicKey: '02'.repeat(33),
+        transactionId: 'reverse-lockup-tx',
+        transactionVout: 2,
+      } as any;
+
+      await (swapNursery as any).refundVtxo(mockArkCurrency, swap);
+
+      expect(mockArkClient.refundVHtlc).toHaveBeenCalledWith(
+        Buffer.from('aa'.repeat(32), 'hex'),
+        mockArkClient.pubkey,
+        Buffer.from('02'.repeat(33), 'hex'),
+        {
+          txId: 'reverse-lockup-tx',
+          vout: 2,
+        },
+        expect.any(String),
+      );
+
+      expect(RefundTransactionRepository.addTransaction).toHaveBeenCalledWith({
+        swapId: swap.id,
+        symbol: 'ARK',
+        id: refundTxId,
+        vin: null,
+      });
+
+      expect(swapNursery.emit).toHaveBeenCalledWith('refund', {
+        swap,
+        confirmed: false,
+        emitFailure: true,
+        refundTransaction: refundTxId,
+      });
+
+      const pendingEmitOrder = (swapNursery.emit as jest.Mock).mock
+        .invocationCallOrder[0];
+      const addTransactionOrder = (
+        RefundTransactionRepository.addTransaction as jest.Mock
+      ).mock.invocationCallOrder[0];
+      expect(addTransactionOrder).toBeLessThan(pendingEmitOrder);
+
+      expect(
+        (swapNursery as any).refundWatcher.checkTransaction,
+      ).toHaveBeenCalledWith(
+        {
+          swapId: swap.id,
+          symbol: 'ARK',
+          id: refundTxId,
+          vin: null,
+        },
+        swap,
+      );
+    });
+
+    test('should not persist or emit anything when the ARK refund fails', async () => {
+      mockArkClient.refundVHtlc.mockRejectedValueOnce(
+        new Error('refund failed'),
+      );
+
+      const swap = {
+        id: 'reverse-ark-swap',
+        type: SwapType.ReverseSubmarine,
+        preimageHash: 'aa'.repeat(32),
+        claimPublicKey: '02'.repeat(33),
+        transactionId: 'reverse-lockup-tx',
+        transactionVout: 2,
+      } as any;
+
+      await expect(
+        (swapNursery as any).refundVtxo(mockArkCurrency, swap),
+      ).rejects.toThrow('refund failed');
+
+      expect(
+        WrappedSwapRepository.setTransactionRefunded,
+      ).not.toHaveBeenCalled();
+      expect(RefundTransactionRepository.addTransaction).not.toHaveBeenCalled();
+      expect(swapNursery.emit).not.toHaveBeenCalled();
+      expect(
+        (swapNursery as any).refundWatcher.checkTransaction,
+      ).not.toHaveBeenCalled();
+    });
+
+    test('should propagate errors when persisting the refund transaction fails', async () => {
+      (
+        RefundTransactionRepository.addTransaction as jest.Mock
+      ).mockRejectedValueOnce(new Error('database error'));
+
+      const swap = {
+        id: 'reverse-ark-swap',
+        type: SwapType.ReverseSubmarine,
+        preimageHash: 'aa'.repeat(32),
+        claimPublicKey: '02'.repeat(33),
+        transactionId: 'reverse-lockup-tx',
+        transactionVout: 2,
+      } as any;
+
+      await expect(
+        (swapNursery as any).refundVtxo(mockArkCurrency, swap),
+      ).rejects.toThrow('database error');
+
+      // The swap is not marked as refunded before the refund transaction is
+      // persisted, so a failure here leaves the swap eligible for a retry
+      // instead of stuck in a terminal state without a refund transaction
+      expect(
+        WrappedSwapRepository.setTransactionRefunded,
+      ).not.toHaveBeenCalled();
+      expect(swapNursery.emit).not.toHaveBeenCalled();
+      expect(
+        (swapNursery as any).refundWatcher.checkTransaction,
+      ).not.toHaveBeenCalled();
+    });
+
+    test('should emit the pending refund before the watcher confirms it', async () => {
+      await swapNursery.init([]);
+
+      const refundWatcher = (swapNursery as any).refundWatcher;
+      const confirmedHandler = (refundWatcher.on as jest.Mock).mock.calls.find(
+        ([event]) => event === 'refund.confirmed',
+      )![1];
+      (refundWatcher.checkTransaction as jest.Mock).mockImplementation(
+        async (tx, checkedSwap) => {
+          await confirmedHandler({
+            swap: checkedSwap,
+            refundTransaction: tx.id,
+          });
+        },
+      );
+
+      const emittedConfirmations: boolean[] = [];
+      swapNursery.on('refund', ({ confirmed }) => {
+        emittedConfirmations.push(confirmed);
+      });
+
+      const swap = {
+        id: 'chain-ark-swap',
+        type: SwapType.Chain,
+        refundCurrency: 'ARK',
+        preimageHash: 'bb'.repeat(32),
+        sendingData: {
+          theirPublicKey: '02'.repeat(33),
+          transactionId: 'chain-lockup-tx',
+          transactionVout: 5,
+        },
+      } as unknown as ChainSwapInfo;
+
+      await (swapNursery as any).refundVtxo(mockArkCurrency, swap);
+
+      expect(emittedConfirmations).toEqual([false, true]);
+      expect(swapNursery.emit).toHaveBeenCalledWith('refund', {
+        swap,
+        confirmed: true,
+        emitFailure: false,
+        refundTransaction: refundTxId,
+      });
+    });
+
+    test('should refund chain ARK swaps with the sending data outpoint', async () => {
+      const swap = {
+        id: 'chain-ark-swap',
+        type: SwapType.Chain,
+        preimageHash: 'bb'.repeat(32),
+        sendingData: {
+          theirPublicKey: '02'.repeat(33),
+          transactionId: 'chain-lockup-tx',
+          transactionVout: 5,
+        },
+      } as unknown as ChainSwapInfo;
+
+      await (swapNursery as any).refundVtxo(mockArkCurrency, swap);
+
+      expect(mockArkClient.refundVHtlc).toHaveBeenCalledWith(
+        Buffer.from('bb'.repeat(32), 'hex'),
+        mockArkClient.pubkey,
+        Buffer.from('02'.repeat(33), 'hex'),
+        {
+          txId: 'chain-lockup-tx',
+          vout: 5,
+        },
+        expect.any(String),
+      );
+
+      expect(RefundTransactionRepository.addTransaction).toHaveBeenCalledWith({
+        swapId: swap.id,
+        symbol: 'ARK',
+        id: refundTxId,
+        vin: null,
+      });
+
+      expect(
+        (swapNursery as any).refundWatcher.checkTransaction,
+      ).toHaveBeenCalledWith(
+        {
+          swapId: swap.id,
+          symbol: 'ARK',
+          id: refundTxId,
+          vin: null,
+        },
+        swap,
       );
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ARK CLI **Decode** command that accepts a base64 PSBT or a file path and outputs decoded transaction details as pretty JSON.

* **Bug Fixes**
  * Prevented duplicate refund confirmations by only transitioning refunds from **Pending** to **Confirmed** once, and avoiding “confirmed” events when no update occurs.
  * Updated ARK vtxo refund flow to emit **pending** first, then rely on monitoring to emit the **confirmed** event.
  * Refund monitoring now continues processing other pending items even if individual checks fail.

* **Tests**
  * Expanded unit and integration tests to cover ARK decoding and the pending→confirmed refund status transition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->