### PR TITLE
feat: non interactive ARK claims

### DIFF
--- a/docs/boltz.conf
+++ b/docs/boltz.conf
@@ -21,6 +21,9 @@
 # Use P2WSH addresses instead of P2SH nested P2WSH for legacy Submarine Swaps
 # swapwitnessaddress = false
 
+# Whether clients may request non-interactive claims for Swaps to ARK
+# nonInteractiveClaims = false
+
 # Network identifier
 # network = "mainnet"
 

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -225,6 +225,7 @@ type ConfigType = {
 
   prepayminerfee: boolean;
   swapwitnessaddress: boolean;
+  nonInteractiveClaims: boolean;
 
   swap: SwapConfig;
   routing: RoutingFeeConfig;
@@ -290,6 +291,7 @@ class Config {
 
       prepayminerfee: false,
       swapwitnessaddress: false,
+      nonInteractiveClaims: false,
 
       swap: {
         deferredClaimSymbols: ['L-BTC'],

--- a/lib/api/Api.ts
+++ b/lib/api/Api.ts
@@ -49,6 +49,7 @@ class Api {
 
     this.app.use(
       express.json({
+        limit: '100kb',
         verify(req, _, buf: Buffer, encoding: string) {
           if (buf && buf.length) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/lib/api/Errors.ts
+++ b/lib/api/Errors.ts
@@ -7,6 +7,10 @@ export default {
     `undefined parameter: ${argName}`,
   UNSUPPORTED_PARAMETER: (symbol: string, argName: string): string =>
     `${symbol} does not support ${argName}`,
+  ARK_ADDRESS_WRONG_NETWORK: (argName: string): string =>
+    `ark address in "${argName}" is for the wrong network`,
+  ARK_ADDRESS_WRONG_SERVER: (argName: string): string =>
+    `ark address in "${argName}" is for the wrong server`,
   INVALID_SWAP_STATUS: (status: string): string =>
     `invalid swap status: ${status}`,
   INVALID_EXTRA_FEES_PERCENTAGE: (percentage: number): string =>

--- a/lib/api/Utils.ts
+++ b/lib/api/Utils.ts
@@ -75,7 +75,11 @@ export const validateRequest = (
     const value = body[arg.name];
 
     if (value !== undefined) {
-      if (typeof value === arg.type) {
+      // "typeof null" is "object", but null is never a valid value
+      if (
+        typeof value === arg.type &&
+        (arg.type !== 'object' || value !== null)
+      ) {
         if (arg.hex && value !== '') {
           const buffer = getHexBuffer(value);
 

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -125,6 +125,8 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/SwapTreeLeaf'
      *         unilateralRefundWithoutBoltzLeaf:
      *           $ref: '#/components/schemas/SwapTreeLeaf'
+     *         nonInteractiveClaimLeaf:
+     *           $ref: '#/components/schemas/SwapTreeLeaf'
      */
 
     /**

--- a/lib/api/v2/routers/SwapRouter.ts
+++ b/lib/api/v2/routers/SwapRouter.ts
@@ -2,6 +2,8 @@ import type { Request, Response } from 'express';
 import { Router } from 'express';
 import type Logger from '../../../Logger';
 import { getHexBuffer, getHexString, stringify } from '../../../Utils';
+import type { NonInteractiveClaim } from '../../../chain/ArkClient';
+import ArkClient from '../../../chain/ArkClient';
 import { SwapUpdateEvent, SwapVersion } from '../../../consts/Enums';
 import { unsafeKeys } from '../../../data/Utils';
 import ChainSwapRepository from '../../../db/repositories/ChainSwapRepository';
@@ -35,6 +37,11 @@ import RouterBase from './RouterBase';
 const metadataMaxBytes = 1024;
 const metadataMaxHexLength = metadataMaxBytes * 2;
 const metadataHexRegex = /^(?:[0-9a-fA-F]{2})+$/;
+
+const webHookUrlMaxLength = 1024;
+
+// Size of the database column
+const extraFeesIdMaxLength = 255;
 
 class SwapRouter extends RouterBase {
   constructor(
@@ -130,6 +137,7 @@ class SwapRouter extends RouterBase {
      *       properties:
      *         id:
      *           type: string
+     *           maxLength: 255
      *           description: Identifier for the extra fee
      *         percentage:
      *           type: number
@@ -231,6 +239,7 @@ class SwapRouter extends RouterBase {
      *       properties:
      *         url:
      *           type: string
+     *           maxLength: 1024
      *           description: URL that should be called. Only HTTPS is allowed
      *         hashSwapId:
      *           type: boolean
@@ -1012,6 +1021,19 @@ class SwapRouter extends RouterBase {
      * @openapi
      * components:
      *   schemas:
+     *     NonInteractiveClaim:
+     *       type: object
+     *       required: ["claimAddress"]
+     *       properties:
+     *         claimAddress:
+     *           type: string
+     *           description: Ark address that has to be paid by the transaction claiming the VHTLC
+     */
+
+    /**
+     * @openapi
+     * components:
+     *   schemas:
      *     ReverseRequest:
      *       type: object
      *       required: ["from", "to"]
@@ -1078,7 +1100,12 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/WebhookData'
      *         extraFees:
      *           $ref: '#/components/schemas/ExtraFees'
+     *         nonInteractiveClaim:
+     *           allOf:
+     *             - $ref: '#/components/schemas/NonInteractiveClaim'
+     *           description: Enables the non-interactive claim path of the VHTLC. Only allowed for swaps to ARK
      */
+
     /**
      * @openapi
      * components:
@@ -1495,6 +1522,10 @@ class SwapRouter extends RouterBase {
      *           $ref: '#/components/schemas/WebhookData'
      *         extraFees:
      *           $ref: '#/components/schemas/ExtraFees'
+     *         nonInteractiveClaim:
+     *           allOf:
+     *             - $ref: '#/components/schemas/NonInteractiveClaim'
+     *           description: Enables the non-interactive claim path of the VHTLC. Only allowed for swaps to ARK
      */
 
     /**
@@ -3072,6 +3103,7 @@ class SwapRouter extends RouterBase {
       descriptionHash,
       addressSignature,
       metadata,
+      nonInteractiveClaim,
     } = validateRequest(req.body, [
       { name: 'to', type: 'string' },
       { name: 'from', type: 'string' },
@@ -3087,6 +3119,7 @@ class SwapRouter extends RouterBase {
       { name: 'invoiceExpiry', type: 'number', optional: true },
       { name: 'onchainAmount', type: 'number', optional: true },
       { name: 'claimCovenant', type: 'boolean', optional: true },
+      { name: 'nonInteractiveClaim', type: 'object', optional: true },
       { name: 'preimageHash', type: 'string', hex: true, optional: true },
       { name: 'descriptionHash', type: 'string', hex: true, optional: true },
       { name: 'claimPublicKey', type: 'string', hex: true, optional: true },
@@ -3099,6 +3132,8 @@ class SwapRouter extends RouterBase {
     const webHookData = this.parseWebHook(webhook);
     const extraFeesData = this.parseExtraFees(extraFees);
     const metadataData = this.parseMetadata(metadata);
+    const nonInteractiveClaimData =
+      this.parseNonInteractiveClaim(nonInteractiveClaim);
 
     const response = await this.service.createReverseSwap({
       pairId,
@@ -3122,6 +3157,7 @@ class SwapRouter extends RouterBase {
       extraFees: extraFeesData,
       version: SwapVersion.Taproot,
       userAddressSignature: addressSignature,
+      nonInteractiveClaim: nonInteractiveClaimData,
     });
 
     await this.persistMetadata(response.id, metadataData);
@@ -3241,6 +3277,7 @@ class SwapRouter extends RouterBase {
       refundPublicKey,
       serverLockAmount,
       metadata,
+      nonInteractiveClaim,
     } = validateRequest(req.body, [
       { name: 'to', type: 'string' },
       { name: 'from', type: 'string' },
@@ -3254,6 +3291,7 @@ class SwapRouter extends RouterBase {
       { name: 'claimPublicKey', type: 'string', hex: true, optional: true },
       { name: 'refundPublicKey', type: 'string', hex: true, optional: true },
       { name: 'metadata', type: 'string', optional: true },
+      { name: 'nonInteractiveClaim', type: 'object', optional: true },
     ]);
     const referralId = parseReferralId(req);
 
@@ -3261,6 +3299,8 @@ class SwapRouter extends RouterBase {
     const webHookData = this.parseWebHook(webhook);
     const extraFeesData = this.parseExtraFees(extraFees);
     const metadataData = this.parseMetadata(metadata);
+    const nonInteractiveClaimData =
+      this.parseNonInteractiveClaim(nonInteractiveClaim);
 
     const { pairId, orderSide } = this.service.convertToPairAndSide(from, to);
     const response = await this.service.createChainSwap({
@@ -3276,6 +3316,7 @@ class SwapRouter extends RouterBase {
       serverLockAmount,
       webHook: webHookData,
       extraFees: extraFeesData,
+      nonInteractiveClaim: nonInteractiveClaimData,
     });
 
     await this.persistMetadata(response.id, metadataData);
@@ -3564,6 +3605,10 @@ class SwapRouter extends RouterBase {
       { name: 'hashSwapId', type: 'boolean', optional: true },
     ]);
 
+    if (res.url.length === 0 || res.url.length > webHookUrlMaxLength) {
+      throw ApiErrors.INVALID_PARAMETER('webhook.url');
+    }
+
     if (res.status) {
       validateArray('status', res.status, 'string', 21);
 
@@ -3578,6 +3623,28 @@ class SwapRouter extends RouterBase {
     return res;
   };
 
+  private parseNonInteractiveClaim = (
+    data: Record<string, any> | undefined,
+  ): NonInteractiveClaim | undefined => {
+    if (data === undefined) {
+      return undefined;
+    }
+
+    const res = validateRequest(data, [
+      { name: 'claimAddress', type: 'string' },
+    ]);
+
+    try {
+      ArkClient.decodeAddress(res.claimAddress);
+    } catch {
+      throw ApiErrors.INVALID_PARAMETER('nonInteractiveClaim.claimAddress');
+    }
+
+    return {
+      claimAddress: res.claimAddress,
+    };
+  };
+
   private parseExtraFees = (
     data: Record<string, any> | undefined,
   ): ExtraFees | undefined => {
@@ -3590,7 +3657,11 @@ class SwapRouter extends RouterBase {
       { name: 'percentage', type: 'number', optional: true },
     ]);
 
-    if (unsafeKeys.has(res.id)) {
+    if (
+      res.id.length === 0 ||
+      res.id.length > extraFeesIdMaxLength ||
+      unsafeKeys.has(res.id)
+    ) {
       throw ApiErrors.INVALID_EXTRA_FEES_ID(res.id);
     }
 

--- a/lib/chain/ArkClient.ts
+++ b/lib/chain/ArkClient.ts
@@ -80,6 +80,10 @@ type ArkAddress = {
   boardingAddress: string;
 };
 
+export type NonInteractiveClaim = arkrpc.NonInteractiveClaim;
+
+export type VHtlcTaprootTree = arkrpc.TaprootTree;
+
 enum ArkBlockEventKind {
   Height = 'height',
   MedianTime = 'medianTime',
@@ -108,6 +112,8 @@ class ArkClient extends BaseClient<
   private static readonly opCsvMultiple = 512;
 
   public pubkey!: Buffer;
+  public signerPubkey!: Buffer;
+  public addrPrefix!: string;
   public subscription!: ArkSubscription;
 
   private chainClient?: IChainClient;
@@ -169,6 +175,22 @@ class ArkClient extends BaseClient<
     return this.useLocktimeSeconds;
   }
 
+  /**
+   * @param serverPubKey - server public key of a decoded Ark address; x-only or compressed with a parity byte
+   */
+  public isOwnServerKey = (serverPubKey: Buffer): boolean => {
+    if (this.signerPubkey === undefined) {
+      return false;
+    }
+
+    return ArkClient.toXOnly(serverPubKey).equals(
+      ArkClient.toXOnly(this.signerPubkey),
+    );
+  };
+
+  private static toXOnly = (pubkey: Buffer): Buffer =>
+    pubkey.length === 33 ? pubkey.subarray(1) : pubkey;
+
   public static decodeAddress = (address: string) => {
     const dec = bech32m.decodeUnsafe(address, 1023);
     if (dec === undefined) {
@@ -181,6 +203,7 @@ class ArkClient extends BaseClient<
     }
 
     return {
+      prefix: dec.prefix,
       serverPubKey: data.subarray(1, 33),
       tweakedPubKey: data.subarray(33, 65),
     };
@@ -267,6 +290,8 @@ class ArkClient extends BaseClient<
         `Connected to ${this.serviceName()} ${this.symbol} with pubkey: ${info.pubkey}`,
       );
       this.pubkey = getHexBuffer(info.pubkey);
+      this.signerPubkey = getHexBuffer(info.signerPubkey);
+      this.addrPrefix = info.addrPrefix;
 
       this.setClientStatus(ClientStatus.Connected);
     } catch (error) {
@@ -316,6 +341,8 @@ class ArkClient extends BaseClient<
     try {
       const info = await this.getInfo();
       this.pubkey = getHexBuffer(info.pubkey);
+      this.signerPubkey = getHexBuffer(info.signerPubkey);
+      this.addrPrefix = info.addrPrefix;
 
       this.logger.info(
         `Reestablished connection to ${this.serviceName()} ${this.symbol}`,
@@ -475,6 +502,7 @@ class ArkClient extends BaseClient<
     refundDelay: number,
     claimPublicKey?: Buffer,
     refundPublicKey?: Buffer,
+    nonInteractiveClaim?: NonInteractiveClaim,
   ): Promise<{
     vHtlc: arkrpc.CreateVHTLCResponse;
     timeouts: Timeouts;
@@ -511,6 +539,7 @@ class ArkClient extends BaseClient<
       unilateralClaimDelay: undefined,
       unilateralRefundDelay: undefined,
       unilateralRefundWithoutReceiverDelay: undefined,
+      nonInteractiveClaim,
     };
 
     if (claimPublicKey) {

--- a/lib/service/Errors.ts
+++ b/lib/service/Errors.ts
@@ -213,4 +213,8 @@ export default {
     message: 'could not register webhook',
     code: concatErrorCode(ErrorCodePrefix.Service, 59),
   }),
+  NON_INTERACTIVE_CLAIMS_DISABLED: (): Error => ({
+    message: 'non-interactive claims are disabled',
+    code: concatErrorCode(ErrorCodePrefix.Service, 60),
+  }),
 };

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -32,8 +32,11 @@ import {
 } from '../Utils';
 import ApiErrors from '../api/Errors';
 import { checkPreimageHashLength, errorsNotToLog } from '../api/Utils';
-import type { Timeouts as ArkTimeouts } from '../chain/ArkClient';
-import type ArkClient from '../chain/ArkClient';
+import type {
+  Timeouts as ArkTimeouts,
+  NonInteractiveClaim,
+} from '../chain/ArkClient';
+import ArkClient from '../chain/ArkClient';
 import ElementsClient from '../chain/ElementsClient';
 import {
   etherDecimals,
@@ -1805,6 +1808,9 @@ class Service {
 
     claimCovenant?: boolean;
 
+    // Only used for Reverse Swaps to Ark
+    nonInteractiveClaim?: NonInteractiveClaim;
+
     // Description for the invoice and magic routing hint
     description?: string;
     descriptionHash?: Buffer;
@@ -1931,6 +1937,12 @@ class Service {
 
         break;
     }
+
+    this.checkNonInteractiveClaimSupported(
+      sending,
+      sendingCurrency,
+      args.nonInteractiveClaim,
+    );
 
     const [onchainTimeoutBlockDelta] =
       await this.timeoutDeltaProvider.getTimeout(
@@ -2112,6 +2124,7 @@ class Service {
         claimPublicKey: args.claimPublicKey,
         descriptionHash: args.descriptionHash,
         claimCovenant: args.claimCovenant || false,
+        nonInteractiveClaim: args.nonInteractiveClaim,
         userAddressSignature: args.userAddressSignature,
         invoice:
           args.invoice !== undefined && decodedInvoice !== undefined
@@ -2250,6 +2263,8 @@ class Service {
 
     webHook?: WebHookData;
     extraFees?: ExtraFees;
+
+    nonInteractiveClaim?: NonInteractiveClaim;
   }) => {
     await this.checkSwapWithPreimageExists(SwapType.Chain, args.preimageHash);
 
@@ -2321,6 +2336,12 @@ class Service {
         throw ApiErrors.UNDEFINED_PARAMETER('refundPublicKey');
       }
     }
+
+    this.checkNonInteractiveClaimSupported(
+      sending,
+      sendingCurrency,
+      args.nonInteractiveClaim,
+    );
 
     const sendingTimeoutBlockDelta = (
       await this.timeoutDeltaProvider.getTimeout(
@@ -2446,6 +2467,7 @@ class Service {
         claimPublicKey: args.claimPublicKey,
         refundPublicKey: args.refundPublicKey,
         serverLockAmount: args.serverLockAmount,
+        nonInteractiveClaim: args.nonInteractiveClaim,
         acceptZeroConf: this.rateProvider.acceptZeroConf(
           receivingCurrency.symbol,
           args.userLockAmount,
@@ -2625,6 +2647,45 @@ class Service {
           throw Errors.SWAP_WITH_PREIMAGE_EXISTS();
         }
         break;
+    }
+  };
+
+  // The non-interactive claim leaf lives on the server-locked Ark VHTLC, so
+  // it is only valid when the server sends Ark (e.g. BTC -> ARK)
+  private checkNonInteractiveClaimSupported = (
+    sendingSymbol: string,
+    sendingCurrency: Currency,
+    nonInteractiveClaim?: NonInteractiveClaim,
+  ) => {
+    if (nonInteractiveClaim === undefined) {
+      return;
+    }
+
+    if (sendingCurrency.type !== CurrencyType.Ark) {
+      throw ApiErrors.UNSUPPORTED_PARAMETER(
+        sendingSymbol,
+        'nonInteractiveClaim',
+      );
+    }
+
+    let decoded: ReturnType<typeof ArkClient.decodeAddress>;
+    try {
+      decoded = ArkClient.decodeAddress(nonInteractiveClaim.claimAddress);
+    } catch {
+      throw ApiErrors.INVALID_PARAMETER('nonInteractiveClaim.claimAddress');
+    }
+
+    const arkNode = sendingCurrency.arkNode!;
+    if (decoded.prefix !== arkNode.addrPrefix) {
+      throw ApiErrors.ARK_ADDRESS_WRONG_NETWORK(
+        'nonInteractiveClaim.claimAddress',
+      );
+    }
+
+    if (!arkNode.isOwnServerKey(decoded.serverPubKey)) {
+      throw ApiErrors.ARK_ADDRESS_WRONG_SERVER(
+        'nonInteractiveClaim.claimAddress',
+      );
     }
   };
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -182,6 +182,7 @@ class Service {
   public readonly lockupTransactionTracker: LockupTransactionTracker;
 
   private prepayMinerFee: boolean;
+  private readonly nonInteractiveClaims: boolean;
 
   private readonly balanceCheck: BalanceCheck;
   private readonly paymentRequestUtils: PaymentRequestUtils;
@@ -203,6 +204,13 @@ class Service {
     this.logger.debug(
       `Prepay miner fee for Reverse Swaps is ${
         this.prepayMinerFee ? 'enabled' : 'disabled'
+      }`,
+    );
+
+    this.nonInteractiveClaims = config.nonInteractiveClaims;
+    this.logger.debug(
+      `Non-interactive claims for Swaps to ${ArkClient.symbol} are ${
+        this.nonInteractiveClaims ? 'enabled' : 'disabled'
       }`,
     );
 
@@ -2659,6 +2667,10 @@ class Service {
   ) => {
     if (nonInteractiveClaim === undefined) {
       return;
+    }
+
+    if (!this.nonInteractiveClaims) {
+      throw Errors.NON_INTERACTIVE_CLAIMS_DISABLED();
     }
 
     if (sendingCurrency.type !== CurrencyType.Ark) {

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -33,7 +33,11 @@ import {
   getUnixTime,
   splitPairId,
 } from '../Utils';
-import type { Timeouts } from '../chain/ArkClient';
+import type {
+  NonInteractiveClaim,
+  Timeouts,
+  VHtlcTaprootTree,
+} from '../chain/ArkClient';
 import ArkClient from '../chain/ArkClient';
 import { LegacyReverseSwapOutputType } from '../consts/Consts';
 import DefaultMap from '../consts/DefaultMap';
@@ -132,9 +136,9 @@ type CreatedOnchainSwap = {
   timeoutBlockHeight?: number;
   timeoutBlockHeights?: Timeouts;
 
-  // Only set for Taproot swaps
+  // Only set for Taproot swaps; VHtlcTaprootTree for Ark
   refundPublicKey?: string;
-  swapTree?: SwapTreeSerializer.SerializedTree;
+  swapTree?: SwapTreeSerializer.SerializedTree | VHtlcTaprootTree;
 
   // Only set for Ethereum like chains
   claimAddress?: string;
@@ -810,6 +814,9 @@ class SwapManager {
 
     claimCovenant: boolean;
 
+    // Only used for Reverse Swaps to Ark
+    nonInteractiveClaim?: NonInteractiveClaim;
+
     memo?: string;
     descriptionHash?: Buffer;
 
@@ -1112,10 +1119,12 @@ class SwapManager {
         args.onchainTimeoutBlockDelta,
         args.claimPublicKey!,
         undefined,
+        args.nonInteractiveClaim,
       );
 
       result.refundPublicKey = getHexString(sendingCurrency.arkNode!.pubkey);
       result.lockupAddress = vHtlc.vHtlc.address;
+      result.swapTree = vHtlc.vHtlc.swapTree;
 
       result.timeoutBlockHeights = vHtlc.timeouts;
 
@@ -1211,6 +1220,8 @@ class SwapManager {
     sendingTimeoutBlockDelta: number;
     receivingTimeoutBlockDelta: number;
 
+    nonInteractiveClaim?: NonInteractiveClaim;
+
     referralId?: string;
 
     // Pre-generated swap id; when omitted a new one is generated
@@ -1260,6 +1271,7 @@ class SwapManager {
       claimAddress: string | undefined;
       refundAddress: string | undefined;
       tree: Types.SwapTree | Types.LiquidSwapTree | undefined;
+      arkTree: VHtlcTaprootTree | undefined;
       timeouts?: Timeouts;
     }> => {
       const res: Partial<ChainSwapDataTypeInsert> = {
@@ -1272,6 +1284,7 @@ class SwapManager {
       let claimAddress: string | undefined;
       let refundAddress: string | undefined;
       let tree: Types.SwapTree | Types.LiquidSwapTree | undefined;
+      let arkTree: VHtlcTaprootTree | undefined;
       let timeouts: Timeouts | undefined;
 
       if (
@@ -1319,6 +1332,7 @@ class SwapManager {
           timeoutBlockDelta,
           isSending ? theirPublicKey : undefined,
           isSending ? undefined : theirPublicKey,
+          isSending ? args.nonInteractiveClaim : undefined,
         );
         await currency.arkNode!.subscription.subscribeAddresses([
           {
@@ -1334,6 +1348,7 @@ class SwapManager {
         res.lockupAddress = vHtlc.vHtlc.address;
         res.timeoutBlockHeight = vHtlc.timeouts.refund;
         res.swapTree = JSON.stringify(vHtlc.vHtlc.swapTree);
+        arkTree = vHtlc.vHtlc.swapTree;
       } else {
         const blockNumber = await currency.provider!.getLocktimeHeight();
         res.timeoutBlockHeight = blockNumber + timeoutBlockDelta;
@@ -1357,6 +1372,7 @@ class SwapManager {
 
       return {
         tree,
+        arkTree,
         serverKeys,
         blindingKey,
         claimAddress,
@@ -1413,7 +1429,7 @@ class SwapManager {
       timeouts: data.timeouts,
       swapTree: data.tree
         ? SwapTreeSerializer.serializeSwapTree(data.tree)
-        : undefined,
+        : data.arkTree,
     });
 
     return {

--- a/proto/ark/service.proto
+++ b/proto/ark/service.proto
@@ -132,11 +132,6 @@ service Service {
       body: "*"
     };
   }
-  rpc IsInvoiceSettled(IsInvoiceSettledRequest) returns (IsInvoiceSettledResponse) {
-    option (google.api.http) = {
-      get: "/v1/invoice/status"
-    };
-  }
   // GetVirtualTxs returns the virtual transactions in hex format for the specified txids.
   rpc GetVirtualTxs(GetVirtualTxsRequest) returns (GetVirtualTxsResponse) {
     option (google.api.http) = {
@@ -177,7 +172,7 @@ service Service {
     };
   };
 
-  // ListDelegates returns delegator tasks filtered by status, paginated by limit/offset.
+  // ListDelegates returns delegate tasks filtered by status, paginated by limit/offset.
   rpc ListDelegates(ListDelegatesRequest) returns (ListDelegatesResponse) {
     option (google.api.http) = {
       get: "/v1/delegates"
@@ -274,8 +269,8 @@ message SignTransactionResponse {
 
 message CreateVHTLCRequest {
   string preimage_hash = 1;
-  string sender_pubkey = 2;
-  string receiver_pubkey = 3;
+  string sender_pubkey = 2; 
+  string receiver_pubkey = 3; 
   // Optional absolute locktime for refund condition (in blocks)
   uint32 refund_locktime = 4;
   // Optional unilateral claim delay (relative timelock)
@@ -366,7 +361,7 @@ message GetVHTLCSpendingTxRequest {
 }
 
 message GetVHTLCSpendingTxResponse {
-  // The fully signed ark transaction in hex format.
+  // The fully signed ark psbt.
   string tx = 1;
 }
 
@@ -391,6 +386,7 @@ message TaprootTree {
   TaprootLeaf unilateral_claim_leaf = 4;
   TaprootLeaf unilateral_refund_leaf = 5;
   TaprootLeaf unilateral_refund_without_boltz_leaf = 6;
+  optional TaprootLeaf non_interactive_claim_leaf = 7;
 }
 
 message TaprootLeaf {
@@ -398,15 +394,11 @@ message TaprootLeaf {
   string output = 2;
 }
 
-message IsInvoiceSettledRequest {
-  string invoice = 1;
+message NonInteractiveClaim {
+  // ark address of the claim tx recipient
+  string claim_address = 1;
 }
 
-message IsInvoiceSettledResponse {
-  bool settled = 1;
-}
-
-// RelativeLocktime represents a relative timelock
 message RelativeLocktime {
   enum LocktimeType {
     LOCKTIME_TYPE_UNSPECIFIED = 0;
@@ -415,11 +407,6 @@ message RelativeLocktime {
   }
   LocktimeType type = 1;
   uint32 value = 2;
-}
-
-message NonInteractiveClaim {
-  // ark address of the claim tx recipient
-  string claim_address = 1;
 }
 
 message Tapscripts {
@@ -527,7 +514,7 @@ message Delegate {
   DelegateIntent intent = 2;
   repeated DelegateForfeitTx forfeit_txs = 3;
   uint64 fee = 4;
-  string delegator_public_key = 5;
+  string delegate_public_key = 5;
   int64 scheduled_at = 6;
   string status = 7;
   string fail_reason = 8;

--- a/proto/ark/service.proto
+++ b/proto/ark/service.proto
@@ -274,8 +274,8 @@ message SignTransactionResponse {
 
 message CreateVHTLCRequest {
   string preimage_hash = 1;
-  string sender_pubkey = 2; 
-  string receiver_pubkey = 3; 
+  string sender_pubkey = 2;
+  string receiver_pubkey = 3;
   // Optional absolute locktime for refund condition (in blocks)
   uint32 refund_locktime = 4;
   // Optional unilateral claim delay (relative timelock)
@@ -284,6 +284,8 @@ message CreateVHTLCRequest {
   RelativeLocktime unilateral_refund_delay = 6;
   // Optional unilateral refund without receiver delay (relative timelock)
   RelativeLocktime unilateral_refund_without_receiver_delay = 7;
+  // Optional non-interactive claim config
+  NonInteractiveClaim non_interactive_claim = 8;
 }
 message CreateVHTLCResponse {
   string id = 1;
@@ -413,6 +415,11 @@ message RelativeLocktime {
   }
   LocktimeType type = 1;
   uint32 value = 2;
+}
+
+message NonInteractiveClaim {
+  // ark address of the claim tx recipient
+  string claim_address = 1;
 }
 
 message Tapscripts {

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -4016,6 +4016,7 @@
         "properties": {
           "id": {
             "type": "string",
+            "maxLength": 255,
             "description": "Identifier for the extra fee"
           },
           "percentage": {
@@ -4098,6 +4099,7 @@
         "properties": {
           "url": {
             "type": "string",
+            "maxLength": 1024,
             "description": "URL that should be called. Only HTTPS is allowed"
           },
           "hashSwapId": {
@@ -4464,6 +4466,18 @@
           }
         }
       },
+      "NonInteractiveClaim": {
+        "type": "object",
+        "required": [
+          "claimAddress"
+        ],
+        "properties": {
+          "claimAddress": {
+            "type": "string",
+            "description": "Ark address that has to be paid by the transaction claiming the VHTLC"
+          }
+        }
+      },
       "ReverseRequest": {
         "type": "object",
         "required": [
@@ -4563,6 +4577,14 @@
           },
           "extraFees": {
             "$ref": "#/components/schemas/ExtraFees"
+          },
+          "nonInteractiveClaim": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NonInteractiveClaim"
+              }
+            ],
+            "description": "Enables the non-interactive claim path of the VHTLC. Only allowed for swaps to ARK"
           }
         }
       },
@@ -4840,6 +4862,14 @@
           },
           "extraFees": {
             "$ref": "#/components/schemas/ExtraFees"
+          },
+          "nonInteractiveClaim": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NonInteractiveClaim"
+              }
+            ],
+            "description": "Enables the non-interactive claim path of the VHTLC. Only allowed for swaps to ARK"
           }
         }
       },

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -4005,6 +4005,9 @@
           },
           "unilateralRefundWithoutBoltzLeaf": {
             "$ref": "#/components/schemas/SwapTreeLeaf"
+          },
+          "nonInteractiveClaimLeaf": {
+            "$ref": "#/components/schemas/SwapTreeLeaf"
           }
         }
       },

--- a/test/integration/chain/ArkClient.spec.ts
+++ b/test/integration/chain/ArkClient.spec.ts
@@ -38,6 +38,19 @@ describe('ArkClient', () => {
     expect(getHexBuffer(info.pubkey)).toEqual(arkClient.pubkey);
   });
 
+  test('should set signerPubkey and addrPrefix after connecting', async () => {
+    await arkClient.connect(bitcoinClient);
+
+    const info = await arkClient.getInfo();
+    expect(arkClient.signerPubkey).toEqual(getHexBuffer(info.signerPubkey));
+    expect(arkClient.addrPrefix).toEqual(info.addrPrefix);
+
+    const { address } = await arkClient.getAddress();
+    const decoded = ArkClient.decodeAddress(address);
+    expect(decoded.prefix).toEqual(arkClient.addrPrefix);
+    expect(arkClient.isOwnServerKey(decoded.serverPubKey)).toEqual(true);
+  });
+
   test('should get block height', async () => {
     const blockHeight = await arkClient.getBlockHeight();
     expect(blockHeight).toBeGreaterThan(0);
@@ -265,6 +278,7 @@ describe('ArkClient', () => {
           'tark1qr340xg400jtxat9hdd0ungyu6s05zjtdf85uj9smyzxshf98ndakjpdlzx4q6n5was20sqf5kff8999rupjsl2ptlz3nqtkl6hv27fvrc05ag',
         ),
       ).toEqual({
+        prefix: 'tark',
         serverPubKey: getHexBuffer(
           'e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdb',
         ),

--- a/test/integration/swap/UtxoNursery.spec.ts
+++ b/test/integration/swap/UtxoNursery.spec.ts
@@ -693,7 +693,8 @@ describe('UtxoNursery', () => {
             amount: BigInt(created.claimDetails.amount!),
             privateKey: claimKeys.privateKey,
             swapTree: SwapTreeSerializer.deserializeSwapTree(
-              created.claimDetails.swapTree!,
+              created.claimDetails
+                .swapTree! as SwapTreeSerializer.SerializedTree,
             ),
             internalKey: Musig.create(claimKeys.privateKey, [
               getHexBuffer(created.claimDetails.serverPublicKey!),

--- a/test/unit/api/Utils.spec.ts
+++ b/test/unit/api/Utils.spec.ts
@@ -108,6 +108,42 @@ describe('Utils', () => {
         optionalChecks,
       ),
     ).toEqual({ test: 'test' });
+
+    const objectChecks: ApiArgument[] = [
+      {
+        name: 'test',
+        type: 'object',
+        optional: true,
+      },
+    ];
+
+    // Null is not a valid object
+    expect(() =>
+      validateRequest(
+        {
+          test: null,
+        },
+        objectChecks,
+      ),
+    ).toThrow(`invalid parameter: ${objectChecks[0].name}`);
+
+    // Objects and arrays are valid objects
+    expect(
+      validateRequest(
+        {
+          test: { some: 'data' },
+        },
+        objectChecks,
+      ),
+    ).toEqual({ test: { some: 'data' } });
+    expect(
+      validateRequest(
+        {
+          test: ['some', 'data'],
+        },
+        objectChecks,
+      ),
+    ).toEqual({ test: ['some', 'data'] });
   });
 
   describe('validateArray', () => {

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -188,6 +188,8 @@ describe('SwapRouter', () => {
   const validMetadata = 'deadbeef';
   const validMetadataBuffer = getHexBuffer(validMetadata);
   const oversizedMetadata = '00'.repeat(1025);
+  const arkClaimAddress =
+    'tark1qr340xg400jtxat9hdd0ungyu6s05zjtdf85uj9smyzxshf98ndakjpdlzx4q6n5was20sqf5kff8999rupjsl2ptlz3nqtkl6hv27fvrc05ag';
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -1533,6 +1535,27 @@ describe('SwapRouter', () => {
   claimPublicKey: '0011',
   metadata: oversizedMetadata,
 }}
+    ${'invalid parameter: nonInteractiveClaim'} | ${{
+  to: 'L-BTC',
+  from: 'BTC',
+  preimageHash: '00',
+  claimPublicKey: '0011',
+  nonInteractiveClaim: 'notAnObject',
+}}
+    ${'invalid parameter: nonInteractiveClaim'} | ${{
+  to: 'L-BTC',
+  from: 'BTC',
+  preimageHash: '00',
+  claimPublicKey: '0011',
+  nonInteractiveClaim: null,
+}}
+    ${'undefined parameter: claimAddress'} | ${{
+  to: 'L-BTC',
+  from: 'BTC',
+  preimageHash: '00',
+  claimPublicKey: '0011',
+  nonInteractiveClaim: {},
+}}
   `(
     'should not create reverse swaps with invalid parameters ($error)',
     async ({ body, error }) => {
@@ -1726,6 +1749,32 @@ describe('SwapRouter', () => {
       extraFees: reqBody.extraFees,
       preimageHash: getHexBuffer(reqBody.preimageHash),
       claimPublicKey: getHexBuffer(reqBody.claimPublicKey),
+    });
+  });
+
+  test('should create reverse swaps with nonInteractiveClaim', async () => {
+    const reqBody = {
+      to: 'ARK',
+      from: 'BTC',
+      claimPublicKey: '21',
+      preimageHash: getHexString(randomBytes(32)),
+      nonInteractiveClaim: {
+        claimAddress: arkClaimAddress,
+      },
+    };
+    const res = mockResponse();
+
+    await swapRouter['createReverse'](mockRequest(reqBody), res);
+
+    expect(service.createReverseSwap).toHaveBeenCalledTimes(1);
+    expect(service.createReverseSwap).toHaveBeenCalledWith({
+      pairId: 'L-BTC/BTC',
+      prepayMinerFee: false,
+      orderSide: OrderSide.BUY,
+      version: SwapVersion.Taproot,
+      preimageHash: getHexBuffer(reqBody.preimageHash),
+      claimPublicKey: getHexBuffer(reqBody.claimPublicKey),
+      nonInteractiveClaim: reqBody.nonInteractiveClaim,
     });
   });
 
@@ -2231,6 +2280,24 @@ describe('SwapRouter', () => {
   preimageHash: '32392e7849d736455b18707052e48d9f204d1575ecf979f19ae12919a32c0e4c',
   metadata: oversizedMetadata,
 }}
+    ${'invalid parameter: nonInteractiveClaim'} | ${{
+  to: 'L-BTC',
+  from: 'BTC',
+  preimageHash: '32392e7849d736455b18707052e48d9f204d1575ecf979f19ae12919a32c0e4c',
+  nonInteractiveClaim: 'notAnObject',
+}}
+    ${'invalid parameter: nonInteractiveClaim'} | ${{
+  to: 'L-BTC',
+  from: 'BTC',
+  preimageHash: '32392e7849d736455b18707052e48d9f204d1575ecf979f19ae12919a32c0e4c',
+  nonInteractiveClaim: null,
+}}
+    ${'undefined parameter: claimAddress'} | ${{
+  to: 'L-BTC',
+  from: 'BTC',
+  preimageHash: '32392e7849d736455b18707052e48d9f204d1575ecf979f19ae12919a32c0e4c',
+  nonInteractiveClaim: {},
+}}
   `(
     'should not create chain swaps with invalid parameters ($error)',
     async ({ body, error }) => {
@@ -2380,6 +2447,34 @@ describe('SwapRouter', () => {
       preimageHash: getHexBuffer(reqBody.preimageHash),
       claimPublicKey: getHexBuffer(reqBody.claimPublicKey),
       refundPublicKey: getHexBuffer(reqBody.refundPublicKey),
+    });
+  });
+
+  test('should create chain swaps with nonInteractiveClaim', async () => {
+    const reqBody = {
+      to: 'ARK',
+      from: 'BTC',
+      userLockAmount: 123,
+      claimPublicKey: '21',
+      refundPublicKey: '12',
+      preimageHash: getHexString(randomBytes(32)),
+      nonInteractiveClaim: {
+        claimAddress: arkClaimAddress,
+      },
+    };
+    const res = mockResponse();
+
+    await swapRouter['createChain'](mockRequest(reqBody), res);
+
+    expect(service.createChainSwap).toHaveBeenCalledTimes(1);
+    expect(service.createChainSwap).toHaveBeenCalledWith({
+      pairId: 'L-BTC/BTC',
+      orderSide: OrderSide.BUY,
+      userLockAmount: reqBody.userLockAmount,
+      preimageHash: getHexBuffer(reqBody.preimageHash),
+      claimPublicKey: getHexBuffer(reqBody.claimPublicKey),
+      refundPublicKey: getHexBuffer(reqBody.refundPublicKey),
+      nonInteractiveClaim: reqBody.nonInteractiveClaim,
     });
   });
 
@@ -2827,17 +2922,28 @@ describe('SwapRouter', () => {
     });
 
     test.each`
-      error                              | data
-      ${'undefined parameter: url'}      | ${{}}
-      ${'invalid parameter: url'}        | ${{ url: 1 }}
-      ${'invalid parameter: status'}     | ${{ url: 'http', status: 'correct' }}
-      ${'invalid parameter: hashSwapId'} | ${{ url: 'http', hashSwapId: 'correct' }}
+      error                               | data
+      ${'undefined parameter: url'}       | ${{}}
+      ${'invalid parameter: url'}         | ${{ url: 1 }}
+      ${'invalid parameter: webhook.url'} | ${{ url: '' }}
+      ${'invalid parameter: webhook.url'} | ${{ url: 'a'.repeat(1025) }}
+      ${'invalid parameter: status'}      | ${{ url: 'http', status: 'correct' }}
+      ${'invalid parameter: hashSwapId'}  | ${{ url: 'http', hashSwapId: 'correct' }}
     `(
       'should not parse webhook with invalid parameters ($error)',
       ({ error, data }) => {
         expect(() => swapRouter['parseWebHook'](data)).toThrow(error);
       },
     );
+
+    test('should parse webhook with url of maximal length', () => {
+      const data = {
+        url: 'a'.repeat(1024),
+        hashSwapId: false,
+      };
+
+      expect(swapRouter['parseWebHook'](data)).toEqual(data);
+    });
 
     describe('status', () => {
       test.each`
@@ -2975,6 +3081,59 @@ describe('SwapRouter', () => {
         ).toThrow(ApiErrors.INVALID_EXTRA_FEES_ID(id));
       },
     );
+
+    test.each`
+      name          | id
+      ${'empty'}    | ${''}
+      ${'too long'} | ${'a'.repeat(256)}
+    `('should reject id that is $name', ({ id }) => {
+      expect(() => swapRouter['parseExtraFees']({ id, percentage: 1 })).toThrow(
+        ApiErrors.INVALID_EXTRA_FEES_ID(id),
+      );
+    });
+
+    test('should parse extra fees with id of maximal length', () => {
+      const data = {
+        id: 'a'.repeat(255),
+        percentage: 1,
+      };
+
+      expect(swapRouter['parseExtraFees'](data)).toEqual(data);
+    });
+  });
+
+  describe('parseNonInteractiveClaim', () => {
+    test('should parse non-interactive claims', () => {
+      const data = {
+        claimAddress: arkClaimAddress,
+      };
+
+      expect(swapRouter['parseNonInteractiveClaim'](data)).toEqual(data);
+    });
+
+    test('should omit extra data', () => {
+      expect(
+        swapRouter['parseNonInteractiveClaim']({
+          claimAddress: arkClaimAddress,
+          some: 'extra',
+        }),
+      ).toEqual({ claimAddress: arkClaimAddress });
+    });
+
+    test('should return undefined when input data is undefined', () => {
+      expect(swapRouter['parseNonInteractiveClaim'](undefined)).toBeUndefined();
+    });
+
+    test.each`
+      name                            | error                                                    | data
+      ${'missing claimAddress'}       | ${'undefined parameter: claimAddress'}                   | ${{}}
+      ${'claimAddress of wrong type'} | ${'invalid parameter: claimAddress'}                     | ${{ claimAddress: 21 }}
+      ${'garbage claimAddress'}       | ${'invalid parameter: nonInteractiveClaim.claimAddress'} | ${{ claimAddress: 'notAnAddress' }}
+      ${'bech32 claimAddress'}        | ${'invalid parameter: nonInteractiveClaim.claimAddress'} | ${{ claimAddress: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4' }}
+      ${'truncated claimAddress'}     | ${'invalid parameter: nonInteractiveClaim.claimAddress'} | ${{ claimAddress: arkClaimAddress.slice(0, -4) }}
+    `('should throw for $name', ({ error, data }) => {
+      expect(() => swapRouter['parseNonInteractiveClaim'](data)).toThrow(error);
+    });
   });
 
   describe('getReferralFromHeader', () => {

--- a/test/unit/chain/ArkClient.spec.ts
+++ b/test/unit/chain/ArkClient.spec.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import Logger from '../../../lib/Logger';
+import { getHexBuffer, getHexString } from '../../../lib/Utils';
 import ArkClient from '../../../lib/chain/ArkClient';
 
 describe('ArkClient', () => {
@@ -64,5 +65,127 @@ describe('ArkClient', () => {
           mockSidecar as any,
         ),
     ).toThrow('could not find configured macaroon file for Fulmine ARK');
+  });
+
+  describe('createVHtlc', () => {
+    const blockHeight = 100;
+    const refundDelay = 21;
+
+    const preimageHash = getHexBuffer(
+      '6b0d0275c597a18cfcc23261a62e095e2ba12ac5c866823d2926912806a5b10a',
+    );
+    const claimPublicKey = getHexBuffer(
+      '026c94d2958888e70fd32349b3c195803976e0865a54ab1755f19c2c820fcbafa8',
+    );
+
+    const createClient = () => {
+      const client = new ArkClient(
+        Logger.disabledLogger,
+        {
+          host: '127.0.0.1',
+          port: 7000,
+        },
+        mockSidecar as any,
+      );
+      client['chainClient'] = {
+        symbol: 'BTC',
+        getBlockchainInfo: jest.fn().mockResolvedValue({ blocks: blockHeight }),
+      } as any;
+
+      const grpcClient = {
+        createVhtlc: jest.fn((_req, _metadata, callback) =>
+          callback(null, { address: 'arkAddress' }),
+        ),
+      };
+      client['client'] = grpcClient as any;
+
+      return { client, grpcClient };
+    };
+
+    test('should pass nonInteractiveClaim in the request', async () => {
+      const { client, grpcClient } = createClient();
+      const nonInteractiveClaim = { claimAddress: 'tark1address' };
+
+      const { timeouts } = await client.createVHtlc(
+        preimageHash,
+        refundDelay,
+        claimPublicKey,
+        undefined,
+        nonInteractiveClaim,
+      );
+
+      expect(grpcClient.createVhtlc).toHaveBeenCalledTimes(1);
+      const req = grpcClient.createVhtlc.mock.calls[0][0];
+      expect(req.nonInteractiveClaim).toEqual(nonInteractiveClaim);
+      expect(req.receiverPubkey).toEqual(getHexString(claimPublicKey));
+      expect(req.senderPubkey).toEqual('');
+      expect(req.refundLocktime).toEqual(blockHeight + refundDelay);
+
+      expect(timeouts.refund).toEqual(blockHeight + refundDelay);
+    });
+
+    test('should leave nonInteractiveClaim undefined when not set', async () => {
+      const { client, grpcClient } = createClient();
+
+      await client.createVHtlc(preimageHash, refundDelay, claimPublicKey);
+
+      expect(grpcClient.createVhtlc).toHaveBeenCalledTimes(1);
+      expect(
+        grpcClient.createVhtlc.mock.calls[0][0].nonInteractiveClaim,
+      ).toBeUndefined();
+    });
+  });
+
+  describe('isOwnServerKey', () => {
+    const xOnly =
+      'e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdb';
+    const otherXOnly =
+      'aa5799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdb';
+
+    const createClient = (signerPubkey: Buffer) => {
+      const client = new ArkClient(
+        Logger.disabledLogger,
+        {
+          host: '127.0.0.1',
+          port: 7000,
+        },
+        mockSidecar as any,
+      );
+      client.signerPubkey = signerPubkey;
+
+      return client;
+    };
+
+    test.each`
+      name                                             | signerPubkey          | serverPubKey          | expected
+      ${'x-only signer and x-only key'}                | ${xOnly}              | ${xOnly}              | ${true}
+      ${'compressed even signer and x-only key'}       | ${`02${xOnly}`}       | ${xOnly}              | ${true}
+      ${'compressed odd signer and x-only key'}        | ${`03${xOnly}`}       | ${xOnly}              | ${true}
+      ${'x-only signer and compressed even key'}       | ${xOnly}              | ${`02${xOnly}`}       | ${true}
+      ${'x-only signer and compressed odd key'}        | ${xOnly}              | ${`03${xOnly}`}       | ${true}
+      ${'compressed signer and compressed key'}        | ${`02${xOnly}`}       | ${`02${xOnly}`}       | ${true}
+      ${'compressed keys with different parity bytes'} | ${`02${xOnly}`}       | ${`03${xOnly}`}       | ${true}
+      ${'different x-only keys'}                       | ${xOnly}              | ${otherXOnly}         | ${false}
+      ${'different compressed keys'}                   | ${`02${xOnly}`}       | ${`02${otherXOnly}`}  | ${false}
+      ${'empty signer key'}                            | ${''}                 | ${xOnly}              | ${false}
+      ${'empty key'}                                   | ${xOnly}              | ${''}                 | ${false}
+      ${'truncated key'}                               | ${xOnly}              | ${xOnly.slice(0, 62)} | ${false}
+      ${'truncated signer key'}                        | ${xOnly.slice(0, 62)} | ${xOnly}              | ${false}
+    `(
+      'should return $expected for $name',
+      ({ signerPubkey, serverPubKey, expected }) => {
+        expect(
+          createClient(getHexBuffer(signerPubkey)).isOwnServerKey(
+            getHexBuffer(serverPubKey),
+          ),
+        ).toEqual(expected);
+      },
+    );
+
+    test('should return false when signer key is not initialized', () => {
+      const client = createClient(undefined as any);
+
+      expect(client.isOwnServerKey(getHexBuffer(xOnly))).toEqual(false);
+    });
   });
 });

--- a/test/unit/chain/ArkSubscription.spec.ts
+++ b/test/unit/chain/ArkSubscription.spec.ts
@@ -73,6 +73,7 @@ describe('ArkSubscription', () => {
         }
 
         return {
+          prefix: 'tark',
           serverPubKey: Buffer.alloc(32, 2),
           tweakedPubKey,
         };
@@ -246,6 +247,7 @@ describe('ArkSubscription', () => {
         }
 
         return {
+          prefix: 'tark',
           serverPubKey: Buffer.alloc(32, 2),
           tweakedPubKey,
         };

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -4389,6 +4389,101 @@ describe('Service', () => {
     });
   });
 
+  describe('checkNonInteractiveClaimSupported', () => {
+    const claimAddress =
+      'tark1qr340xg400jtxat9hdd0ungyu6s05zjtdf85uj9smyzxshf98ndakjpdlzx4q6n5was20sqf5kff8999rupjsl2ptlz3nqtkl6hv27fvrc05ag';
+    const serverPubKey = getHexBuffer(
+      '02e35799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdb',
+    );
+
+    const createArkCurrency = (signerPubkey: Buffer, addrPrefix: string) => {
+      const arkNode = new ArkClient(
+        Logger.disabledLogger,
+        { host: '127.0.0.1', port: 9999 } as any,
+        {} as any,
+      );
+      arkNode.signerPubkey = signerPubkey;
+      arkNode.addrPrefix = addrPrefix;
+
+      return {
+        arkNode,
+        symbol: ArkClient.symbol,
+        type: CurrencyType.Ark,
+      } as any;
+    };
+
+    test('should do nothing when no non-interactive claim is set', () => {
+      expect(() =>
+        service['checkNonInteractiveClaimSupported'](
+          'BTC',
+          currencies.get('BTC')!,
+          undefined,
+        ),
+      ).not.toThrow();
+    });
+
+    test('should throw when the sending currency is not Ark', () => {
+      expect(() =>
+        service['checkNonInteractiveClaimSupported'](
+          'BTC',
+          currencies.get('BTC')!,
+          { claimAddress },
+        ),
+      ).toThrow(ApiErrors.UNSUPPORTED_PARAMETER('BTC', 'nonInteractiveClaim'));
+    });
+
+    test('should accept addresses of the same network and server', () => {
+      expect(() =>
+        service['checkNonInteractiveClaimSupported'](
+          ArkClient.symbol,
+          createArkCurrency(serverPubKey, 'tark'),
+          { claimAddress },
+        ),
+      ).not.toThrow();
+    });
+
+    test('should throw when the address cannot be decoded', () => {
+      expect(() =>
+        service['checkNonInteractiveClaimSupported'](
+          ArkClient.symbol,
+          createArkCurrency(serverPubKey, 'tark'),
+          { claimAddress: 'notanaddress' },
+        ),
+      ).toThrow(
+        ApiErrors.INVALID_PARAMETER('nonInteractiveClaim.claimAddress'),
+      );
+    });
+
+    test('should throw when the address is for a different network', () => {
+      expect(() =>
+        service['checkNonInteractiveClaimSupported'](
+          ArkClient.symbol,
+          createArkCurrency(serverPubKey, 'ark'),
+          { claimAddress },
+        ),
+      ).toThrow(
+        ApiErrors.ARK_ADDRESS_WRONG_NETWORK('nonInteractiveClaim.claimAddress'),
+      );
+    });
+
+    test('should throw when the address is for a different server', () => {
+      expect(() =>
+        service['checkNonInteractiveClaimSupported'](
+          ArkClient.symbol,
+          createArkCurrency(
+            getHexBuffer(
+              '02aa5799157be4b37565bb5afe4d04e6a0fa0a4b6a4f4e48b0d904685d253cdbdb',
+            ),
+            'tark',
+          ),
+          { claimAddress },
+        ),
+      ).toThrow(
+        ApiErrors.ARK_ADDRESS_WRONG_SERVER('nonInteractiveClaim.claimAddress'),
+      );
+    });
+  });
+
   describe('getPair', () => {
     const getPair = service['getPair'];
 

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -840,7 +840,7 @@ describe('Service', () => {
       }),
   } as any as Sidecar;
 
-  const createService = () =>
+  const createService = (configOverrides: Record<string, any> = {}) =>
     new Service(
       Logger.disabledLogger,
       undefined,
@@ -851,6 +851,7 @@ describe('Service', () => {
         swap: {},
         pairs: [],
         currencies: [],
+        ...configOverrides,
       } as any as ConfigType,
       mockedWalletManager(),
       new NodeSwitch(Logger.disabledLogger),
@@ -4412,9 +4413,11 @@ describe('Service', () => {
       } as any;
     };
 
+    const enabledService = createService({ nonInteractiveClaims: true });
+
     test('should do nothing when no non-interactive claim is set', () => {
       expect(() =>
-        service['checkNonInteractiveClaimSupported'](
+        enabledService['checkNonInteractiveClaimSupported'](
           'BTC',
           currencies.get('BTC')!,
           undefined,
@@ -4424,7 +4427,7 @@ describe('Service', () => {
 
     test('should throw when the sending currency is not Ark', () => {
       expect(() =>
-        service['checkNonInteractiveClaimSupported'](
+        enabledService['checkNonInteractiveClaimSupported'](
           'BTC',
           currencies.get('BTC')!,
           { claimAddress },
@@ -4434,7 +4437,7 @@ describe('Service', () => {
 
     test('should accept addresses of the same network and server', () => {
       expect(() =>
-        service['checkNonInteractiveClaimSupported'](
+        enabledService['checkNonInteractiveClaimSupported'](
           ArkClient.symbol,
           createArkCurrency(serverPubKey, 'tark'),
           { claimAddress },
@@ -4444,7 +4447,7 @@ describe('Service', () => {
 
     test('should throw when the address cannot be decoded', () => {
       expect(() =>
-        service['checkNonInteractiveClaimSupported'](
+        enabledService['checkNonInteractiveClaimSupported'](
           ArkClient.symbol,
           createArkCurrency(serverPubKey, 'tark'),
           { claimAddress: 'notanaddress' },
@@ -4456,7 +4459,7 @@ describe('Service', () => {
 
     test('should throw when the address is for a different network', () => {
       expect(() =>
-        service['checkNonInteractiveClaimSupported'](
+        enabledService['checkNonInteractiveClaimSupported'](
           ArkClient.symbol,
           createArkCurrency(serverPubKey, 'ark'),
           { claimAddress },
@@ -4468,7 +4471,7 @@ describe('Service', () => {
 
     test('should throw when the address is for a different server', () => {
       expect(() =>
-        service['checkNonInteractiveClaimSupported'](
+        enabledService['checkNonInteractiveClaimSupported'](
           ArkClient.symbol,
           createArkCurrency(
             getHexBuffer(
@@ -4481,6 +4484,40 @@ describe('Service', () => {
       ).toThrow(
         ApiErrors.ARK_ADDRESS_WRONG_SERVER('nonInteractiveClaim.claimAddress'),
       );
+    });
+
+    describe('nonInteractiveClaims disabled', () => {
+      test('should throw when a non-interactive claim is set with the default config', () => {
+        expect(() =>
+          service['checkNonInteractiveClaimSupported'](
+            ArkClient.symbol,
+            createArkCurrency(serverPubKey, 'tark'),
+            { claimAddress },
+          ),
+        ).toThrow(Errors.NON_INTERACTIVE_CLAIMS_DISABLED().message);
+      });
+
+      test('should throw when a non-interactive claim is set with the flag disabled explicitly', () => {
+        const disabledService = createService({ nonInteractiveClaims: false });
+
+        expect(() =>
+          disabledService['checkNonInteractiveClaimSupported'](
+            ArkClient.symbol,
+            createArkCurrency(serverPubKey, 'tark'),
+            { claimAddress },
+          ),
+        ).toThrow(Errors.NON_INTERACTIVE_CLAIMS_DISABLED().message);
+      });
+
+      test('should do nothing when no non-interactive claim is set', () => {
+        expect(() =>
+          service['checkNonInteractiveClaimSupported'](
+            'BTC',
+            currencies.get('BTC')!,
+            undefined,
+          ),
+        ).not.toThrow();
+      });
     });
   });
 

--- a/test/unit/swap/SwapManager.spec.ts
+++ b/test/unit/swap/SwapManager.spec.ts
@@ -1832,6 +1832,199 @@ describe('SwapManager', () => {
     );
   });
 
+  describe('ARK swaps', () => {
+    const preimageHash = getHexBuffer(
+      '6b0d0275c597a18cfcc23261a62e095e2ba12ac5c866823d2926912806a5b10a',
+    );
+    const claimKey = getHexBuffer(
+      '026c94d2958888e70fd32349b3c195803976e0865a54ab1755f19c2c820fcbafa8',
+    );
+    const refundKey = getHexBuffer(
+      '03f1c589378d79bb4a38be80bd085f5454a07d7f5c515fa0752f1b443816442ac2',
+    );
+
+    const nonInteractiveClaim = {
+      claimAddress: 'tark1claimAddress',
+    };
+
+    const arkTree = {
+      claimLeaf: { version: 192, output: 'arkClaimLeaf' },
+      refundLeaf: { version: 192, output: 'arkRefundLeaf' },
+    } as any;
+    const timeouts = {
+      refund: 543,
+      unilateralClaim: 16,
+      unilateralRefund: 32,
+      unilateralRefundWithoutReceiver: 64,
+    };
+
+    let arkNode: any;
+
+    beforeEach(() => {
+      arkNode = {
+        symbol: 'ARK',
+        pubkey: Buffer.alloc(33, 3),
+        createVHtlc: jest.fn().mockResolvedValue({
+          vHtlc: {
+            id: 'vHtlcId',
+            address: 'arkLockupAddress',
+            swapTree: arkTree,
+          },
+          timeouts,
+        }),
+        subscription: {
+          subscribeAddresses: jest.fn().mockResolvedValue(undefined),
+        },
+      };
+      manager['currencies'].set('ARK', {
+        arkNode,
+        symbol: 'ARK',
+        type: CurrencyType.Ark,
+        lndClients: new Map(),
+      } as any as Currency);
+
+      ChainSwapRepository.addChainSwap = jest.fn().mockResolvedValue(undefined);
+    });
+
+    test('should create reverse swaps to ARK with nonInteractiveClaim', async () => {
+      const onchainTimeoutBlockDelta = 140;
+
+      const reverseSwap = await manager.createReverseSwap({
+        preimageHash,
+        nonInteractiveClaim,
+        onchainTimeoutBlockDelta,
+        orderSide: OrderSide.BUY,
+        baseCurrency: 'ARK',
+        quoteCurrency: 'BTC',
+        onchainAmount: 8,
+        percentageFee: 1,
+        holdInvoiceAmount: 10,
+        lightningTimeoutBlockDelta: 143,
+        claimCovenant: false,
+        claimPublicKey: claimKey,
+        version: SwapVersion.Taproot,
+      });
+
+      expect(arkNode.createVHtlc).toHaveBeenCalledTimes(1);
+      expect(arkNode.createVHtlc).toHaveBeenCalledWith(
+        preimageHash,
+        onchainTimeoutBlockDelta,
+        claimKey,
+        undefined,
+        nonInteractiveClaim,
+      );
+
+      expect(reverseSwap).toMatchObject({
+        swapTree: arkTree,
+        timeoutBlockHeights: timeouts,
+        lockupAddress: 'arkLockupAddress',
+        refundPublicKey: getHexString(arkNode.pubkey),
+      });
+
+      expect(mockAddReverseSwap).toHaveBeenCalledTimes(1);
+      expect(mockAddReverseSwap).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lockupAddress: 'arkLockupAddress',
+          timeoutBlockHeight: timeouts.refund,
+          redeemScript: JSON.stringify(arkTree),
+        }),
+      );
+
+      expect(arkNode.subscription.subscribeAddresses).toHaveBeenCalledTimes(1);
+      expect(arkNode.subscription.subscribeAddresses).toHaveBeenCalledWith([
+        {
+          address: 'arkLockupAddress',
+          vHtlcId: 'vHtlcId',
+        },
+      ]);
+    });
+
+    test('should create chain swaps sending ARK with nonInteractiveClaim', async () => {
+      const sendingTimeoutBlockDelta = 140;
+
+      const chainSwap = await manager.createChainSwap({
+        preimageHash,
+        nonInteractiveClaim,
+        sendingTimeoutBlockDelta,
+        orderSide: OrderSide.BUY,
+        baseCurrency: 'ARK',
+        quoteCurrency: 'BTC',
+        percentageFee: 1,
+        userLockAmount: 100_000,
+        serverLockAmount: 99_000,
+        acceptZeroConf: false,
+        receivingTimeoutBlockDelta: 150,
+        claimPublicKey: claimKey,
+        refundPublicKey: refundKey,
+      });
+
+      expect(arkNode.createVHtlc).toHaveBeenCalledTimes(1);
+      expect(arkNode.createVHtlc).toHaveBeenCalledWith(
+        preimageHash,
+        sendingTimeoutBlockDelta,
+        claimKey,
+        undefined,
+        nonInteractiveClaim,
+      );
+
+      expect(chainSwap.claimDetails).toMatchObject({
+        timeouts,
+        amount: 99_000,
+        swapTree: arkTree,
+        lockupAddress: 'arkLockupAddress',
+        timeoutBlockHeight: timeouts.refund,
+        serverPublicKey: getHexString(arkNode.pubkey),
+      });
+
+      // The receiving side is a regular serialized swap tree
+      expect(chainSwap.lockupDetails.swapTree).toBeDefined();
+      expect(chainSwap.lockupDetails.swapTree).not.toEqual(arkTree);
+
+      expect(arkNode.subscription.subscribeAddresses).toHaveBeenCalledTimes(1);
+      expect(arkNode.subscription.subscribeAddresses).toHaveBeenCalledWith([
+        {
+          address: 'arkLockupAddress',
+          vHtlcId: 'vHtlcId',
+        },
+      ]);
+    });
+
+    test('should not forward nonInteractiveClaim for chain swaps receiving ARK', async () => {
+      const receivingTimeoutBlockDelta = 150;
+
+      const chainSwap = await manager.createChainSwap({
+        preimageHash,
+        nonInteractiveClaim,
+        receivingTimeoutBlockDelta,
+        orderSide: OrderSide.SELL,
+        baseCurrency: 'ARK',
+        quoteCurrency: 'BTC',
+        percentageFee: 1,
+        userLockAmount: 100_000,
+        serverLockAmount: 99_000,
+        acceptZeroConf: false,
+        sendingTimeoutBlockDelta: 140,
+        claimPublicKey: claimKey,
+        refundPublicKey: refundKey,
+      });
+
+      expect(arkNode.createVHtlc).toHaveBeenCalledTimes(1);
+      expect(arkNode.createVHtlc).toHaveBeenCalledWith(
+        preimageHash,
+        receivingTimeoutBlockDelta,
+        undefined,
+        refundKey,
+        undefined,
+      );
+
+      expect(chainSwap.lockupDetails).toMatchObject({
+        timeouts,
+        swapTree: arkTree,
+        lockupAddress: 'arkLockupAddress',
+      });
+    });
+  });
+
   test('it should get currencies', () => {
     const getCurrencies = manager['getCurrencies'];
 


### PR DESCRIPTION
Supersedes #1422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional non-interactive claim support for ARK reverse and chain swaps (configurable), including OpenAPI modeling and server-side forwarding/claim handling.
* **Bug Fixes**
  * Rejects `null` for object-typed request parameters.
  * Tightens validation for webhook URLs, extra-fee IDs, and non-interactive claim decoding with ARK network/server checks.
  * Limits incoming request body size.
* **Documentation**
  * Updated API/OpenAPI and configuration documentation for the new non-interactive claim fields and constraints.
* **Tests**
  * Expanded unit and integration coverage for claim validation and ARK address/taproot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->