### PR TITLE
fix: skip claiming already settled swaps

### DIFF
--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -923,11 +923,45 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     }
   };
 
+  private fetchSwapForSettlement = async (
+    swap: Swap | ChainSwapInfo,
+  ): Promise<Swap | ChainSwapInfo | undefined> => {
+    const fetched =
+      swap.type === SwapType.Submarine
+        ? await SwapRepository.getSwap({ id: swap.id })
+        : await ChainSwapRepository.getChainSwap({ id: swap.id });
+
+    if (fetched === null || fetched === undefined) {
+      this.logger.warn(`Could not find swap with id: ${swap.id}`);
+      return undefined;
+    }
+
+    if (
+      fetched.status === SwapUpdateEvent.TransactionClaimPending ||
+      SuccessSwapUpdateEvents.includes(fetched.status as SwapUpdateEvent)
+    ) {
+      this.logger.debug(
+        `Skipping claim of ${swapTypeToPrettyString(fetched.type)} Swap ${fetched.id}: already settled`,
+      );
+      return undefined;
+    }
+
+    return fetched;
+  };
+
   public attemptSettleSwap = async (
     currency: Currency,
     swap: Swap | ChainSwapInfo,
     preimage?: Buffer,
   ): Promise<void> => {
+    // Duplicate claim events (reorgs, rescan overlaps) can arrive with a stale
+    // swap object; re-fetch so an already settled swap is not claimed again
+    const fetchedSwap = await this.fetchSwapForSettlement(swap);
+    if (fetchedSwap === undefined) {
+      return;
+    }
+    swap = fetchedSwap;
+
     let payRes: PaidSwapInvoice | undefined;
 
     if (swap.type === SwapType.Submarine) {
@@ -1028,6 +1062,21 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     reverseSwap: ReverseSwap,
     preimage: Buffer,
   ) => {
+    const fetchedSwap = await ReverseSwapRepository.getReverseSwap({
+      id: reverseSwap.id,
+    });
+    if (fetchedSwap === null || fetchedSwap === undefined) {
+      this.logger.warn(`Could not find swap with id: ${reverseSwap.id}`);
+      return;
+    }
+    if (fetchedSwap.status === SwapUpdateEvent.InvoiceSettled) {
+      this.logger.debug(
+        `Skipping invoice settlement of Reverse Swap ${reverseSwap.id}: already settled`,
+      );
+      return;
+    }
+    reverseSwap = fetchedSwap;
+
     const { base, quote } = splitPairId(reverseSwap.pair);
     const lightningCurrency = getLightningCurrency(
       base,

--- a/test/integration/swap/SwapNursery.spec.ts
+++ b/test/integration/swap/SwapNursery.spec.ts
@@ -1,0 +1,177 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+import { randomBytes } from 'crypto';
+import Logger from '../../../lib/Logger';
+import { generateSwapId, getHexString } from '../../../lib/Utils';
+import {
+  CurrencyType,
+  OrderSide,
+  SwapUpdateEvent,
+  SwapVersion,
+} from '../../../lib/consts/Enums';
+import type Database from '../../../lib/db/Database';
+import ChainSwap from '../../../lib/db/models/ChainSwap';
+import ChainSwapData from '../../../lib/db/models/ChainSwapData';
+import Pair from '../../../lib/db/models/Pair';
+import { NodeType } from '../../../lib/db/models/ReverseSwap';
+import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
+import PairRepository from '../../../lib/db/repositories/PairRepository';
+import SwapNursery from '../../../lib/swap/SwapNursery';
+import type { Currency } from '../../../lib/wallet/WalletManager';
+import { getPostgresDatabase } from '../../Utils';
+
+describe('SwapNursery', () => {
+  const logger = Logger.disabledLogger;
+
+  const btcCurrency = {
+    symbol: 'BTC',
+    type: CurrencyType.BitcoinLike,
+  } as unknown as Currency;
+
+  const claimer = {
+    on: jest.fn(),
+    deferClaim: jest.fn().mockResolvedValue(true),
+  } as any;
+
+  const nursery = new SwapNursery(
+    logger,
+    {} as any,
+    undefined,
+    {} as any,
+    {} as any,
+    {} as any,
+    { ethereumManagers: [], wallets: new Map() } as any,
+    {} as any,
+    0,
+    claimer,
+    { on: jest.fn(), setAttemptSettle: jest.fn() } as any,
+    {} as any,
+    {} as any,
+  );
+
+  const createChainSwap = async () => {
+    const preimage = randomBytes(32);
+    const id = generateSwapId(SwapVersion.Taproot);
+
+    await ChainSwapRepository.addChainSwap({
+      chainSwap: {
+        id,
+        pair: 'L-BTC/BTC',
+        orderSide: OrderSide.BUY,
+        preimageHash: getHexString(Buffer.from(sha256(preimage))),
+        status: SwapUpdateEvent.TransactionServerConfirmed,
+        acceptZeroConf: false,
+        createdRefundSignature: false,
+        fee: 1000,
+      },
+      receivingData: {
+        swapId: id,
+        symbol: 'BTC',
+        lockupAddress: 'bcrt1qreceiving',
+        timeoutBlockHeight: 812,
+        expectedAmount: 100_000,
+        amount: 100_000,
+        transactionId: getHexString(randomBytes(32)),
+        transactionVout: 0,
+      },
+      sendingData: {
+        swapId: id,
+        symbol: 'L-BTC',
+        lockupAddress: 'el1qsending',
+        timeoutBlockHeight: 21,
+        expectedAmount: 99_000,
+        amount: 99_000,
+        transactionId: getHexString(randomBytes(32)),
+      },
+    });
+
+    const swap = (await ChainSwapRepository.getChainSwap({ id }))!;
+
+    return { swap, preimage };
+  };
+
+  let database: Database;
+  let createdPair = false;
+
+  beforeAll(async () => {
+    database = getPostgresDatabase();
+    await database.init();
+
+    if ((await Pair.findByPk('L-BTC/BTC')) === null) {
+      createdPair = true;
+      await PairRepository.addPair({
+        id: 'L-BTC/BTC',
+        base: 'L-BTC',
+        quote: 'BTC',
+      });
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    claimer.deferClaim.mockResolvedValue(true);
+  });
+
+  afterAll(async () => {
+    await ChainSwapData.destroy({ where: {} });
+    await ChainSwap.destroy({ where: {} });
+    if (createdPair) {
+      await Pair.destroy({ where: { id: 'L-BTC/BTC' } });
+    }
+
+    (nursery as any).pendingPaymentTracker.lightningTrackers[
+      NodeType.CLN
+    ].stop();
+
+    await database.close();
+  });
+
+  describe('attemptSettleSwap', () => {
+    test('should not claim again when the swap was settled after the stale snapshot was taken', async () => {
+      const { swap: staleSwap, preimage } = await createChainSwap();
+
+      // What the first, successful claim does; the stale snapshot does not see it
+      await ChainSwapRepository.setClaimMinerFee(
+        (await ChainSwapRepository.getChainSwap({ id: staleSwap.id }))!,
+        preimage,
+        420,
+      );
+      expect(staleSwap.status).toEqual(
+        SwapUpdateEvent.TransactionServerConfirmed,
+      );
+
+      const debugLogs: string[] = [];
+      const loggerSpy = jest
+        .spyOn(logger, 'debug')
+        .mockImplementation((msg: string) => {
+          debugLogs.push(msg);
+        });
+
+      await nursery.attemptSettleSwap(btcCurrency, staleSwap, preimage);
+
+      loggerSpy.mockRestore();
+
+      expect(claimer.deferClaim).not.toHaveBeenCalled();
+      expect(debugLogs).toContain(
+        `Skipping claim of Chain Swap ${staleSwap.id}: already settled`,
+      );
+    });
+
+    test('should settle an unclaimed swap with the freshly fetched database row', async () => {
+      const { swap: staleSwap, preimage } = await createChainSwap();
+
+      const claimPending = new Promise<any>((resolve) => {
+        nursery.once('claim.pending', resolve);
+      });
+
+      await nursery.attemptSettleSwap(btcCurrency, staleSwap, preimage);
+
+      expect(claimer.deferClaim).toHaveBeenCalledTimes(1);
+
+      const settledSwap = await claimPending;
+      expect(settledSwap.id).toEqual(staleSwap.id);
+      // The re-fetched row, not the snapshot that was passed in
+      expect(settledSwap).not.toBe(staleSwap);
+      expect(claimer.deferClaim).toHaveBeenCalledWith(settledSwap, preimage);
+    });
+  });
+});

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -648,6 +648,12 @@ describe('SwapNursery', () => {
       nodeId: mockLndClient.id,
     } as ReverseSwap;
 
+    beforeEach(() => {
+      (ReverseSwapRepository.getReverseSwap as jest.Mock).mockResolvedValue(
+        mockReverseSwap,
+      );
+    });
+
     test('should settle hold invoice when no matching submarine swap exists', async () => {
       mockGetSwapResult = null;
 
@@ -927,6 +933,40 @@ describe('SwapNursery', () => {
       }
 
       expect(timeoutCallback!).toBeDefined();
+    });
+
+    test('should skip settlement when the invoice was settled already', async () => {
+      (ReverseSwapRepository.getReverseSwap as jest.Mock).mockResolvedValueOnce(
+        {
+          ...mockReverseSwap,
+          status: SwapUpdateEvent.InvoiceSettled,
+        },
+      );
+
+      await swapNursery.settleReverseSwapInvoice(mockReverseSwap, mockPreimage);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        `Skipping invoice settlement of Reverse Swap ${mockReverseSwap.id}: already settled`,
+      );
+      expect(mockRaceCall).not.toHaveBeenCalled();
+      expect(mockSettleHoldInvoice).not.toHaveBeenCalled();
+      expect(LightningNursery.cancelReverseInvoices).not.toHaveBeenCalled();
+      expect(ReverseSwapRepository.setInvoiceSettled).not.toHaveBeenCalled();
+      expect(mockNotifications.sendMessage).not.toHaveBeenCalled();
+    });
+
+    test('should skip settlement when the reverse swap cannot be found anymore', async () => {
+      (ReverseSwapRepository.getReverseSwap as jest.Mock).mockResolvedValueOnce(
+        null,
+      );
+
+      await swapNursery.settleReverseSwapInvoice(mockReverseSwap, mockPreimage);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        `Could not find swap with id: ${mockReverseSwap.id}`,
+      );
+      expect(mockRaceCall).not.toHaveBeenCalled();
+      expect(ReverseSwapRepository.setInvoiceSettled).not.toHaveBeenCalled();
     });
   });
 
@@ -2273,6 +2313,152 @@ describe('SwapNursery', () => {
         'transaction',
         expect.anything(),
       );
+    });
+  });
+
+  describe('attemptSettleSwap idempotency', () => {
+    const mockPreimage = Buffer.from('preimage');
+
+    beforeEach(() => {
+      (swapNursery as any).claimer = {
+        deferClaim: jest.fn().mockResolvedValue(true),
+      };
+      jest.spyOn(swapNursery, 'emit');
+    });
+
+    test('should skip settlement when the chain swap was claimed already', async () => {
+      const staleChainSwap = {
+        id: 'settled-chain-swap',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.TransactionServerConfirmed,
+        receivingData: { symbol: 'BTC' },
+      } as unknown as ChainSwapInfo;
+      mockGetChainSwapResult = {
+        ...staleChainSwap,
+        status: SwapUpdateEvent.TransactionClaimed,
+      };
+
+      await swapNursery.attemptSettleSwap(
+        mockCurrency,
+        staleChainSwap,
+        mockPreimage,
+      );
+
+      expect(ChainSwapRepository.getChainSwap).toHaveBeenCalledWith({
+        id: staleChainSwap.id,
+      });
+      expect((swapNursery as any).claimer.deferClaim).not.toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        `Skipping claim of Chain Swap ${staleChainSwap.id}: already settled`,
+      );
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'claim.failure',
+        expect.anything(),
+      );
+    });
+
+    test('should skip settlement when the submarine swap was claimed already', async () => {
+      const staleSwap = {
+        id: 'settled-submarine-swap',
+        type: SwapType.Submarine,
+      } as unknown as Swap;
+      mockGetSwapResult = {
+        ...staleSwap,
+        status: SwapUpdateEvent.TransactionClaimed,
+      };
+      const payInvoiceSpy = jest.spyOn(swapNursery as any, 'payInvoice');
+
+      await swapNursery.attemptSettleSwap(mockCurrency, staleSwap);
+
+      expect(SwapRepository.getSwap).toHaveBeenCalledWith({
+        id: staleSwap.id,
+      });
+      expect(payInvoiceSpy).not.toHaveBeenCalled();
+    });
+
+    test('should skip settlement when the swap cannot be found anymore', async () => {
+      mockGetChainSwapResult = null;
+      const staleChainSwap = {
+        id: 'gone-chain-swap',
+        type: SwapType.Chain,
+      } as unknown as ChainSwapInfo;
+
+      await swapNursery.attemptSettleSwap(
+        mockCurrency,
+        staleChainSwap,
+        mockPreimage,
+      );
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        `Could not find swap with id: ${staleChainSwap.id}`,
+      );
+      expect((swapNursery as any).claimer.deferClaim).not.toHaveBeenCalled();
+    });
+
+    test('should settle with the re-fetched swap instead of the stale one', async () => {
+      const staleChainSwap = {
+        id: 'fresh-chain-swap',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.TransactionServerMempool,
+      } as unknown as ChainSwapInfo;
+      const fetchedChainSwap = {
+        ...staleChainSwap,
+        status: SwapUpdateEvent.TransactionServerConfirmed,
+      };
+      mockGetChainSwapResult = fetchedChainSwap;
+
+      await swapNursery.attemptSettleSwap(
+        mockCurrency,
+        staleChainSwap,
+        mockPreimage,
+      );
+
+      expect((swapNursery as any).claimer.deferClaim).toHaveBeenCalledWith(
+        fetchedChainSwap,
+        mockPreimage,
+      );
+      expect(swapNursery.emit).toHaveBeenCalledWith(
+        'claim.pending',
+        fetchedChainSwap,
+      );
+    });
+
+    test('should claim only once when a duplicate EVM claim event arrives', async () => {
+      const listeners: Record<string, (...args: any[]) => Promise<void>> = {};
+      const ethereumNursery = {
+        on: jest.fn(
+          (event: string, callback: (...args: any[]) => Promise<void>) => {
+            listeners[event] = callback;
+          },
+        ),
+        init: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const chainSwap = {
+        id: 'duplicate-claim-swap',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.TransactionServerConfirmed,
+        receivingData: { symbol: 'BTC' },
+      } as unknown as ChainSwapInfo;
+      mockGetChainSwapResult = chainSwap;
+
+      await (swapNursery as any).listenEthereumNursery(ethereumNursery);
+
+      await listeners['claim']({ swap: chainSwap, preimage: mockPreimage });
+      mockGetChainSwapResult = {
+        ...chainSwap,
+        status: SwapUpdateEvent.TransactionClaimPending,
+      };
+      await listeners['claim']({ swap: chainSwap, preimage: mockPreimage });
+      mockGetChainSwapResult = {
+        ...chainSwap,
+        status: SwapUpdateEvent.TransactionClaimed,
+      };
+      await listeners['claim']({ swap: chainSwap, preimage: mockPreimage });
+
+      expect((swapNursery as any).claimer.deferClaim).toHaveBeenCalledTimes(1);
+      expect(swapNursery.emit).toHaveBeenCalledTimes(1);
+      expect(swapNursery.emit).toHaveBeenCalledWith('claim.pending', chainSwap);
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap settlement reliability when duplicate events, rescans, or stale data are encountered.
  * Prevented already-settled swaps and invoices from being claimed or settled again.
  * Added safe handling when a swap cannot be found during settlement.
  * Ensured settlement uses the latest available swap state, avoiding duplicate claims and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->