### PR TITLE
refactor: harden webhook creation order

### DIFF
--- a/boltzr/protos/boltzr.proto
+++ b/boltzr/protos/boltzr.proto
@@ -15,6 +15,7 @@ service BoltzR {
 
   rpc StartWebHookRetries (StartWebHookRetriesRequest) returns (StartWebHookRetriesResponse);
   rpc CreateWebHook (CreateWebHookRequest) returns (CreateWebHookResponse);
+  rpc DeleteWebHook (DeleteWebHookRequest) returns (DeleteWebHookResponse);
   rpc SendWebHook (SendWebHookRequest) returns (SendWebHookResponse);
 
   rpc ClaimBatch (ClaimBatchRequest) returns (ClaimBatchResponse);
@@ -111,6 +112,11 @@ message CreateWebHookRequest {
   repeated string status = 4;
 }
 message CreateWebHookResponse {}
+
+message DeleteWebHookRequest {
+  string id = 1;
+}
+message DeleteWebHookResponse {}
 
 message SendWebHookRequest {
   string id = 1;

--- a/boltzr/src/db/helpers/web_hook.rs
+++ b/boltzr/src/db/helpers/web_hook.rs
@@ -5,11 +5,12 @@ use crate::db::schema::{chainSwaps, reverseSwaps, swaps, web_hooks};
 use crate::webhook::caller::HookState;
 use crate::webhook::{SwapUpdateCallData, WebHookCallData};
 use diesel::prelude::*;
-use diesel::{insert_into, update};
+use diesel::{delete, insert_into, update};
 use tracing::{instrument, trace};
 
 pub trait WebHookHelper {
     fn insert_web_hook(&self, hook: &WebHook) -> QueryResponse<usize>;
+    fn delete_web_hook(&self, id: &str) -> QueryResponse<usize>;
     fn set_state(&self, id: &str, state: WebHookState) -> QueryResponse<usize>;
     fn get_by_id(&self, id: &str) -> QueryResponse<Option<WebHook>>;
     fn get_by_state(&self, state: WebHookState) -> QueryResponse<Vec<WebHook>>;
@@ -42,6 +43,14 @@ impl WebHookHelper for WebHookHelperDatabase {
         trace!("Inserting WebHook: {:#?}", hook);
         Ok(insert_into(web_hooks::dsl::web_hooks)
             .values(hook)
+            .execute(&mut self.pool.get()?)?)
+    }
+
+    #[instrument(skip_all, fields(swap_id = id))]
+    fn delete_web_hook(&self, id: &str) -> QueryResponse<usize> {
+        trace!("Deleting WebHook of swap {}", id);
+        Ok(delete(web_hooks::dsl::web_hooks)
+            .filter(web_hooks::dsl::id.eq(id))
             .execute(&mut self.pool.get()?)?)
     }
 
@@ -228,6 +237,34 @@ pub mod test {
         };
         assert_eq!(helper.insert_web_hook(&hook).unwrap(), 1);
         assert!(helper.insert_web_hook(&hook).err().is_some());
+    }
+
+    #[test]
+    fn test_delete_web_hook() {
+        let helper = WebHookHelperDatabase::new(get_pool());
+
+        let hook = WebHook {
+            id: Alphanumeric.sample_string(&mut rand::thread_rng(), 16),
+            state: WebHookState::None.into(),
+            url: "https://some.thing".to_string(),
+            hash_swap_id: true,
+            status: None,
+        };
+        assert_eq!(helper.insert_web_hook(&hook).unwrap(), 1);
+
+        assert_eq!(helper.delete_web_hook(&hook.id).unwrap(), 1);
+        assert_eq!(helper.get_by_id(&hook.id).unwrap(), None);
+    }
+
+    #[test]
+    fn test_delete_web_hook_not_existing() {
+        let helper = WebHookHelperDatabase::new(get_pool());
+        assert_eq!(
+            helper
+                .delete_web_hook(&Alphanumeric.sample_string(&mut rand::thread_rng(), 16))
+                .unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/boltzr/src/grpc/server.rs
+++ b/boltzr/src/grpc/server.rs
@@ -220,6 +220,7 @@ mod server_test {
 
         impl WebHookHelper for WebHookHelper {
             fn insert_web_hook(&self, hook: &WebHook) -> QueryResponse<usize>;
+            fn delete_web_hook(&self, id: &str) -> QueryResponse<usize>;
             fn set_state(&self, id: &str, state: WebHookState) -> QueryResponse<usize>;
             fn get_by_id(&self, id: &str) -> QueryResponse<Option<WebHook>>;
             fn get_by_state(&self, state: WebHookState) -> QueryResponse<Vec<WebHook>>;

--- a/boltzr/src/grpc/service.rs
+++ b/boltzr/src/grpc/service.rs
@@ -8,14 +8,15 @@ use crate::grpc::service::boltzr::{
     Block, BlockAddedRequest, Bolt11Invoice, Bolt12Invoice, Bolt12Offer, CheckTransactionRequest,
     CheckTransactionResponse, ClaimBatchRequest, ClaimBatchResponse, CreateWebHookRequest,
     CreateWebHookResponse, DecodeInvoiceOrOfferRequest, DecodeInvoiceOrOfferResponse,
-    EstimateFeeRequest, EstimateFeeResponse, Feature, GetInfoRequest, GetInfoResponse,
-    GetMessagesRequest, GetMessagesResponse, IsMarkedRequest, IsMarkedResponse, LogLevel,
-    RelevantTransaction, RelevantTransactionRequest, RescanChainsRequest, RescanChainsResponse,
-    SendMessageRequest, SendMessageResponse, SendSwapUpdateRequest, SendSwapUpdateResponse,
-    SendWebHookRequest, SendWebHookResponse, SetLogLevelRequest, SetLogLevelResponse,
-    SignEvmRefundRequest, SignEvmRefundResponse, StartWebHookRetriesRequest,
-    StartWebHookRetriesResponse, SwapUpdate, SwapUpdateRequest, SwapUpdateResponse,
-    TransactionStatus, bolt11_invoice, bolt12_invoice, decode_invoice_or_offer_response,
+    DeleteWebHookRequest, DeleteWebHookResponse, EstimateFeeRequest, EstimateFeeResponse, Feature,
+    GetInfoRequest, GetInfoResponse, GetMessagesRequest, GetMessagesResponse, IsMarkedRequest,
+    IsMarkedResponse, LogLevel, RelevantTransaction, RelevantTransactionRequest,
+    RescanChainsRequest, RescanChainsResponse, SendMessageRequest, SendMessageResponse,
+    SendSwapUpdateRequest, SendSwapUpdateResponse, SendWebHookRequest, SendWebHookResponse,
+    SetLogLevelRequest, SetLogLevelResponse, SignEvmRefundRequest, SignEvmRefundResponse,
+    StartWebHookRetriesRequest, StartWebHookRetriesResponse, SwapUpdate, SwapUpdateRequest,
+    SwapUpdateResponse, TransactionStatus, bolt11_invoice, bolt12_invoice,
+    decode_invoice_or_offer_response,
 };
 use crate::grpc::status_fetcher::StatusFetcher;
 use crate::lightning::invoice::Invoice;
@@ -337,6 +338,20 @@ where
         }) {
             Ok(_) => Ok(Response::new(CreateWebHookResponse {})),
             Err(err) => Err(Status::new(Code::InvalidArgument, err.to_string())),
+        }
+    }
+
+    #[instrument(name = "grpc::delete_web_hook", skip_all)]
+    async fn delete_web_hook(
+        &self,
+        request: Request<DeleteWebHookRequest>,
+    ) -> Result<Response<DeleteWebHookResponse>, Status> {
+        let params = request.into_inner();
+        debug!("Deleting WebHook for swap {}", params.id);
+
+        match self.web_hook_helper.delete_web_hook(&params.id) {
+            Ok(_) => Ok(Response::new(DeleteWebHookResponse {})),
+            Err(err) => Err(Status::new(Code::Internal, err.to_string())),
         }
     }
 
@@ -823,9 +838,9 @@ mod test {
     use crate::grpc::service::boltzr::boltz_r_server::BoltzR;
     use crate::grpc::service::boltzr::sign_evm_refund_request::Contract;
     use crate::grpc::service::boltzr::{
-        CreateWebHookRequest, CreateWebHookResponse, GetInfoRequest, GetInfoResponse,
-        SendWebHookRequest, SendWebHookResponse, SignEvmRefundRequest, StartWebHookRetriesRequest,
-        StartWebHookRetriesResponse,
+        CreateWebHookRequest, CreateWebHookResponse, DeleteWebHookRequest, DeleteWebHookResponse,
+        GetInfoRequest, GetInfoResponse, SendWebHookRequest, SendWebHookResponse,
+        SignEvmRefundRequest, StartWebHookRetriesRequest, StartWebHookRetriesResponse,
     };
     use crate::grpc::status_fetcher::StatusFetcher;
     use crate::notifications::commands::Commands;
@@ -908,6 +923,7 @@ mod test {
 
         impl WebHookHelper for WebHookHelper {
             fn insert_web_hook(&self, hook: &WebHook) -> QueryResponse<usize>;
+            fn delete_web_hook(&self, id: &str) -> QueryResponse<usize>;
             fn set_state(&self, id: &str, state: WebHookState) -> QueryResponse<usize>;
             fn get_by_id(&self, id: &str) -> QueryResponse<Option<WebHook>>;
             fn get_by_state(&self, state: WebHookState) -> QueryResponse<Vec<WebHook>>;
@@ -999,6 +1015,20 @@ mod test {
             .unwrap();
         assert_eq!(err.code(), Code::InvalidArgument);
         assert_eq!(err.message(), "relative URL without a base");
+    }
+
+    #[tokio::test]
+    async fn test_delete_web_hook() {
+        let (_, svc) = make_service().await;
+        assert_eq!(
+            svc.delete_web_hook(Request::new(DeleteWebHookRequest {
+                id: "id".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner(),
+            DeleteWebHookResponse {}
+        );
     }
 
     #[tokio::test]
@@ -1198,6 +1228,7 @@ mod test {
             .expect_get_by_state()
             .returning(|_| Ok(Vec::new()));
         hook_helper.expect_insert_web_hook().returning(|_| Ok(1));
+        hook_helper.expect_delete_web_hook().returning(|_| Ok(1));
         hook_helper.expect_set_state().returning(|_, _| Ok(1));
         hook_helper.expect_clone().returning(make_mock_hook_helper);
 

--- a/lib/service/Errors.ts
+++ b/lib/service/Errors.ts
@@ -209,4 +209,8 @@ export default {
     message: 'invalid payment timeout',
     code: concatErrorCode(ErrorCodePrefix.Service, 58),
   }),
+  COULD_NOT_REGISTER_WEBHOOK: (): Error => ({
+    message: 'could not register webhook',
+    code: concatErrorCode(ErrorCodePrefix.Service, 59),
+  }),
 };

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -18,6 +18,7 @@ import {
   createApiCredential,
   formatError,
   fromProtoInt,
+  generateSwapId,
   getChainCurrency,
   getHexString,
   getLightningCurrency,
@@ -1284,49 +1285,56 @@ class Service {
     }
 
     const referralId = await this.getReferralId(args.referralId);
-    const {
-      id,
-      address,
-      swapTree,
-      timeoutBlockHeight,
-      timeoutBlockHeights,
-      blindingKey,
-      redeemScript,
-      claimAddress,
-      claimPublicKey,
-    } = await this.swapManager.createSwap({
-      orderSide,
-      referralId,
-      timeoutBlockDelta,
-      baseCurrency: base,
-      quoteCurrency: quote,
-      version: args.version,
-      preimageHash: args.preimageHash,
-      paymentTimeout: args.paymentTimeout,
-      refundPublicKey: args.refundPublicKey,
-    });
 
-    this.eventHandler.emitSwapCreation(id);
-
-    if (args.webHook) {
-      await this.addWebHook(id, args.webHook, async () => {
-        await (await SwapRepository.getSwap({ id }))?.destroy();
-      });
+    const id = generateSwapId(args.version);
+    if (args.webHook !== undefined) {
+      await this.addWebHook(id, args.webHook);
     }
 
-    return {
-      id,
-      address,
-      swapTree,
-      referralId,
-      canBeRouted,
-      blindingKey,
-      redeemScript,
-      claimAddress,
-      claimPublicKey,
-      timeoutBlockHeight,
-      timeoutBlockHeights,
-    };
+    try {
+      const {
+        address,
+        swapTree,
+        timeoutBlockHeight,
+        timeoutBlockHeights,
+        blindingKey,
+        redeemScript,
+        claimAddress,
+        claimPublicKey,
+      } = await this.swapManager.createSwap({
+        id,
+        orderSide,
+        referralId,
+        timeoutBlockDelta,
+        baseCurrency: base,
+        quoteCurrency: quote,
+        version: args.version,
+        preimageHash: args.preimageHash,
+        paymentTimeout: args.paymentTimeout,
+        refundPublicKey: args.refundPublicKey,
+      });
+
+      this.eventHandler.emitSwapCreation(id);
+
+      return {
+        id,
+        address,
+        swapTree,
+        referralId,
+        canBeRouted,
+        blindingKey,
+        redeemScript,
+        claimAddress,
+        claimPublicKey,
+        timeoutBlockHeight,
+        timeoutBlockHeights,
+      };
+    } catch (error) {
+      if (args.webHook !== undefined) {
+        await this.removeWebHook(id);
+      }
+      throw error;
+    }
   };
 
   /**
@@ -1696,6 +1704,10 @@ class Service {
       });
       await swap?.destroy();
 
+      if (webHook !== undefined) {
+        await this.removeWebHook(createdSwap.id);
+      }
+
       throw error;
     }
   };
@@ -2060,85 +2072,90 @@ class Service {
       throw Errors.ONCHAIN_AMOUNT_TOO_LOW();
     }
 
-    const {
-      id,
-      invoice,
-      swapTree,
-      blindingKey,
-      redeemScript,
-      refundAddress,
-      lockupAddress,
-      refundPublicKey,
-      minerFeeInvoice,
-      timeoutBlockHeight,
-      timeoutBlockHeights,
-    } = await this.swapManager.createReverseSwap({
-      referralId,
-      percentageFee,
-      onchainAmount,
-      holdInvoiceAmount,
-      onchainTimeoutBlockDelta,
-      lightningTimeoutBlockDelta,
-      prepayMinerFeeInvoiceAmount,
-      prepayMinerFeeOnchainAmount,
-      orderSide: side,
-      baseCurrency: base,
-      quoteCurrency: quote,
-      version: args.version,
-      memo: args.description,
-      preimageHash: preimageHash,
-      routingNode: args.routingNode,
-      userAddress: args.userAddress,
-      claimAddress: args.claimAddress,
-      invoiceExpiry: args.invoiceExpiry,
-      claimPublicKey: args.claimPublicKey,
-      descriptionHash: args.descriptionHash,
-      claimCovenant: args.claimCovenant || false,
-      userAddressSignature: args.userAddressSignature,
-      invoice:
-        args.invoice !== undefined && decodedInvoice !== undefined
-          ? { invoice: args.invoice, decoded: decodedInvoice }
-          : undefined,
-    });
+    const id = generateSwapId(args.version);
+    if (args.webHook !== undefined) {
+      await this.addWebHook(id, args.webHook);
+    }
 
-    this.eventHandler.emitSwapCreation(id);
-
-    if (args.webHook) {
-      await this.addWebHook(id, args.webHook, async () => {
-        await (await ReverseRoutingHintRepository.getHint(id))?.destroy();
-        await (await ReverseSwapRepository.getReverseSwap({ id }))?.destroy();
+    try {
+      const {
+        invoice,
+        swapTree,
+        blindingKey,
+        redeemScript,
+        refundAddress,
+        lockupAddress,
+        refundPublicKey,
+        minerFeeInvoice,
+        timeoutBlockHeight,
+        timeoutBlockHeights,
+      } = await this.swapManager.createReverseSwap({
+        id,
+        referralId,
+        percentageFee,
+        onchainAmount,
+        holdInvoiceAmount,
+        onchainTimeoutBlockDelta,
+        lightningTimeoutBlockDelta,
+        prepayMinerFeeInvoiceAmount,
+        prepayMinerFeeOnchainAmount,
+        orderSide: side,
+        baseCurrency: base,
+        quoteCurrency: quote,
+        version: args.version,
+        memo: args.description,
+        preimageHash: preimageHash,
+        routingNode: args.routingNode,
+        userAddress: args.userAddress,
+        claimAddress: args.claimAddress,
+        invoiceExpiry: args.invoiceExpiry,
+        claimPublicKey: args.claimPublicKey,
+        descriptionHash: args.descriptionHash,
+        claimCovenant: args.claimCovenant || false,
+        userAddressSignature: args.userAddressSignature,
+        invoice:
+          args.invoice !== undefined && decodedInvoice !== undefined
+            ? { invoice: args.invoice, decoded: decodedInvoice }
+            : undefined,
       });
+
+      this.eventHandler.emitSwapCreation(id);
+
+      await this.createExtraFees(id, extraFee, args.extraFees);
+
+      const response: any = {
+        id,
+        swapTree,
+        referralId,
+        blindingKey,
+        redeemScript,
+        refundAddress,
+        lockupAddress,
+        refundPublicKey,
+        timeoutBlockHeight,
+        timeoutBlockHeights,
+      };
+
+      if (args.invoice === undefined) {
+        response.invoice = invoice;
+      }
+
+      if (swapIsPrepayMinerFee) {
+        response.minerFeeInvoice = minerFeeInvoice;
+        response.prepayMinerFeeAmount = prepayMinerFeeOnchainAmount;
+      }
+
+      if (invoiceAmountDefined) {
+        response.onchainAmount = onchainAmount;
+      }
+
+      return response;
+    } catch (error) {
+      if (args.webHook !== undefined) {
+        await this.removeWebHook(id);
+      }
+      throw error;
     }
-
-    await this.createExtraFees(id, extraFee, args.extraFees);
-
-    const response: any = {
-      id,
-      swapTree,
-      referralId,
-      blindingKey,
-      redeemScript,
-      refundAddress,
-      lockupAddress,
-      refundPublicKey,
-      timeoutBlockHeight,
-      timeoutBlockHeights,
-    };
-
-    if (args.invoice === undefined) {
-      response.invoice = invoice;
-    }
-
-    if (swapIsPrepayMinerFee) {
-      response.minerFeeInvoice = minerFeeInvoice;
-      response.prepayMinerFeeAmount = prepayMinerFeeOnchainAmount;
-    }
-
-    if (invoiceAmountDefined) {
-      response.onchainAmount = onchainAmount;
-    }
-
-    return response;
   };
 
   private calculateChainSwapAmounts = (
@@ -2408,50 +2425,57 @@ class Service {
       );
     }
 
-    const res = await this.swapManager.createChainSwap({
-      referralId,
-      percentageFee,
-      sendingTimeoutBlockDelta,
-      receivingTimeoutBlockDelta,
-      orderSide: side,
-      baseCurrency: base,
-      quoteCurrency: quote,
-      claimAddress: args.claimAddress,
-      preimageHash: args.preimageHash,
-      userLockAmount: args.userLockAmount,
-      claimPublicKey: args.claimPublicKey,
-      refundPublicKey: args.refundPublicKey,
-      serverLockAmount: args.serverLockAmount,
-      acceptZeroConf: this.rateProvider.acceptZeroConf(
-        receivingCurrency.symbol,
-        args.userLockAmount,
-      ),
-    });
-
-    this.eventHandler.emitSwapCreation(res.id);
-
-    if (args.webHook) {
-      await this.addWebHook(res.id, args.webHook, async () => {
-        await ChainSwapRepository.destroy(res.id);
-      });
+    const id = generateSwapId(SwapVersion.Taproot);
+    if (args.webHook !== undefined) {
+      await this.addWebHook(id, args.webHook);
     }
 
-    await this.createExtraFees(res.id, extraFee, args.extraFees);
-
-    return {
-      referralId,
-      id: res.id,
-      claimDetails: res.claimDetails,
-      lockupDetails: {
-        ...res.lockupDetails,
-        bip21: this.paymentRequestUtils.encodeBip21(
+    try {
+      const res = await this.swapManager.createChainSwap({
+        id,
+        referralId,
+        percentageFee,
+        sendingTimeoutBlockDelta,
+        receivingTimeoutBlockDelta,
+        orderSide: side,
+        baseCurrency: base,
+        quoteCurrency: quote,
+        claimAddress: args.claimAddress,
+        preimageHash: args.preimageHash,
+        userLockAmount: args.userLockAmount,
+        claimPublicKey: args.claimPublicKey,
+        refundPublicKey: args.refundPublicKey,
+        serverLockAmount: args.serverLockAmount,
+        acceptZeroConf: this.rateProvider.acceptZeroConf(
           receivingCurrency.symbol,
-          res.lockupDetails.lockupAddress,
-          res.lockupDetails.amount,
-          getSwapMemo(sendingCurrency.symbol, SwapType.Chain),
+          args.userLockAmount,
         ),
-      },
-    };
+      });
+
+      this.eventHandler.emitSwapCreation(id);
+
+      await this.createExtraFees(id, extraFee, args.extraFees);
+
+      return {
+        referralId,
+        id,
+        claimDetails: res.claimDetails,
+        lockupDetails: {
+          ...res.lockupDetails,
+          bip21: this.paymentRequestUtils.encodeBip21(
+            receivingCurrency.symbol,
+            res.lockupDetails.lockupAddress,
+            res.lockupDetails.amount,
+            getSwapMemo(sendingCurrency.symbol, SwapType.Chain),
+          ),
+        },
+      };
+    } catch (error) {
+      if (args.webHook !== undefined) {
+        await this.removeWebHook(id);
+      }
+      throw error;
+    }
   };
 
   /**
@@ -2607,9 +2631,7 @@ class Service {
   private addWebHook = async (
     swapId: string,
     data: WebHookData,
-    // To delete the swap in case the WebHook cannot be set
-    swapDeleteFn: () => Promise<void>,
-  ) => {
+  ): Promise<void> => {
     try {
       await this.sidecar.createWebHook(
         swapId,
@@ -2618,8 +2640,24 @@ class Service {
         data.status,
       );
     } catch (e) {
-      await swapDeleteFn();
-      throw `setting Webhook failed: ${formatError(e)}`;
+      this.logger.warn(
+        `Registering webhook for swap ${swapId} failed: ${formatError(e)}`,
+      );
+      throw Errors.COULD_NOT_REGISTER_WEBHOOK();
+    }
+  };
+
+  // Best-effort removal of a webhook that was registered before the swap
+  // creation it belongs to failed. A stranded webhook is inert, so a failure
+  // here must not mask the original swap creation error.
+  private removeWebHook = async (swapId: string): Promise<void> => {
+    try {
+      await this.sidecar.deleteWebHook(swapId);
+    } catch (e) {
+      this.logger.warn(`Could not remove webhook for swap ${swapId}`);
+      this.logger.debug(
+        `Removing webhook for swap ${swapId} failed: ${formatError(e)}`,
+      );
     }
   };
 

--- a/lib/sidecar/Sidecar.ts
+++ b/lib/sidecar/Sidecar.ts
@@ -292,6 +292,17 @@ class Sidecar extends BaseClient<
     >('createWebHook', req);
   };
 
+  public deleteWebHook = async (swapId: string) => {
+    const req: sidecarrpc.DeleteWebHookRequest = {
+      id: swapId,
+    };
+
+    await this.unaryNodeCall<
+      sidecarrpc.DeleteWebHookRequest,
+      sidecarrpc.DeleteWebHookResponse
+    >('deleteWebHook', req);
+  };
+
   public claimBatch = async (swapIds: string[]) => {
     const req: sidecarrpc.ClaimBatchRequest = {
       swapIds,

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -402,6 +402,9 @@ class SwapManager {
 
     // Only required for UTXO based chains
     refundPublicKey?: Buffer;
+
+    // Pre-generated swap id; when omitted a new one is generated
+    id?: string;
   }): Promise<CreatedSwap> => {
     const { sendingCurrency, receivingCurrency } = this.getCurrencies(
       args.baseCurrency,
@@ -413,7 +416,7 @@ class SwapManager {
       throw Errors.NO_LIGHTNING_SUPPORT(sendingCurrency.symbol);
     }
 
-    const id = generateSwapId(args.version);
+    const id = args.id ?? generateSwapId(args.version);
 
     this.logger.verbose(
       `Creating new ${swapVersionToString(args.version)} Swap from ${
@@ -811,6 +814,9 @@ class SwapManager {
     descriptionHash?: Buffer;
 
     invoiceExpiry?: number;
+
+    // Pre-generated swap id; when omitted a new one is generated
+    id?: string;
   }): Promise<CreatedReverseSwap> => {
     const isInvoice = args.invoice !== undefined;
     const { sendingCurrency, receivingCurrency } = this.getCurrencies(
@@ -828,7 +834,7 @@ class SwapManager {
       throw Errors.NO_LIGHTNING_SUPPORT(receivingCurrency.symbol);
     }
 
-    const id = generateSwapId(args.version);
+    const id = args.id ?? generateSwapId(args.version);
 
     this.logger.verbose(
       `Creating new ${swapVersionToString(args.version)} Reverse Swap from ${
@@ -1206,6 +1212,9 @@ class SwapManager {
     receivingTimeoutBlockDelta: number;
 
     referralId?: string;
+
+    // Pre-generated swap id; when omitted a new one is generated
+    id?: string;
   }): Promise<CreatedChainSwap> => {
     const { sendingCurrency, receivingCurrency } = this.getCurrencies(
       args.baseCurrency,
@@ -1213,7 +1222,7 @@ class SwapManager {
       args.orderSide,
     );
 
-    const id = generateSwapId(SwapVersion.Taproot);
+    const id = args.id ?? generateSwapId(SwapVersion.Taproot);
 
     this.logger.verbose(
       `Creating new ${swapVersionToString(SwapVersion.Taproot)} Chain Swap from ${

--- a/test/unit/api/v2/routers/SwapRouter.spec.ts
+++ b/test/unit/api/v2/routers/SwapRouter.spec.ts
@@ -1674,6 +1674,34 @@ describe('SwapRouter', () => {
     });
   });
 
+  test('should propagate the error when webhook registration fails', async () => {
+    const reqBody = {
+      to: 'L-BTC',
+      from: 'BTC',
+      invoice: 'lni',
+      claimPublicKey: '21',
+      metadata: validMetadata,
+      webhook: {
+        url: 'test',
+        hashSwapId: false,
+      },
+    };
+    const error = { message: 'could not register webhook' };
+    const res = mockResponse();
+    (service.createReverseSwap as jest.Mock).mockRejectedValueOnce(error);
+
+    await expect(
+      swapRouter['createReverse'](mockRequest(reqBody), res),
+    ).rejects.toEqual(error);
+
+    // A failed webhook registration aborts the whole request; the creation
+    // tail must not run
+    expect(SwapMetadataRepository.set).not.toHaveBeenCalled();
+    expect(MarkedSwapRepository.addMarkedSwap).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
   test('should create reverse swaps with extraFees', async () => {
     const reqBody = {
       to: 'L-BTC',

--- a/test/unit/service/Service.spec.ts
+++ b/test/unit/service/Service.spec.ts
@@ -819,6 +819,7 @@ describe('Service', () => {
     rescanMempool: jest.fn(),
     checkTransaction: jest.fn().mockResolvedValue(undefined),
     createWebHook: jest.fn().mockImplementation(async () => {}),
+    deleteWebHook: jest.fn().mockResolvedValue(undefined),
     decodeInvoiceOrOffer: jest
       .fn()
       .mockImplementation(async (invoice: string) => {
@@ -2030,7 +2031,7 @@ describe('Service', () => {
     expect(emittedId).toEqual(response.id);
     expect(response).toEqual({
       referralId,
-      id: mockedSwap.id,
+      id: expect.any(String),
       canBeRouted: true,
       address: mockedSwap.address,
       redeemScript: mockedSwap.redeemScript,
@@ -2047,6 +2048,7 @@ describe('Service', () => {
       referralId,
       preimageHash,
       refundPublicKey,
+      id: response.id,
       baseCurrency: 'BTC',
       quoteCurrency: 'BTC',
       timeoutBlockDelta: 1,
@@ -2074,7 +2076,7 @@ describe('Service', () => {
     ).rejects.toEqual(Errors.SWAP_WITH_PREIMAGE_EXISTS());
   });
 
-  test('should delete swap when adding webhook fails', async () => {
+  test('should reject swap creation when adding a webhook fails', async () => {
     mockGetSwapResult = null;
 
     const pair = 'BTC/BTC';
@@ -2093,6 +2095,7 @@ describe('Service', () => {
     sidecar.createWebHook = jest.fn().mockImplementation(async () => {
       throw 'fail';
     });
+
     await expect(
       service.createSwap({
         webHook,
@@ -2103,11 +2106,45 @@ describe('Service', () => {
         pairId: pair,
         version: SwapVersion.Legacy,
       }),
-    ).rejects.toEqual('setting Webhook failed: fail');
+    ).rejects.toEqual(Errors.COULD_NOT_REGISTER_WEBHOOK());
+
+    // The webhook is registered before the swap, so a failure means no swap
+    // was created and there is nothing to clean up
+    expect(sidecar.createWebHook).toHaveBeenCalledTimes(1);
+    expect(sidecar.deleteWebHook).not.toHaveBeenCalled();
+    expect(service.swapManager.createSwap).not.toHaveBeenCalled();
+  });
+
+  test('should remove the webhook when swap creation fails', async () => {
+    mockGetSwapResult = null;
+
+    const webHook: WebHookData = {
+      url: 'http',
+      hashSwapId: true,
+    };
+
+    sidecar.createWebHook = jest.fn().mockResolvedValue(undefined);
+    sidecar.deleteWebHook = jest.fn().mockResolvedValue(undefined);
+    mockCreateSwap.mockRejectedValueOnce('swap creation failed');
+
+    await expect(
+      service.createSwap({
+        webHook,
+        orderSide: 'buy',
+        referralId: 'referral',
+        preimageHash: getHexBuffer(
+          'fc3703b99248a0a2d948c6021fdd70debb90ab37233e62531c7f900fe3852c89',
+        ),
+        refundPublicKey: getHexBuffer('0xfff'),
+        pairId: 'BTC/BTC',
+        version: SwapVersion.Legacy,
+      }),
+    ).rejects.toEqual('swap creation failed');
 
     expect(sidecar.createWebHook).toHaveBeenCalledTimes(1);
-    expect(SwapRepository.getSwap).toHaveBeenCalledTimes(2);
-    expect(SwapRepository.getSwap).toHaveBeenCalledWith({ id: mockedSwap.id });
+    const registeredId = (sidecar.createWebHook as jest.Mock).mock.calls[0][0];
+    expect(sidecar.deleteWebHook).toHaveBeenCalledTimes(1);
+    expect(sidecar.deleteWebHook).toHaveBeenCalledWith(registeredId);
   });
 
   test('should get swap rates', async () => {
@@ -2462,6 +2499,10 @@ describe('Service', () => {
     );
     const invoice =
       'lnbcrt1m1p0xdry7pp5jadnlr9y5qs5nl93u06v9w2azqr8rf5n09u2wk0c6jktyfxwfpwqdqqcqzpgsp5svss08dmgw9q6emmwfzp74hcs2rq2fu3u78qge5l942al5glzjmq9qy9qsq4v5x0qlfp3fvpm9mrzmmdrptwdrd7gxyaypz4y0g8l8apmzfjgvqtxg9z89y0kg2lh6ykd8czt5ven6nlvr407vdm0mp9l9tvhg33gspv3yr0j';
+    const webHook: WebHookData = {
+      url: 'http',
+      hashSwapId: true,
+    };
 
     const response = await service.createSwapWithInvoice(
       pair,
@@ -2470,6 +2511,9 @@ describe('Service', () => {
       invoice,
       undefined,
       referralId,
+      SwapVersion.Legacy,
+      undefined,
+      webHook,
     );
 
     expect(response).toEqual({
@@ -2485,6 +2529,7 @@ describe('Service', () => {
       refundPublicKey,
       pairId: pair,
       version: SwapVersion.Legacy,
+      webHook,
       preimageHash: getHexBuffer(
         '975b3f8ca4a02149fcb1e3f4c2b95d100671a6937978a759f8d4acb224ce485c',
       ),
@@ -2525,6 +2570,51 @@ describe('Service', () => {
     await expect(
       service.createSwapWithInvoice('', '', Buffer.alloc(0), ''),
     ).rejects.toEqual(Errors.SWAP_WITH_INVOICE_EXISTS());
+  });
+
+  test('should remove the webhook when setting the invoice fails', async () => {
+    const createdSwap = {
+      id: 'swapInvoice',
+      referralId: 'asdf',
+      address: 'bcrt1qundqmnml8644l23g7cr3fjnksks4nc6mxf4gk9',
+    };
+    const error = { message: 'setSwapInvoice failed' };
+    const mockDestroySwap = jest.fn().mockResolvedValue({});
+
+    service.createSwap = jest.fn().mockResolvedValue(createdSwap);
+    service['setSwapInvoice'] = jest.fn().mockRejectedValue(error);
+    sidecar.deleteWebHook = jest.fn().mockResolvedValue(undefined);
+
+    // 1: no existing swap for the invoice, 2: arg for setSwapInvoice,
+    // 3: swap fetched in the catch block for cleanup
+    mockGetSwapResult = [undefined, {}, { destroy: mockDestroySwap }];
+
+    const invoice =
+      'lnbcrt1m1p0xdry7pp5jadnlr9y5qs5nl93u06v9w2azqr8rf5n09u2wk0c6jktyfxwfpwqdqqcqzpgsp5svss08dmgw9q6emmwfzp74hcs2rq2fu3u78qge5l942al5glzjmq9qy9qsq4v5x0qlfp3fvpm9mrzmmdrptwdrd7gxyaypz4y0g8l8apmzfjgvqtxg9z89y0kg2lh6ykd8czt5ven6nlvr407vdm0mp9l9tvhg33gspv3yr0j';
+    const webHook: WebHookData = {
+      url: 'http',
+      hashSwapId: true,
+    };
+
+    await expect(
+      service.createSwapWithInvoice(
+        'BTC/BTC',
+        'sell',
+        getHexBuffer(
+          '02d3727f1c2017adf58295378d02ace4c514666b8d75d4751940b940718ceb34ed',
+        ),
+        invoice,
+        undefined,
+        undefined,
+        SwapVersion.Legacy,
+        undefined,
+        webHook,
+      ),
+    ).rejects.toEqual(error);
+
+    expect(mockDestroySwap).toHaveBeenCalledTimes(1);
+    expect(sidecar.deleteWebHook).toHaveBeenCalledTimes(1);
+    expect(sidecar.deleteWebHook).toHaveBeenCalledWith(createdSwap.id);
   });
 
   test('should create reverse swaps', async () => {
@@ -2572,7 +2662,7 @@ describe('Service', () => {
     expect(response).toEqual({
       referralId,
       onchainAmount,
-      id: mockedReverseSwap.id,
+      id: expect.any(String),
       invoice: mockedReverseSwap.invoice,
       redeemScript: mockedReverseSwap.redeemScript,
       lockupAddress: mockedReverseSwap.lockupAddress,
@@ -2601,6 +2691,7 @@ describe('Service', () => {
       preimageHash,
       onchainAmount,
       claimPublicKey,
+      id: response.id,
       memo: description,
       baseCurrency: 'BTC',
       quoteCurrency: 'BTC',
@@ -2615,7 +2706,7 @@ describe('Service', () => {
 
     expect(sidecar.createWebHook).toHaveBeenCalledTimes(1);
     expect(sidecar.createWebHook).toHaveBeenCalledWith(
-      mockedReverseSwap.id,
+      response.id,
       webHook.url,
       webHook.hashSwapId,
       undefined,
@@ -2640,6 +2731,7 @@ describe('Service', () => {
       preimageHash,
       percentageFee,
       claimPublicKey,
+      id: expect.any(String),
       baseCurrency: 'LTC',
       quoteCurrency: 'BTC',
       claimCovenant: false,
@@ -2783,7 +2875,7 @@ describe('Service', () => {
 
     expect(response).toEqual({
       onchainAmount,
-      id: mockedReverseSwap.id,
+      id: expect.any(String),
       invoice: mockedReverseSwap.invoice,
       redeemScript: mockedReverseSwap.redeemScript,
       lockupAddress: mockedReverseSwap.lockupAddress,
@@ -2792,6 +2884,7 @@ describe('Service', () => {
 
     expect(mockCreateReverseSwap).toHaveBeenCalledTimes(1);
     expect(mockCreateReverseSwap).toHaveBeenCalledWith({
+      id: expect.any(String),
       preimageHash,
       onchainAmount,
       claimPublicKey,
@@ -2810,7 +2903,7 @@ describe('Service', () => {
     expect(ExtraFeeRepository.create).toHaveBeenCalledWith({
       fee: extraFee,
       id: extraFees.id,
-      swapId: mockedReverseSwap.id,
+      swapId: expect.any(String),
       percentage: extraFees.percentage,
     });
   });
@@ -2853,7 +2946,7 @@ describe('Service', () => {
     });
 
     expect(response).toEqual({
-      id: mockedReverseSwap.id,
+      id: expect.any(String),
       invoice: mockedReverseSwap.invoice,
       redeemScript: mockedReverseSwap.redeemScript,
       lockupAddress: mockedReverseSwap.lockupAddress,
@@ -2862,6 +2955,7 @@ describe('Service', () => {
 
     expect(mockCreateReverseSwap).toHaveBeenCalledTimes(1);
     expect(mockCreateReverseSwap).toHaveBeenCalledWith({
+      id: expect.any(String),
       preimageHash,
       onchainAmount,
       claimPublicKey,
@@ -2880,12 +2974,12 @@ describe('Service', () => {
     expect(ExtraFeeRepository.create).toHaveBeenCalledWith({
       fee: extraFee,
       id: extraFees.id,
-      swapId: mockedReverseSwap.id,
+      swapId: expect.any(String),
       percentage: extraFees.percentage,
     });
   });
 
-  test('should delete reverse swap when adding webhook fails', async () => {
+  test('should reject reverse swap creation when adding a webhook fails', async () => {
     const pair = 'BTC/BTC';
     const orderSide = 'buy';
     const referralId = 'asdf';
@@ -2898,11 +2992,11 @@ describe('Service', () => {
       url: 'http',
       hashSwapId: true,
     };
-    sidecar.createWebHook = jest.fn();
 
     sidecar.createWebHook = jest.fn().mockImplementation(async () => {
       throw 'fail';
     });
+
     await expect(
       service.createReverseSwap({
         webHook,
@@ -2915,17 +3009,239 @@ describe('Service', () => {
         pairId: pair,
         version: SwapVersion.Legacy,
       }),
-    ).rejects.toEqual('setting Webhook failed: fail');
+    ).rejects.toEqual(Errors.COULD_NOT_REGISTER_WEBHOOK());
 
     expect(sidecar.createWebHook).toHaveBeenCalledTimes(1);
-    expect(ReverseRoutingHintRepository.getHint).toHaveBeenCalledTimes(1);
-    expect(ReverseRoutingHintRepository.getHint).toHaveBeenCalledWith(
-      mockedReverseSwap.id,
-    );
-    expect(ReverseSwapRepository.getReverseSwap).toHaveBeenCalledTimes(2);
-    expect(ReverseSwapRepository.getReverseSwap).toHaveBeenCalledWith({
-      id: mockedReverseSwap.id,
+    expect(sidecar.deleteWebHook).not.toHaveBeenCalled();
+    expect(service.swapManager.createReverseSwap).not.toHaveBeenCalled();
+    expect(ReverseRoutingHintRepository.getHint).not.toHaveBeenCalled();
+  });
+
+  test('should reject chain swap creation when adding a webhook fails', async () => {
+    const chainService = createService();
+    const chainSwapManager = mockedSwapManager() as any;
+    const createChainSwap = jest.fn().mockResolvedValue({
+      id: 'chainId',
+      claimDetails: { amount: 98_900 },
+      lockupDetails: {
+        amount: 100_000,
+        lockupAddress: 'lockupAddress',
+      },
     });
+
+    chainSwapManager.createChainSwap = createChainSwap;
+    chainSwapManager.renegotiator = {
+      getFees: jest.fn().mockReturnValue({
+        baseFee: 100,
+        feePercent: 0.01,
+      }),
+      calculateServerLockAmount: jest.fn().mockReturnValue({
+        percentageFee: 1_000,
+        serverLockAmount: 98_900,
+      }),
+    };
+    chainService.swapManager = chainSwapManager;
+
+    (chainService as any).getPair = jest.fn().mockResolvedValue({
+      base: 'LTC',
+      quote: 'BTC',
+      rate: 1,
+      referral: null,
+    });
+    (chainService as any).verifyAmount = jest.fn().mockResolvedValue(undefined);
+    (chainService as any).timeoutDeltaProvider.getTimeout = jest
+      .fn()
+      .mockResolvedValue([1, true]);
+    (chainService as any).balanceCheck.checkBalance = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    (chainService as any).paymentRequestUtils.encodeBip21 = jest
+      .fn()
+      .mockReturnValue('bip21');
+
+    mockGetSwapResult = null;
+    mockGetReverseSwapResult = null;
+    ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
+    ChainSwapRepository.destroy = jest.fn().mockResolvedValue(undefined);
+    sidecar.createWebHook = jest.fn().mockRejectedValue(new Error('fail'));
+
+    try {
+      await expect(
+        chainService.createChainSwap({
+          pairId: 'LTC/BTC',
+          orderSide: 'buy',
+          userLockAmount: 100_000,
+          preimageHash: randomBytes(32),
+          claimPublicKey: getHexBuffer('0xfff'),
+          refundPublicKey: getHexBuffer('0xfff'),
+          webHook: {
+            url: 'http',
+            hashSwapId: true,
+          },
+        }),
+      ).rejects.toEqual(Errors.COULD_NOT_REGISTER_WEBHOOK());
+
+      // Webhook is registered before the chain swap, so a failure means no
+      // swap was created and there is nothing to clean up
+      expect(sidecar.deleteWebHook).not.toHaveBeenCalled();
+      expect(createChainSwap).not.toHaveBeenCalled();
+      expect(ChainSwapRepository.destroy).not.toHaveBeenCalled();
+    } finally {
+      chainService['nodeInfo'].stopSchedule();
+    }
+  });
+
+  test('should remove the webhook when chain swap creation fails', async () => {
+    const chainService = createService();
+    const chainSwapManager = mockedSwapManager() as any;
+    const createChainSwap = jest
+      .fn()
+      .mockRejectedValue('chain creation failed');
+
+    chainSwapManager.createChainSwap = createChainSwap;
+    chainSwapManager.renegotiator = {
+      getFees: jest.fn().mockReturnValue({
+        baseFee: 100,
+        feePercent: 0.01,
+      }),
+      calculateServerLockAmount: jest.fn().mockReturnValue({
+        percentageFee: 1_000,
+        serverLockAmount: 98_900,
+      }),
+    };
+    chainService.swapManager = chainSwapManager;
+
+    (chainService as any).getPair = jest.fn().mockResolvedValue({
+      base: 'LTC',
+      quote: 'BTC',
+      rate: 1,
+      referral: null,
+    });
+    (chainService as any).verifyAmount = jest.fn().mockResolvedValue(undefined);
+    (chainService as any).timeoutDeltaProvider.getTimeout = jest
+      .fn()
+      .mockResolvedValue([1, true]);
+    (chainService as any).balanceCheck.checkBalance = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    (chainService as any).paymentRequestUtils.encodeBip21 = jest
+      .fn()
+      .mockReturnValue('bip21');
+
+    mockGetSwapResult = null;
+    mockGetReverseSwapResult = null;
+    ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
+    ChainSwapRepository.destroy = jest.fn().mockResolvedValue(undefined);
+    sidecar.createWebHook = jest.fn().mockResolvedValue(undefined);
+    sidecar.deleteWebHook = jest.fn().mockResolvedValue(undefined);
+
+    try {
+      await expect(
+        chainService.createChainSwap({
+          pairId: 'LTC/BTC',
+          orderSide: 'buy',
+          userLockAmount: 100_000,
+          preimageHash: randomBytes(32),
+          claimPublicKey: getHexBuffer('0xfff'),
+          refundPublicKey: getHexBuffer('0xfff'),
+          webHook: {
+            url: 'http',
+            hashSwapId: true,
+          },
+        }),
+      ).rejects.toEqual('chain creation failed');
+
+      expect(createChainSwap).toHaveBeenCalledTimes(1);
+      expect(sidecar.createWebHook).toHaveBeenCalledTimes(1);
+      const registeredId = (sidecar.createWebHook as jest.Mock).mock
+        .calls[0][0];
+      expect(sidecar.deleteWebHook).toHaveBeenCalledTimes(1);
+      expect(sidecar.deleteWebHook).toHaveBeenCalledWith(registeredId);
+    } finally {
+      chainService['nodeInfo'].stopSchedule();
+    }
+  });
+
+  test('should return the registered id when creating a chain swap', async () => {
+    const chainService = createService();
+    const chainSwapManager = mockedSwapManager() as any;
+    const createChainSwap = jest.fn().mockResolvedValue({
+      id: 'managerId',
+      claimDetails: { amount: 98_900 },
+      lockupDetails: {
+        amount: 100_000,
+        lockupAddress: 'lockupAddress',
+      },
+    });
+
+    chainSwapManager.createChainSwap = createChainSwap;
+    chainSwapManager.renegotiator = {
+      getFees: jest.fn().mockReturnValue({
+        baseFee: 100,
+        feePercent: 0.01,
+      }),
+      calculateServerLockAmount: jest.fn().mockReturnValue({
+        percentageFee: 1_000,
+        serverLockAmount: 98_900,
+      }),
+    };
+    chainService.swapManager = chainSwapManager;
+
+    (chainService as any).getPair = jest.fn().mockResolvedValue({
+      base: 'LTC',
+      quote: 'BTC',
+      rate: 1,
+      referral: null,
+    });
+    (chainService as any).verifyAmount = jest.fn().mockResolvedValue(undefined);
+    (chainService as any).timeoutDeltaProvider.getTimeout = jest
+      .fn()
+      .mockResolvedValue([1, true]);
+    (chainService as any).balanceCheck.checkBalance = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    (chainService as any).paymentRequestUtils.encodeBip21 = jest
+      .fn()
+      .mockReturnValue('bip21');
+
+    mockGetSwapResult = null;
+    mockGetReverseSwapResult = null;
+    ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
+    sidecar.createWebHook = jest.fn().mockResolvedValue(undefined);
+    sidecar.deleteWebHook = jest.fn().mockResolvedValue(undefined);
+
+    try {
+      const response = await chainService.createChainSwap({
+        pairId: 'LTC/BTC',
+        orderSide: 'buy',
+        userLockAmount: 100_000,
+        preimageHash: randomBytes(32),
+        claimPublicKey: getHexBuffer('0xfff'),
+        refundPublicKey: getHexBuffer('0xfff'),
+        webHook: {
+          url: 'http',
+          hashSwapId: true,
+        },
+      });
+
+      expect(response.id).not.toEqual('managerId');
+      expect(response.claimDetails).toEqual({ amount: 98_900 });
+      expect(response.lockupDetails).toEqual({
+        amount: 100_000,
+        lockupAddress: 'lockupAddress',
+        bip21: 'bip21',
+      });
+
+      const registeredId = (sidecar.createWebHook as jest.Mock).mock
+        .calls[0][0];
+      expect(response.id).toEqual(registeredId);
+      expect(createChainSwap).toHaveBeenCalledWith(
+        expect.objectContaining({ id: response.id }),
+      );
+      expect(sidecar.deleteWebHook).not.toHaveBeenCalled();
+    } finally {
+      chainService['nodeInfo'].stopSchedule();
+    }
   });
 
   test('should not create Reverse Swaps with reused preiamge hash', async () => {
@@ -2987,6 +3303,7 @@ describe('Service', () => {
       preimageHash,
       onchainAmount,
       claimPublicKey,
+      id: expect.any(String),
       baseCurrency: 'BTC',
       quoteCurrency: 'BTC',
       claimCovenant: false,
@@ -3020,6 +3337,7 @@ describe('Service', () => {
     });
 
     expect(mockCreateReverseSwap).toHaveBeenCalledWith({
+      id: expect.any(String),
       preimageHash,
       onchainAmount,
       percentageFee,
@@ -3057,7 +3375,7 @@ describe('Service', () => {
 
     expect(response).toEqual({
       onchainAmount,
-      id: mockedReverseSwap.id,
+      id: expect.any(String),
       invoice: mockedReverseSwap.invoice,
       redeemScript: mockedReverseSwap.redeemScript,
       lockupAddress: mockedReverseSwap.lockupAddress,
@@ -3067,6 +3385,7 @@ describe('Service', () => {
 
     expect(mockCreateReverseSwap).toHaveBeenCalledTimes(1);
     expect(mockCreateReverseSwap).toHaveBeenCalledWith({
+      id: expect.any(String),
       preimageHash,
       onchainAmount,
       claimPublicKey,
@@ -3116,7 +3435,7 @@ describe('Service', () => {
 
     expect(response).toEqual({
       onchainAmount,
-      id: mockedReverseSwap.id,
+      id: expect.any(String),
       invoice: mockedReverseSwap.invoice,
       redeemScript: mockedReverseSwap.redeemScript,
       lockupAddress: mockedReverseSwap.lockupAddress,
@@ -3130,6 +3449,7 @@ describe('Service', () => {
 
     expect(mockCreateReverseSwap).toHaveBeenCalledTimes(1);
     expect(mockCreateReverseSwap).toHaveBeenCalledWith({
+      id: expect.any(String),
       onchainAmount,
       percentageFee,
       prepayMinerFeeOnchainAmount,
@@ -3182,6 +3502,7 @@ describe('Service', () => {
       prepayMinerFeeOnchainAmount * (1 / pairRate);
 
     expect(mockCreateReverseSwap).toHaveBeenCalledWith({
+      id: expect.any(String),
       prepayMinerFeeOnchainAmount,
       prepayMinerFeeInvoiceAmount,
       baseCurrency: 'ETH',
@@ -3227,6 +3548,7 @@ describe('Service', () => {
 
       expect(mockCreateReverseSwap).toHaveBeenCalledWith({
         claimPublicKey,
+        id: expect.any(String),
         baseCurrency: 'BTC',
         quoteCurrency: 'BTC',
         claimCovenant: false,
@@ -3240,6 +3562,47 @@ describe('Service', () => {
         onchainTimeoutBlockDelta: expect.anything(),
         lightningTimeoutBlockDelta: expect.anything(),
       });
+    });
+
+    test('should remove the webhook when reverse swap creation fails', async () => {
+      const paymentHash = randomBytes(32);
+      const invoice = 'lni';
+
+      ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
+      mockGetSwapResult = null;
+      mockGetReverseSwapResult = null;
+      service.sidecar.decodeInvoiceOrOffer = jest.fn().mockResolvedValue({
+        type: InvoiceType.Bolt12Invoice,
+        paymentHash,
+        amountMsat: 100_000_000,
+      } as any);
+
+      sidecar.createWebHook = jest.fn().mockResolvedValue(undefined);
+      sidecar.deleteWebHook = jest.fn().mockResolvedValue(undefined);
+      mockCreateReverseSwap.mockRejectedValueOnce('reverse creation failed');
+
+      await expect(
+        service.createReverseSwap({
+          invoice,
+          orderSide: 'buy',
+          claimPublicKey: getHexBuffer('0xfff'),
+          pairId: 'BTC/BTC',
+          version: SwapVersion.Legacy,
+          webHook: {
+            url: 'http',
+            hashSwapId: true,
+          },
+        }),
+      ).rejects.toEqual('reverse creation failed');
+
+      // The webhook was registered before the swap creation failed, so it must
+      // be cleaned up
+      expect(sidecar.createWebHook).toHaveBeenCalledTimes(1);
+      const registeredId = (sidecar.createWebHook as jest.Mock).mock
+        .calls[0][0];
+      expect(sidecar.deleteWebHook).toHaveBeenCalledTimes(1);
+      expect(sidecar.deleteWebHook).toHaveBeenCalledWith(registeredId);
+      expect(ReverseRoutingHintRepository.getHint).not.toHaveBeenCalled();
     });
 
     test('should throw if invoice and preimage hash are specified', async () => {
@@ -3907,9 +4270,8 @@ describe('Service', () => {
         hashSwapId: true,
         status: [SwapUpdateEvent.SwapCreated],
       };
-      const callback = jest.fn();
 
-      await service['addWebHook'](id, data, callback);
+      await expect(service['addWebHook'](id, data)).resolves.toBeUndefined();
 
       expect(sidecar.createWebHook).toHaveBeenCalledTimes(1);
       expect(sidecar.createWebHook).toHaveBeenCalledWith(
@@ -3918,23 +4280,21 @@ describe('Service', () => {
         data.hashSwapId,
         data.status,
       );
-
-      expect(callback).not.toHaveBeenCalled();
     });
 
-    test('should call swap deletion function when adding webhook fails', async () => {
+    test('should throw a redacted error when adding a webhook fails', async () => {
       const id = 'asdf';
       const data: WebHookData = {
-        url: 'http',
+        url: 'https://secret.example/webhook',
         hashSwapId: true,
       };
-      const callback = jest.fn();
+      const warn = jest.spyOn(Logger.disabledLogger, 'warn');
 
       sidecar.createWebHook = jest.fn().mockImplementation(async () => {
-        throw 'fail';
+        throw new Error('private sidecar failure');
       });
-      await expect(service['addWebHook'](id, data, callback)).rejects.toEqual(
-        'setting Webhook failed: fail',
+      await expect(service['addWebHook'](id, data)).rejects.toEqual(
+        Errors.COULD_NOT_REGISTER_WEBHOOK(),
       );
 
       expect(sidecar.createWebHook).toHaveBeenCalledTimes(1);
@@ -3944,8 +4304,40 @@ describe('Service', () => {
         data.hashSwapId,
         undefined,
       );
+      expect(warn).toHaveBeenCalledWith(
+        `Registering webhook for swap ${id} failed: private sidecar failure`,
+      );
+      expect(warn.mock.calls[0][0]).not.toContain(data.url);
 
-      expect(callback).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    });
+
+    test('should remove webhook', async () => {
+      sidecar.deleteWebHook = jest.fn().mockResolvedValue(undefined);
+
+      const id = 'asdf';
+      await expect(service['removeWebHook'](id)).resolves.toBeUndefined();
+
+      expect(sidecar.deleteWebHook).toHaveBeenCalledTimes(1);
+      expect(sidecar.deleteWebHook).toHaveBeenCalledWith(id);
+    });
+
+    test('should swallow errors when removing a webhook fails', async () => {
+      const id = 'asdf';
+      const warn = jest.spyOn(Logger.disabledLogger, 'warn');
+
+      sidecar.deleteWebHook = jest.fn().mockImplementation(async () => {
+        throw new Error('private sidecar failure');
+      });
+      await expect(service['removeWebHook'](id)).resolves.toBeUndefined();
+
+      expect(sidecar.deleteWebHook).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        `Could not remove webhook for swap ${id}`,
+      );
+      expect(warn.mock.calls[0][0]).not.toContain('private sidecar failure');
+
+      warn.mockRestore();
     });
   });
 

--- a/test/unit/sidecar/Sidecar.spec.ts
+++ b/test/unit/sidecar/Sidecar.spec.ts
@@ -68,6 +68,20 @@ describe('Sidecar', () => {
     });
   });
 
+  describe('deleteWebHook', () => {
+    test('should call the sidecar to delete a webhook', async () => {
+      const unaryNodeCall = jest.fn().mockResolvedValue(undefined);
+      sidecar['unaryNodeCall'] = unaryNodeCall;
+
+      await sidecar.deleteWebHook('swap-id');
+
+      expect(unaryNodeCall).toHaveBeenCalledTimes(1);
+      expect(unaryNodeCall).toHaveBeenCalledWith('deleteWebHook', {
+        id: 'swap-id',
+      });
+    });
+  });
+
   describe('subscribeSwapUpdates', () => {
     test('should serialize transaction confirmed flag', async () => {
       const stream = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deleting webhooks by swap ID.
  * Added webhook cleanup when swap creation fails after registration.
  * Added consistent error reporting for webhook registration failures.

* **Bug Fixes**
  * Improved webhook lifecycle handling to prevent stale registrations.
  * Ensured cleanup failures are logged without masking the original error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->