### PR TITLE
fix: detect claim preimage from witness by hash

### DIFF
--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -1,10 +1,6 @@
+import { sha256 } from '@noble/hashes/sha2.js';
 import type { Transaction } from '@scure/btc-signer';
-import {
-  Scripts,
-  SwapTreeSerializer,
-  detectPreimage,
-  detectSwap,
-} from 'boltz-core';
+import { Scripts, SwapTreeSerializer, detectSwap } from 'boltz-core';
 import type { Transaction as LiquidTransaction } from 'liquidjs-lib';
 import { Op } from 'sequelize';
 import {
@@ -367,22 +363,31 @@ class UtxoNursery extends TypedEventEmitter<{
       }
     }
 
-    const inputs = TxView.of(transaction).inputs;
-    for (let vin = 0; vin < inputs.length; vin += 1) {
-      const input = inputs[vin];
-
+    for (const input of TxView.of(transaction).inputs) {
       await Promise.all([
-        this.checkReverseSwapClaim(chainClient, transaction, vin, input),
-        this.checkChainSwapClaim(chainClient, transaction, vin, input),
+        this.checkReverseSwapClaim(chainClient, transaction, input),
+        this.checkChainSwapClaim(chainClient, transaction, input),
       ]);
     }
+  };
+
+  private findWitnessPreimage = (
+    input: { witness?: Uint8Array[] },
+    preimageHash: string,
+  ): Buffer | undefined => {
+    const hash = getHexBuffer(preimageHash);
+    const preimage = (input.witness ?? []).find(
+      (element) =>
+        element.length === 32 && Buffer.from(sha256(element)).equals(hash),
+    );
+
+    return preimage !== undefined ? Buffer.from(preimage) : undefined;
   };
 
   private checkReverseSwapClaim = async (
     chainClient: IChainClient,
     transaction: Transaction | LiquidTransaction,
-    inputIndex: number,
-    input: { txid: string; index: number },
+    input: { txid: string; index: number; witness?: Uint8Array[] },
   ) => {
     const reverseSwap = await ReverseSwapRepository.getReverseSwap({
       status: {
@@ -400,18 +405,26 @@ class UtxoNursery extends TypedEventEmitter<{
       return;
     }
 
-    this.logger.verbose(
-      `Found ${chainClient.symbol} claim transaction of Reverse Swap ${
-        reverseSwap.id
-      }: ${TxView.of(transaction).id}`,
-    );
+    const preimage = reverseSwap.preimage
+      ? getHexBuffer(reverseSwap.preimage)
+      : this.findWitnessPreimage(input, reverseSwap.preimageHash);
 
-    this.emit('reverseSwap.claimed', {
-      reverseSwap,
-      preimage: reverseSwap.preimage
-        ? getHexBuffer(reverseSwap.preimage)
-        : Buffer.from(detectPreimage(inputIndex, transaction)),
-    });
+    if (preimage !== undefined) {
+      this.logger.verbose(
+        `Found ${chainClient.symbol} claim transaction of Reverse Swap ${
+          reverseSwap.id
+        }: ${TxView.of(transaction).id}`,
+      );
+
+      this.emit('reverseSwap.claimed', {
+        reverseSwap,
+        preimage,
+      });
+    } else {
+      this.logger.debug(
+        `Not handling ${chainClient.symbol} transaction ${TxView.of(transaction).id} as claim of Reverse Swap ${reverseSwap.id} because it does not reveal the preimage`,
+      );
+    }
 
     await ClaimTransactionRepository.persistTransaction(this.logger, {
       swapId: reverseSwap.id,
@@ -423,7 +436,6 @@ class UtxoNursery extends TypedEventEmitter<{
   private checkChainSwapClaim = async (
     chainClient: IChainClient,
     transaction: Transaction | LiquidTransaction,
-    inputIndex: number,
     input: { txid: string; index: number; witness?: Uint8Array[] },
   ) => {
     const swap = await ChainSwapRepository.getChainSwapByData(
@@ -446,8 +458,8 @@ class UtxoNursery extends TypedEventEmitter<{
     }
 
     // Only persist user claims: the user claims by spending the server's lockup (sendingData).
-    // Spends of the user's lockup (receivingData) are Boltz's own claims. This runs before
-    // the witness-length filter so cooperative user claims (witness length 1) are persisted too.
+    // Spends of the user's lockup (receivingData) are Boltz's own claims. This is independent
+    // of the preimage check so cooperative user claims (which reveal nothing) are persisted too.
     const isUserClaim =
       input.txid === swap.sendingData.transactionId &&
       input.index === swap.sendingData.transactionVout;
@@ -463,27 +475,24 @@ class UtxoNursery extends TypedEventEmitter<{
       });
     };
 
-    if ((input.witness?.length ?? 0) !== 4) {
-      this.logger.debug(
-        `Not scanning ${chainClient.symbol} transaction ${TxView.of(transaction).id} for claims because it is a cooperative claim or refund transaction`,
+    const preimage = this.findWitnessPreimage(input, swap.preimageHash);
+
+    if (preimage !== undefined) {
+      this.logger.verbose(
+        `Found ${chainClient.symbol} claim transaction of Chain Swap ${
+          swap.chainSwap.id
+        }: ${TxView.of(transaction).id}`,
       );
 
-      await persistUserClaim();
-      return;
+      this.emit('chainSwap.claimed', {
+        swap,
+        preimage,
+      });
+    } else {
+      this.logger.debug(
+        `Not handling ${chainClient.symbol} transaction ${TxView.of(transaction).id} as claim of Chain Swap ${swap.chainSwap.id} because it does not reveal the preimage`,
+      );
     }
-
-    this.logger.verbose(
-      `Found ${chainClient.symbol} claim transaction of Chain Swap ${
-        swap.chainSwap.id
-      }: ${TxView.of(transaction).id}`,
-    );
-
-    this.emit('chainSwap.claimed', {
-      swap,
-      preimage: swap.preimage
-        ? getHexBuffer(swap.preimage)
-        : Buffer.from(detectPreimage(inputIndex, transaction)),
-    });
 
     await persistUserClaim();
   };

--- a/test/integration/swap/UtxoNursery.spec.ts
+++ b/test/integration/swap/UtxoNursery.spec.ts
@@ -2,7 +2,13 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type { Transaction } from '@scure/btc-signer';
 import bolt11 from 'bolt11';
-import { OutputType } from 'boltz-core';
+import type { ClaimDetails } from 'boltz-core';
+import {
+  Musig,
+  OutputType,
+  SwapTreeSerializer,
+  constructClaimTransaction,
+} from 'boltz-core';
 import { randomBytes } from 'crypto';
 import fs from 'fs';
 import type { Transaction as LiquidTransaction } from 'liquidjs-lib';
@@ -10,6 +16,7 @@ import { networks as liquidNetworks } from 'liquidjs-lib';
 import path from 'path';
 import { parseTransaction, setup } from '../../../lib/Core';
 import Logger from '../../../lib/Logger';
+import { TxView } from '../../../lib/TxView';
 import { getHexBuffer, getPairId } from '../../../lib/Utils';
 import {
   CurrencyType,
@@ -18,9 +25,12 @@ import {
 } from '../../../lib/consts/Enums';
 import Database from '../../../lib/db/Database';
 import { NodeType } from '../../../lib/db/models/ReverseSwap';
+import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
+import ClaimTransactionRepository from '../../../lib/db/repositories/ClaimTransactionRepository';
 import PairRepository from '../../../lib/db/repositories/PairRepository';
 import RefundTransactionRepository from '../../../lib/db/repositories/RefundTransactionRepository';
 import SwapRepository from '../../../lib/db/repositories/SwapRepository';
+import WrappedSwapRepository from '../../../lib/db/repositories/WrappedSwapRepository';
 import type ClnPendingPaymentTracker from '../../../lib/lightning/paymentTrackers/ClnPendingPaymentTracker';
 import type NotificationClient from '../../../lib/notifications/NotificationClient';
 import LockupTransactionTracker from '../../../lib/rates/LockupTransactionTracker';
@@ -618,6 +628,101 @@ describe('UtxoNursery', () => {
       emitTransaction(elementsClient.symbol, tx);
 
       await emitPromise;
+    });
+  });
+
+  describe('checkSwapClaims', () => {
+    test('should detect chain swap claims and extract the preimage from the witness', async () => {
+      const preimage = randomBytes(32);
+      const claimKeys = makeKeys();
+      const refundKeys = makeKeys();
+
+      const created = await swapManager.createChainSwap({
+        acceptZeroConf: false,
+        baseCurrency: elementsClient.symbol,
+        quoteCurrency: bitcoinClient.symbol,
+        orderSide: OrderSide.SELL,
+        percentageFee: 100,
+        preimageHash: Buffer.from(sha256(preimage)),
+        claimPublicKey: claimKeys.publicKey,
+        refundPublicKey: refundKeys.publicKey,
+        sendingTimeoutBlockDelta: 102,
+        receivingTimeoutBlockDelta: 101,
+        userLockAmount: 101_000,
+        serverLockAmount: 100_000,
+      });
+
+      const lockupTxId = await bitcoinClient.sendToAddress(
+        created.claimDetails.lockupAddress!,
+        created.claimDetails.amount!,
+        undefined,
+        false,
+        '',
+      );
+      const lockupTx = parseTransaction<Transaction>(
+        CurrencyType.BitcoinLike,
+        await bitcoinClient.getRawTransaction(lockupTxId),
+      );
+
+      const wallet = walletManager.wallets.get(bitcoinClient.symbol)!;
+      const lockupScript = wallet.decodeAddress(
+        created.claimDetails.lockupAddress!,
+      );
+      const vout = TxView.of(lockupTx).outputs.findIndex((out) =>
+        out.script.equals(lockupScript),
+      );
+      expect(vout).not.toEqual(-1);
+
+      await WrappedSwapRepository.setServerLockupTransaction(
+        (await ChainSwapRepository.getChainSwap({ id: created.id }))!,
+        lockupTxId,
+        created.claimDetails.amount!,
+        0,
+        vout,
+      );
+
+      const claimTransaction = constructClaimTransaction(
+        [
+          {
+            vout,
+            preimage,
+            transactionId: lockupTxId,
+            type: OutputType.Taproot,
+            cooperative: false,
+            script: lockupScript,
+            amount: BigInt(created.claimDetails.amount!),
+            privateKey: claimKeys.privateKey,
+            swapTree: SwapTreeSerializer.deserializeSwapTree(
+              created.claimDetails.swapTree!,
+            ),
+            internalKey: Musig.create(claimKeys.privateKey, [
+              getHexBuffer(created.claimDetails.serverPublicKey!),
+              claimKeys.publicKey,
+            ]).aggPubkey,
+          } as ClaimDetails,
+        ],
+        wallet.decodeAddress(await bitcoinClient.getNewAddress('')),
+        1_000n,
+      );
+
+      await bitcoinClient.sendRawTransaction(claimTransaction.hex);
+
+      const emitPromise = new Promise<void>((resolve) => {
+        nursery.once('chainSwap.claimed', ({ swap, preimage: emitted }) => {
+          expect(swap.id).toEqual(created.id);
+          expect(emitted).toEqual(preimage);
+          resolve();
+        });
+      });
+      emitTransaction(bitcoinClient.symbol, claimTransaction);
+      await emitPromise;
+
+      await wait(250);
+      const persisted = await ClaimTransactionRepository.getTransactionForSwap(
+        created.id,
+      );
+      expect(persisted).not.toBeNull();
+      expect(persisted!.id).toEqual(claimTransaction.id);
     });
   });
 });

--- a/test/unit/swap/UtxoNursery.spec.ts
+++ b/test/unit/swap/UtxoNursery.spec.ts
@@ -1,4 +1,5 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 import { hexToBytes } from '@noble/hashes/utils.js';
 import { Transaction } from '@scure/btc-signer';
 import {
@@ -1017,6 +1018,13 @@ describe('UtxoNursery', () => {
 
     mockGetReverseSwapResult = {
       id: 'id',
+      preimageHash: getHexString(
+        sha256(
+          getHexBuffer(
+            '0c25a0d5b61ae3f3dc6889742aefddc5608ebc8bae6dfa96e1a1481c5db7d5ed',
+          ),
+        ),
+      ),
     };
 
     let eventEmitted = false;
@@ -1084,7 +1092,16 @@ describe('UtxoNursery', () => {
 
     const transaction = parseTx(sampleTransactions.claim);
 
-    mockGetReverseSwapResult = { id: 'reverseClaimResilience' };
+    mockGetReverseSwapResult = {
+      id: 'reverseClaimResilience',
+      preimageHash: getHexString(
+        sha256(
+          getHexBuffer(
+            '0c25a0d5b61ae3f3dc6889742aefddc5608ebc8bae6dfa96e1a1481c5db7d5ed',
+          ),
+        ),
+      ),
+    };
 
     ClaimTransactionRepository.addTransaction = jest
       .fn()
@@ -1109,26 +1126,185 @@ describe('UtxoNursery', () => {
     }
   });
 
+  test('should emit reverseSwap.claimed with the stored preimage for cooperative claims', async () => {
+    RefundTransactionRepository.getTransaction = jest
+      .fn()
+      .mockResolvedValue(null);
+    ChainSwapRepository.getChainSwapByData = jest.fn().mockResolvedValue(null);
+
+    const preimage = Buffer.alloc(32, 21);
+    mockGetReverseSwapResult = {
+      id: 'reverseCoopClaim',
+      preimage: getHexString(preimage),
+    };
+
+    const coopClaimTransaction = {
+      getId: () => 'reverseCoopClaimTxId',
+      ins: [
+        {
+          hash: Buffer.alloc(32, 20),
+          index: 1,
+          witness: [Buffer.alloc(64, 1)],
+        },
+      ],
+    } as any;
+
+    const claimed = jest.fn();
+    nursery.once('reverseSwap.claimed', claimed);
+
+    try {
+      await nursery['checkSwapClaims'](btcChainClient, coopClaimTransaction);
+
+      expect(claimed).toHaveBeenCalledTimes(1);
+      expect(claimed).toHaveBeenCalledWith({
+        reverseSwap: mockGetReverseSwapResult,
+        preimage,
+      });
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+        swapId: 'reverseCoopClaim',
+        symbol: btcChainClient.symbol,
+        id: 'reverseCoopClaimTxId',
+      });
+    } finally {
+      mockGetReverseSwapResult = null;
+    }
+  });
+
   describe('chain swap claim persistence', () => {
     const spentHash = Buffer.alloc(32, 7);
     const spentVout = 3;
     const transactionId = 'chainClaimTxId';
+    const claimPreimage = Buffer.alloc(32, 1);
     const fakeTransaction = {
       getId: () => transactionId,
       ins: [
         {
           hash: spentHash,
           index: spentVout,
-          // Non-cooperative chain swap claim has 4 witness elements
           witness: [
-            Buffer.alloc(0),
-            Buffer.alloc(0),
-            Buffer.alloc(0),
-            Buffer.alloc(0),
+            Buffer.alloc(64, 1),
+            claimPreimage,
+            Buffer.alloc(35, 2),
+            Buffer.alloc(33, 3),
           ],
         },
       ],
     } as any;
+
+    const expectFilteredUserClaim = async (
+      id: string,
+      witness: Buffer[],
+      preimageHash: string,
+    ) => {
+      RefundTransactionRepository.getTransaction = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      const mockChainSwap = {
+        id,
+        preimage: null,
+        preimageHash,
+        chainSwap: { id },
+        sendingData: {
+          transactionId: transactionHashToId(spentHash),
+          transactionVout: spentVout,
+        },
+        receivingData: {
+          transactionId: 'other',
+          transactionVout: 0,
+        },
+      };
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(mockChainSwap);
+
+      const filteredTransaction = {
+        getId: () => transactionId,
+        ins: [
+          {
+            hash: spentHash,
+            index: spentVout,
+            witness,
+          },
+        ],
+      } as any;
+
+      const claimed = jest.fn();
+      nursery.once('chainSwap.claimed', claimed);
+
+      await nursery['checkSwapClaims'](btcChainClient, filteredTransaction);
+
+      expect(claimed).not.toHaveBeenCalled();
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+        swapId: id,
+        symbol: btcChainClient.symbol,
+        id: transactionId,
+      });
+    };
+
+    const expectEmittedUserClaim = async (
+      id: string,
+      witness: Buffer[],
+      preimage: Buffer,
+    ) => {
+      RefundTransactionRepository.getTransaction = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      const mockChainSwap = {
+        id,
+        preimage: null,
+        preimageHash: getHexString(sha256(preimage)),
+        chainSwap: { id },
+        sendingData: {
+          transactionId: transactionHashToId(spentHash),
+          transactionVout: spentVout,
+        },
+        receivingData: {
+          transactionId: 'other',
+          transactionVout: 0,
+        },
+      };
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(mockChainSwap);
+
+      const claimTransaction = {
+        getId: () => transactionId,
+        ins: [
+          {
+            hash: spentHash,
+            index: spentVout,
+            witness,
+          },
+        ],
+      } as any;
+
+      const claimed = jest.fn();
+      nursery.once('chainSwap.claimed', claimed);
+
+      await nursery['checkSwapClaims'](btcChainClient, claimTransaction);
+
+      expect(claimed).toHaveBeenCalledTimes(1);
+      expect(claimed).toHaveBeenCalledWith({
+        swap: mockChainSwap,
+        preimage,
+      });
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(ClaimTransactionRepository.addTransaction).toHaveBeenCalledWith({
+        swapId: id,
+        symbol: btcChainClient.symbol,
+        id: transactionId,
+      });
+    };
 
     test('should persist when spend matches sendingData (user claim)', async () => {
       RefundTransactionRepository.getTransaction = jest
@@ -1137,7 +1313,8 @@ describe('UtxoNursery', () => {
 
       const mockChainSwap = {
         id: 'chainSwapId',
-        preimage: getHexString(Buffer.alloc(32, 1)),
+        preimage: getHexString(claimPreimage),
+        preimageHash: getHexString(sha256(claimPreimage)),
         chainSwap: { id: 'chainSwapId' },
         sendingData: {
           transactionId: transactionHashToId(spentHash),
@@ -1171,6 +1348,88 @@ describe('UtxoNursery', () => {
       });
     });
 
+    test('should recognize a Taproot script claim with a final annex', async () => {
+      const preimage = Buffer.alloc(32, 11);
+      await expectEmittedUserClaim(
+        'chainSwapAnnexClaim',
+        [
+          Buffer.alloc(64, 1),
+          preimage,
+          Buffer.alloc(35, 2),
+          Buffer.alloc(33, 3),
+          Buffer.from([0x50, 0x01]),
+        ],
+        preimage,
+      );
+    });
+
+    test('should recognize a claim regardless of extra witness elements', async () => {
+      const preimage = Buffer.alloc(32, 12);
+      await expectEmittedUserClaim(
+        'chainSwapExtraWitness',
+        [
+          Buffer.alloc(64, 1),
+          preimage,
+          Buffer.alloc(35, 2),
+          Buffer.alloc(33, 3),
+          Buffer.from([0x51, 0x01]),
+        ],
+        preimage,
+      );
+    });
+
+    test('should recognize a covenant claim with the preimage as the first element', async () => {
+      const preimage = Buffer.alloc(32, 17);
+      await expectEmittedUserClaim(
+        'chainSwapCovenantClaim',
+        [preimage, Buffer.alloc(35, 2), Buffer.alloc(33, 3)],
+        preimage,
+      );
+    });
+
+    test('should filter a refund transaction', async () => {
+      await expectFilteredUserClaim(
+        'chainSwapRefund',
+        [Buffer.alloc(64, 1), Buffer.alloc(35, 2), Buffer.alloc(33, 3)],
+        getHexString(sha256(Buffer.alloc(32, 13))),
+      );
+    });
+
+    test('should filter a Taproot refund with a final annex', async () => {
+      await expectFilteredUserClaim(
+        'chainSwapRefundAnnex',
+        [
+          Buffer.alloc(64, 1),
+          Buffer.alloc(35, 2),
+          Buffer.alloc(33, 3),
+          Buffer.from([0x50, 0x01]),
+        ],
+        getHexString(sha256(Buffer.alloc(32, 13))),
+      );
+    });
+
+    test('should filter a Taproot key-path spend with a final annex', async () => {
+      await expectFilteredUserClaim(
+        'chainSwapKeyPathAnnex',
+        [Buffer.alloc(64, 1), Buffer.from([0x50, 0x01])],
+        getHexString(sha256(Buffer.alloc(32, 14))),
+      );
+    });
+
+    test('should filter a claim with a mismatched preimage', async () => {
+      const preimage = Buffer.alloc(32, 15);
+      await expectFilteredUserClaim(
+        'chainSwapPreimageMismatch',
+        [
+          Buffer.alloc(64, 1),
+          preimage,
+          Buffer.alloc(35, 2),
+          Buffer.alloc(33, 3),
+        ],
+        getHexString(sha256(Buffer.alloc(32, 16))),
+      );
+    });
+
     test('should not persist when spend matches receivingData (server claim)', async () => {
       RefundTransactionRepository.getTransaction = jest
         .fn()
@@ -1178,7 +1437,8 @@ describe('UtxoNursery', () => {
 
       const mockChainSwap = {
         id: 'chainSwapId',
-        preimage: getHexString(Buffer.alloc(32, 1)),
+        preimage: getHexString(claimPreimage),
+        preimageHash: getHexString(sha256(claimPreimage)),
         chainSwap: { id: 'chainSwapId' },
         sendingData: {
           transactionId: 'other',
@@ -1211,7 +1471,8 @@ describe('UtxoNursery', () => {
 
       const mockChainSwap = {
         id: 'chainSwapId',
-        preimage: getHexString(Buffer.alloc(32, 1)),
+        preimage: getHexString(claimPreimage),
+        preimageHash: getHexString(sha256(claimPreimage)),
         chainSwap: { id: 'chainSwapId' },
         sendingData: {
           transactionId: transactionHashToId(spentHash),
@@ -1252,7 +1513,8 @@ describe('UtxoNursery', () => {
 
       const mockChainSwap = {
         id: 'chainSwapId',
-        preimage: getHexString(Buffer.alloc(32, 1)),
+        preimage: getHexString(claimPreimage),
+        preimageHash: getHexString(sha256(claimPreimage)),
         chainSwap: { id: 'chainSwapId' },
         sendingData: {
           transactionId: transactionHashToId(spentHash),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swap claim detection by deriving preimages directly from transaction witnesses.
  - Added support for a wider range of Taproot, annex, covenant, cooperative, and refund claim formats.
  - Prevented valid claims from being skipped because of extra witness data.
  - Ensured claim transactions are recorded even when preimage details are unavailable or related persistence operations fail.
  - Claim events now include the verified preimage only when it matches the expected hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->