### PR TITLE
fix: swap update event races

### DIFF
--- a/lib/db/LockupIdentity.ts
+++ b/lib/db/LockupIdentity.ts
@@ -1,0 +1,120 @@
+import { SwapUpdateEvent } from '../consts/Enums';
+
+enum LockupWriteOutcome {
+  Acquired = 'acquired',
+  Idempotent = 'idempotent',
+  Rejected = 'rejected',
+}
+
+type LockupWriteResult<T> = {
+  outcome: LockupWriteOutcome;
+  swap: T;
+};
+
+type LockupTargetStatus =
+  | SwapUpdateEvent.TransactionMempool
+  | SwapUpdateEvent.TransactionConfirmed
+  | SwapUpdateEvent.TransactionLockupFailed;
+
+type LockupIdentity = {
+  transactionId: string;
+  vout?: number | null;
+};
+
+const lockupTakeoverStatuses = [
+  SwapUpdateEvent.TransactionLockupFailed,
+  SwapUpdateEvent.TransactionZeroConfRejected,
+];
+
+const canTakeOverLockup = (status: SwapUpdateEvent): boolean =>
+  lockupTakeoverStatuses.includes(status);
+
+const isSameLockup = (
+  existing: LockupIdentity,
+  incoming: LockupIdentity,
+): boolean =>
+  existing.transactionId === incoming.transactionId &&
+  (existing.vout == null ||
+    incoming.vout == null ||
+    existing.vout === incoming.vout);
+
+type LockupWriteDecision = {
+  outcome: LockupWriteOutcome;
+  write: boolean;
+  vout: number | null;
+};
+
+const decideLockupWrite = ({
+  existing,
+  incoming,
+  currentStatus,
+  targetStatus,
+  updatable,
+}: {
+  existing: LockupIdentity | null;
+  incoming: LockupIdentity;
+  currentStatus: SwapUpdateEvent;
+  targetStatus: LockupTargetStatus;
+  updatable: boolean;
+}): LockupWriteDecision => {
+  if (existing === null) {
+    if (!updatable) {
+      return { outcome: LockupWriteOutcome.Rejected, write: false, vout: null };
+    }
+
+    return {
+      outcome: LockupWriteOutcome.Acquired,
+      write: true,
+      vout: incoming.vout ?? null,
+    };
+  }
+
+  if (isSameLockup(existing, incoming)) {
+    const wouldDowngradeConfirmed =
+      currentStatus === SwapUpdateEvent.TransactionConfirmed &&
+      targetStatus !== SwapUpdateEvent.TransactionConfirmed;
+
+    return {
+      outcome: LockupWriteOutcome.Idempotent,
+      write: updatable && !wouldDowngradeConfirmed,
+      vout: incoming.vout ?? existing.vout ?? null,
+    };
+  }
+
+  if (updatable && canTakeOverLockup(currentStatus)) {
+    return {
+      outcome: LockupWriteOutcome.Acquired,
+      write: true,
+      vout: incoming.vout ?? null,
+    };
+  }
+
+  return { outcome: LockupWriteOutcome.Rejected, write: false, vout: null };
+};
+
+const shouldWriteZeroConfRejection = ({
+  existing,
+  incoming,
+  currentStatus,
+}: {
+  existing: LockupIdentity | null;
+  incoming: LockupIdentity;
+  currentStatus: SwapUpdateEvent;
+}): boolean =>
+  existing !== null &&
+  currentStatus === SwapUpdateEvent.TransactionMempool &&
+  isSameLockup(existing, incoming);
+
+export {
+  LockupWriteOutcome,
+  canTakeOverLockup,
+  isSameLockup,
+  decideLockupWrite,
+  shouldWriteZeroConfRejection,
+};
+export type {
+  LockupWriteResult,
+  LockupTargetStatus,
+  LockupIdentity,
+  LockupWriteDecision,
+};

--- a/lib/db/repositories/ChainSwapRepository.ts
+++ b/lib/db/repositories/ChainSwapRepository.ts
@@ -13,6 +13,12 @@ import {
 } from '../../consts/Enums';
 import type { IncorrectAmountDetails } from '../../consts/Types';
 import Database from '../Database';
+import type { LockupTargetStatus, LockupWriteResult } from '../LockupIdentity';
+import {
+  LockupWriteOutcome,
+  decideLockupWrite,
+  shouldWriteZeroConfRejection,
+} from '../LockupIdentity';
 import type { ChainSwapType } from '../models/ChainSwap';
 import ChainSwap from '../models/ChainSwap';
 import type { ChainSwapDataType } from '../models/ChainSwapData';
@@ -337,57 +343,112 @@ class ChainSwapRepository {
       },
     );
 
-  public static setUserLockupTransaction = (
+  public static setUserLockupTransaction = async (
     swap: ChainSwapInfo,
     lockupTransactionId: string,
     onchainAmount: number,
-    confirmed: boolean,
+    status: LockupTargetStatus,
     lockupTransactionVout?: number,
     options?: UserLockupTransactionOptions,
-  ): Promise<ChainSwapInfo> => {
-    const update = async () =>
-      Database.sequelize.transaction(async (transaction) => {
-        const [updatedRows] = await ChainSwap.update(
-          {
-            status: confirmed
-              ? SwapUpdateEvent.TransactionConfirmed
-              : SwapUpdateEvent.TransactionMempool,
-          },
-          {
-            transaction,
-            where: {
-              id: swap.id,
-              status: {
-                [Op.in]:
-                  ChainSwapRepository.getUserLockupTransactionStatuses(options),
-              },
-            },
-          },
-        );
-
-        if (updatedRows === 0) {
-          return;
+  ): Promise<LockupWriteResult<ChainSwapInfo>> => {
+    const outcome = await Database.sequelize.transaction(
+      async (transaction) => {
+        const current = await ChainSwap.findOne({
+          transaction,
+          lock: transaction.LOCK.UPDATE,
+          where: { id: swap.id },
+        });
+        const currentData = await ChainSwapData.findOne({
+          transaction,
+          where: { swapId: swap.id, symbol: swap.receivingData.symbol },
+        });
+        if (current === null || currentData === null) {
+          return LockupWriteOutcome.Rejected;
         }
 
-        await ChainSwapData.update(
-          {
-            amount: onchainAmount,
-            transactionId: lockupTransactionId,
-            transactionVout: lockupTransactionVout,
-          },
-          {
-            transaction,
-            where: {
-              swapId: swap.id,
-              symbol: swap.receivingData.symbol,
-            },
-          },
-        );
-      });
+        const updatable = ChainSwapRepository.getUserLockupTransactionStatuses(
+          options,
+        ).includes(current.status as SwapUpdateEvent);
 
-    return update().then(
-      async () => (await ChainSwapRepository.getChainSwap({ id: swap.id }))!,
+        const decision = decideLockupWrite({
+          existing:
+            currentData.transactionId == null
+              ? null
+              : {
+                  transactionId: currentData.transactionId,
+                  vout: currentData.transactionVout,
+                },
+          incoming: {
+            transactionId: lockupTransactionId,
+            vout: lockupTransactionVout,
+          },
+          currentStatus: current.status as SwapUpdateEvent,
+          targetStatus: status,
+          updatable,
+        });
+
+        if (decision.write) {
+          await current.update({ status }, { transaction });
+          await currentData.update(
+            {
+              amount: onchainAmount,
+              transactionId: lockupTransactionId,
+              transactionVout: decision.vout,
+            },
+            { transaction },
+          );
+        }
+
+        return decision.outcome;
+      },
     );
+
+    return {
+      outcome,
+      swap: (await ChainSwapRepository.getChainSwap({ id: swap.id }))!,
+    };
+  };
+
+  public static setZeroConfRejected = async (
+    swap: ChainSwapInfo,
+    transactionId: string,
+    transactionVout?: number,
+  ): Promise<ChainSwapInfo> => {
+    await Database.sequelize.transaction(async (transaction) => {
+      const current = await ChainSwap.findOne({
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+        where: { id: swap.id },
+      });
+      const currentData = await ChainSwapData.findOne({
+        transaction,
+        where: { swapId: swap.id, symbol: swap.receivingData.symbol },
+      });
+      if (
+        current === null ||
+        currentData === null ||
+        !shouldWriteZeroConfRejection({
+          existing:
+            currentData.transactionId == null
+              ? null
+              : {
+                  transactionId: currentData.transactionId,
+                  vout: currentData.transactionVout,
+                },
+          incoming: { transactionId, vout: transactionVout },
+          currentStatus: current.status as SwapUpdateEvent,
+        })
+      ) {
+        return;
+      }
+
+      await current.update(
+        { status: SwapUpdateEvent.TransactionZeroConfRejected },
+        { transaction },
+      );
+    });
+
+    return (await ChainSwapRepository.getChainSwap({ id: swap.id }))!;
   };
 
   public static setExpectedAmounts = (

--- a/lib/db/repositories/ChainSwapRepository.ts
+++ b/lib/db/repositories/ChainSwapRepository.ts
@@ -360,6 +360,7 @@ class ChainSwapRepository {
         });
         const currentData = await ChainSwapData.findOne({
           transaction,
+          lock: transaction.LOCK.UPDATE,
           where: { swapId: swap.id, symbol: swap.receivingData.symbol },
         });
         if (current === null || currentData === null) {
@@ -422,6 +423,7 @@ class ChainSwapRepository {
       });
       const currentData = await ChainSwapData.findOne({
         transaction,
+        lock: transaction.LOCK.UPDATE,
         where: { swapId: swap.id, symbol: swap.receivingData.symbol },
       });
       if (

--- a/lib/db/repositories/SwapRepository.ts
+++ b/lib/db/repositories/SwapRepository.ts
@@ -2,14 +2,23 @@ import type { CreateOptions, Order, WhereOptions } from 'sequelize';
 import { Op, Transaction } from 'sequelize';
 import { SwapUpdateEvent } from '../../consts/Enums';
 import Database from '../Database';
+import type { LockupTargetStatus, LockupWriteResult } from '../LockupIdentity';
+import {
+  LockupWriteOutcome,
+  decideLockupWrite,
+  shouldWriteZeroConfRejection,
+} from '../LockupIdentity';
 import type { SwapType } from '../models/Swap';
 import Swap from '../models/Swap';
 
 class SwapRepository {
   public static readonly lockupNonUpdatableStatuses = [
+    SwapUpdateEvent.InvoicePending,
     SwapUpdateEvent.InvoicePaid,
+    SwapUpdateEvent.InvoiceFailedToPay,
     SwapUpdateEvent.TransactionClaimPending,
     SwapUpdateEvent.TransactionClaimed,
+    SwapUpdateEvent.SwapExpired,
   ];
 
   public static getSwaps = (
@@ -126,27 +135,94 @@ class SwapRepository {
     swap: Swap,
     lockupTransactionId: string,
     onchainAmount: number,
-    confirmed: boolean,
+    status: LockupTargetStatus,
     lockupTransactionVout?: number,
-  ): Promise<Swap> => {
-    await Swap.update(
-      {
-        onchainAmount,
-        lockupTransactionId,
-        lockupTransactionVout,
-        status: confirmed
-          ? SwapUpdateEvent.TransactionConfirmed
-          : SwapUpdateEvent.TransactionMempool,
-      },
-      {
-        where: {
-          id: swap.id,
-          status: {
-            [Op.notIn]: SwapRepository.lockupNonUpdatableStatuses,
+  ): Promise<LockupWriteResult<Swap>> => {
+    const outcome = await Database.sequelize.transaction(
+      async (transaction) => {
+        const current = await Swap.findOne({
+          transaction,
+          lock: transaction.LOCK.UPDATE,
+          where: { id: swap.id },
+        });
+        if (current === null) {
+          return LockupWriteOutcome.Rejected;
+        }
+
+        const decision = decideLockupWrite({
+          existing:
+            current.lockupTransactionId == null
+              ? null
+              : {
+                  transactionId: current.lockupTransactionId,
+                  vout: current.lockupTransactionVout,
+                },
+          incoming: {
+            transactionId: lockupTransactionId,
+            vout: lockupTransactionVout,
           },
-        },
+          currentStatus: current.status as SwapUpdateEvent,
+          targetStatus: status,
+          updatable: !SwapRepository.lockupNonUpdatableStatuses.includes(
+            current.status as SwapUpdateEvent,
+          ),
+        });
+
+        if (decision.write) {
+          await current.update(
+            {
+              status,
+              onchainAmount,
+              lockupTransactionId,
+              lockupTransactionVout: decision.vout,
+            },
+            { transaction },
+          );
+        }
+
+        return decision.outcome;
       },
     );
+
+    return {
+      outcome,
+      swap: (await SwapRepository.getSwap({ id: swap.id })) || swap,
+    };
+  };
+
+  public static setZeroConfRejected = async (
+    swap: Swap,
+    transactionId: string,
+    transactionVout?: number,
+  ): Promise<Swap> => {
+    await Database.sequelize.transaction(async (transaction) => {
+      const current = await Swap.findOne({
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+        where: { id: swap.id },
+      });
+      if (
+        current === null ||
+        !shouldWriteZeroConfRejection({
+          existing:
+            current.lockupTransactionId == null
+              ? null
+              : {
+                  transactionId: current.lockupTransactionId,
+                  vout: current.lockupTransactionVout,
+                },
+          incoming: { transactionId, vout: transactionVout },
+          currentStatus: current.status as SwapUpdateEvent,
+        })
+      ) {
+        return;
+      }
+
+      await current.update(
+        { status: SwapUpdateEvent.TransactionZeroConfRejected },
+        { transaction },
+      );
+    });
 
     return (await SwapRepository.getSwap({ id: swap.id })) || swap;
   };

--- a/lib/service/Renegotiator.ts
+++ b/lib/service/Renegotiator.ts
@@ -148,12 +148,22 @@ class Renegotiator {
             throw EthereumErrors.UNSUPPORTED_CONTRACT();
           }
 
-          const topicHash = (
-            isEther ? contracts.etherSwap : contracts.erc20Swap
-          ).interface.getEvent('Lockup').topicHash;
-          const lockupEvent = receipt.logs.find(
-            (log) => log.topics.length > 0 && log.topics[0] === topicHash,
+          const contract = isEther ? contracts.etherSwap : contracts.erc20Swap;
+          const topicHash = contract.interface.getEvent('Lockup').topicHash;
+          const contractAddress = (await contract.getAddress()).toLowerCase();
+          const lockupEvents = receipt.logs.filter(
+            (log) =>
+              log.topics.length > 0 &&
+              log.topics[0] === topicHash &&
+              log.address.toLowerCase() === contractAddress,
           );
+          const storedLogIndex = swap.receivingData.transactionVout;
+          const lockupEvent =
+            storedLogIndex != null
+              ? lockupEvents.find((log) => log.index === storedLogIndex)
+              : lockupEvents.length === 1
+                ? lockupEvents[0]
+                : undefined;
           if (lockupEvent === undefined) {
             throw Errors.LOCKUP_NOT_REJECTED();
           }
@@ -177,6 +187,7 @@ class Renegotiator {
               updatedSwap,
               transaction,
               formatEtherSwapValues(values),
+              lockupEvent.index,
               { allowLockupFailedUpdate: true },
             );
           } else {
@@ -190,6 +201,7 @@ class Renegotiator {
               updatedSwap,
               transaction,
               formatERC20SwapValues(values),
+              lockupEvent.index,
               { allowLockupFailedUpdate: true },
             );
           }

--- a/lib/service/cooperative/DeferredClaimer.ts
+++ b/lib/service/cooperative/DeferredClaimer.ts
@@ -518,6 +518,10 @@ class DeferredClaimer extends CoopSignerBase<{
                 ? (swap.swap as Swap).lockupTransactionId!
                 : (swap.swap as ChainSwapInfo).receivingData
                     .lockupTransactionId!;
+            const logIndex =
+              swap.swap.type === SwapType.Submarine
+                ? (swap.swap as Swap).lockupTransactionVout
+                : (swap.swap as ChainSwapInfo).receivingData.transactionVout;
 
             return await queryEtherSwapValuesFromLock(
               swap.swap,
@@ -525,6 +529,7 @@ class DeferredClaimer extends CoopSignerBase<{
               contracts.etherSwap,
               transactionId,
               true,
+              logIndex ?? undefined,
             );
           },
           RPC_LOOKUP_CONCURRENCY,
@@ -568,6 +573,10 @@ class DeferredClaimer extends CoopSignerBase<{
                 ? (swap.swap as Swap).lockupTransactionId!
                 : (swap.swap as ChainSwapInfo).receivingData
                     .lockupTransactionId!;
+            const logIndex =
+              swap.swap.type === SwapType.Submarine
+                ? (swap.swap as Swap).lockupTransactionVout
+                : (swap.swap as ChainSwapInfo).receivingData.transactionVout;
 
             return await queryERC20SwapValuesFromLock(
               swap.swap,
@@ -575,6 +584,7 @@ class DeferredClaimer extends CoopSignerBase<{
               contracts.erc20Swap,
               transactionId,
               true,
+              logIndex ?? undefined,
             );
           },
           RPC_LOOKUP_CONCURRENCY,

--- a/lib/service/cooperative/DeferredClaimer.ts
+++ b/lib/service/cooperative/DeferredClaimer.ts
@@ -530,6 +530,7 @@ class DeferredClaimer extends CoopSignerBase<{
               transactionId,
               true,
               logIndex ?? undefined,
+              this.logger,
             );
           },
           RPC_LOOKUP_CONCURRENCY,
@@ -585,6 +586,7 @@ class DeferredClaimer extends CoopSignerBase<{
               transactionId,
               true,
               logIndex ?? undefined,
+              this.logger,
             );
           },
           RPC_LOOKUP_CONCURRENCY,

--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -115,6 +115,10 @@ class EipSigner {
         swap.type === SwapType.Submarine
           ? (swap as Swap).lockupTransactionId
           : (swap as ChainSwapInfo).receivingData.lockupTransactionId;
+      const lockupLogIndex =
+        swap.type === SwapType.Submarine
+          ? (swap as Swap).lockupTransactionVout
+          : (swap as ChainSwapInfo).receivingData.transactionVout;
 
       if (lockupTransactionId === undefined || lockupTransactionId === null) {
         throw Errors.NOT_ELIGIBLE_FOR_COOPERATIVE_REFUND(
@@ -141,6 +145,7 @@ class EipSigner {
             contracts.etherSwap,
             lockupTransactionId,
             true,
+            lockupLogIndex ?? undefined,
           )
         : await queryERC20SwapValuesFromLock(
             swap,
@@ -148,6 +153,7 @@ class EipSigner {
             contracts.erc20Swap,
             lockupTransactionId,
             true,
+            lockupLogIndex ?? undefined,
           );
 
       await EipSigner.setRefundSignatureCreated(swap);

--- a/lib/service/cooperative/EipSigner.ts
+++ b/lib/service/cooperative/EipSigner.ts
@@ -146,6 +146,7 @@ class EipSigner {
             lockupTransactionId,
             true,
             lockupLogIndex ?? undefined,
+            this.logger,
           )
         : await queryERC20SwapValuesFromLock(
             swap,
@@ -154,6 +155,7 @@ class EipSigner {
             lockupTransactionId,
             true,
             lockupLogIndex ?? undefined,
+            this.logger,
           );
 
       await EipSigner.setRefundSignatureCreated(swap);

--- a/lib/swap/ArkNursery.ts
+++ b/lib/swap/ArkNursery.ts
@@ -16,6 +16,7 @@ import {
   swapTypeToPrettyString,
 } from '../consts/Enums';
 import TypedEventEmitter from '../consts/TypedEventEmitter';
+import { LockupWriteOutcome } from '../db/LockupIdentity';
 import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
 import type {
@@ -26,6 +27,7 @@ import ChainSwapRepository from '../db/repositories/ChainSwapRepository';
 import ReverseSwapRepository from '../db/repositories/ReverseSwapRepository';
 import SwapRepository from '../db/repositories/SwapRepository';
 import type { Currency } from '../wallet/WalletManager';
+import { shouldIgnoreCompetingLockup } from './CompetingLockup';
 import Errors from './Errors';
 import type OverpaymentProtector from './OverpaymentProtector';
 
@@ -179,14 +181,36 @@ class ArkNursery extends TypedEventEmitter<{
     this.logger.info(
       `Found ${ArkClient.symbol} lockup vHTLC for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${vHtlc.txId}:${vHtlc.vout}`,
     );
-    swap = await ChainSwapRepository.setUserLockupTransaction(
+    if (
+      shouldIgnoreCompetingLockup({
+        prevId: swap.receivingData.transactionId,
+        prevVout: swap.receivingData.transactionVout,
+        incomingId: vHtlc.txId,
+        incomingVout: vHtlc.vout,
+        recordedStatus: swap.status as SwapUpdateEvent,
+      })
+    ) {
+      this.logger.debug(
+        `Ignoring competing lockup vHTLC ${vHtlc.txId} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
+      );
+      return;
+    }
+
+    const lockupResult = await ChainSwapRepository.setUserLockupTransaction(
       swap,
       vHtlc.txId,
       vHtlc.amount,
-      true,
+      SwapUpdateEvent.TransactionConfirmed,
       vHtlc.vout,
       options,
     );
+    if (lockupResult.outcome === LockupWriteOutcome.Rejected) {
+      this.logger.debug(
+        `Ignoring lockup vHTLC ${vHtlc.txId} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because another lockup owns it`,
+      );
+      return;
+    }
+    swap = lockupResult.swap;
 
     if (!ChainSwapRepository.canActOnUserLockup(swap, options)) {
       this.logger.debug(
@@ -280,14 +304,36 @@ class ArkNursery extends TypedEventEmitter<{
       `Found ${ArkClient.symbol} lockup vHTLC for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${vHtlc.txId}:${vHtlc.vout}`,
     );
 
-    swap = await SwapRepository.setLockupTransaction(
+    if (
+      shouldIgnoreCompetingLockup({
+        prevId: swap.lockupTransactionId,
+        prevVout: swap.lockupTransactionVout,
+        incomingId: vHtlc.txId,
+        incomingVout: vHtlc.vout,
+        recordedStatus: swap.status as SwapUpdateEvent,
+      })
+    ) {
+      this.logger.debug(
+        `Ignoring competing lockup vHTLC ${vHtlc.txId} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
+      );
+      return;
+    }
+
+    const lockupResult = await SwapRepository.setLockupTransaction(
       swap,
       vHtlc.txId,
       vHtlc.amount,
       // TODO: how to handle out of round?
-      true,
+      SwapUpdateEvent.TransactionConfirmed,
       vHtlc.vout,
     );
+    if (lockupResult.outcome === LockupWriteOutcome.Rejected) {
+      this.logger.debug(
+        `Ignoring lockup vHTLC ${vHtlc.txId} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because another lockup owns it`,
+      );
+      return;
+    }
+    swap = lockupResult.swap;
 
     if (swap.expectedAmount! > vHtlc.amount) {
       this.emit('swap.lockup.failed', {

--- a/lib/swap/ArkNursery.ts
+++ b/lib/swap/ArkNursery.ts
@@ -38,6 +38,7 @@ class ArkNursery extends TypedEventEmitter<{
   'swap.lockup': {
     swap: Swap;
     lockupTransactionId: string;
+    lockupTransactionVout: number;
   };
   'swap.lockup.failed': {
     swap: Swap;
@@ -53,6 +54,7 @@ class ArkNursery extends TypedEventEmitter<{
   'chainSwap.lockup': {
     swap: ChainSwapInfo;
     lockupTransactionId: string;
+    lockupTransactionVout: number;
   };
   'chainSwap.lockup.failed': {
     swap: ChainSwapInfo;
@@ -250,6 +252,7 @@ class ArkNursery extends TypedEventEmitter<{
     this.emit('chainSwap.lockup', {
       swap,
       lockupTransactionId: vHtlc.txId,
+      lockupTransactionVout: vHtlc.vout,
     });
   };
 
@@ -362,6 +365,7 @@ class ArkNursery extends TypedEventEmitter<{
     this.emit('swap.lockup', {
       swap,
       lockupTransactionId: vHtlc.txId,
+      lockupTransactionVout: vHtlc.vout,
     });
   };
 

--- a/lib/swap/CompetingLockup.ts
+++ b/lib/swap/CompetingLockup.ts
@@ -1,0 +1,30 @@
+import type { SwapUpdateEvent } from '../consts/Enums';
+import { canTakeOverLockup, isSameLockup } from '../db/LockupIdentity';
+
+type CompetingLockupParams = {
+  prevId: string | null | undefined;
+  prevVout?: number | null;
+  incomingId: string;
+  incomingVout?: number | null;
+  recordedStatus: SwapUpdateEvent;
+};
+
+export const shouldIgnoreCompetingLockup = ({
+  prevId,
+  prevVout,
+  incomingId,
+  incomingVout,
+  recordedStatus,
+}: CompetingLockupParams): boolean => {
+  if (
+    prevId == null ||
+    isSameLockup(
+      { transactionId: prevId, vout: prevVout },
+      { transactionId: incomingId, vout: incomingVout },
+    )
+  ) {
+    return false;
+  }
+
+  return !canTakeOverLockup(recordedStatus);
+};

--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -1,6 +1,7 @@
 import type { TransactionResponse } from 'ethers';
 import { Transaction } from 'ethers';
 import { Op } from 'sequelize';
+import InstrumentedLock from '../InstrumentedLock';
 import type Logger from '../Logger';
 import {
   formatError,
@@ -19,6 +20,7 @@ import {
 } from '../consts/Enums';
 import TypedEventEmitter from '../consts/TypedEventEmitter';
 import type { ERC20SwapValues, EtherSwapValues } from '../consts/Types';
+import { LockupWriteOutcome } from '../db/LockupIdentity';
 import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
 import type {
@@ -33,6 +35,7 @@ import type Wallet from '../wallet/Wallet';
 import type WalletManager from '../wallet/WalletManager';
 import type EthereumManager from '../wallet/ethereum/EthereumManager';
 import type ERC20WalletProvider from '../wallet/providers/ERC20WalletProvider';
+import { shouldIgnoreCompetingLockup } from './CompetingLockup';
 import Errors from './Errors';
 import EthereumTransactionConfirmationTracker from './EthereumConfirmationTracker';
 import type OverpaymentProtector from './OverpaymentProtector';
@@ -44,6 +47,7 @@ class EthereumNursery extends TypedEventEmitter<{
   'eth.lockup': {
     swap: Swap | ChainSwapInfo;
     transactionHash: string;
+    logIndex: number;
     etherSwapValues: EtherSwapValues;
   };
 
@@ -51,6 +55,7 @@ class EthereumNursery extends TypedEventEmitter<{
   'erc20.lockup': {
     swap: Swap | ChainSwapInfo;
     transactionHash: string;
+    logIndex: number;
     erc20SwapValues: ERC20SwapValues;
   };
 
@@ -72,6 +77,7 @@ class EthereumNursery extends TypedEventEmitter<{
   };
 }> {
   private readonly contractTransactionTracker: EthereumTransactionConfirmationTracker;
+  private readonly lock = new InstrumentedLock('ethereumNursery');
 
   constructor(
     private readonly logger: Logger,
@@ -155,70 +161,35 @@ class EthereumNursery extends TypedEventEmitter<{
     this.contractTransactionTracker.trackTransaction(swap, transaction.hash);
   };
 
-  public checkEtherSwapLockup = async (
+  private isCompetingLockup = (
+    swap: Swap | ChainSwapInfo,
+    incomingId: string,
+    incomingVout: number,
+  ): boolean =>
+    shouldIgnoreCompetingLockup({
+      prevId:
+        swap.type === SwapType.Submarine
+          ? (swap as Swap).lockupTransactionId
+          : (swap as ChainSwapInfo).receivingData.transactionId,
+      prevVout:
+        swap.type === SwapType.Submarine
+          ? (swap as Swap).lockupTransactionVout
+          : (swap as ChainSwapInfo).receivingData.transactionVout,
+      incomingId,
+      incomingVout,
+      recordedStatus: swap.status as SwapUpdateEvent,
+    });
+
+  private validateEtherSwapLockup = async (
     swap: Swap | ChainSwapInfo,
     transaction: Transaction | TransactionResponse,
     etherSwapValues: EtherSwapValues,
-    options?: UserLockupTransactionOptions,
-  ) => {
-    if (
-      this.getSwapReceivingCurrency(swap) !==
-      this.ethereumManager.networkDetails.symbol
-    ) {
-      return;
-    }
-
-    this.logger.debug(
-      `Found lockup in ${this.ethereumManager.networkDetails.name} EtherSwap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
-    );
-
-    const lockupAmount = Number(etherSwapValues.amount / etherDecimals);
-    swap =
-      swap.type === SwapType.Submarine
-        ? await SwapRepository.setLockupTransaction(
-            swap as Swap,
-            transaction.hash!,
-            lockupAmount,
-            true,
-          )
-        : await ChainSwapRepository.setUserLockupTransaction(
-            swap as ChainSwapInfo,
-            transaction.hash!,
-            lockupAmount,
-            true,
-            undefined,
-            options,
-          );
-
-    if (
-      swap.type === SwapType.Submarine &&
-      (swap as Swap).refundAddress == null
-    ) {
-      swap = await SwapRepository.setRefundAddress(
-        swap as Swap,
-        etherSwapValues.refundAddress,
-      );
-    }
-
-    if (
-      swap.type === SwapType.Chain &&
-      !ChainSwapRepository.canActOnUserLockup(swap as ChainSwapInfo, options)
-    ) {
-      this.logger.debug(
-        `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
-      );
-      return;
-    }
-
+  ): Promise<string | undefined> => {
     if (etherSwapValues.claimAddress !== this.ethereumManager.address) {
-      this.emit('lockup.failed', {
-        swap,
-        reason: Errors.INVALID_CLAIM_ADDRESS(
-          etherSwapValues.claimAddress,
-          this.ethereumManager.address,
-        ).message,
-      });
-      return;
+      return Errors.INVALID_CLAIM_ADDRESS(
+        etherSwapValues.claimAddress,
+        this.ethereumManager.address,
+      ).message;
     }
 
     const timeoutBlockHeight =
@@ -228,14 +199,10 @@ class EthereumNursery extends TypedEventEmitter<{
 
     // Commitment swaps can have timelocks longer than the swap timeout
     if (etherSwapValues.timelock < timeoutBlockHeight) {
-      this.emit('lockup.failed', {
-        swap,
-        reason: Errors.INVALID_TIMELOCK(
-          etherSwapValues.timelock,
-          timeoutBlockHeight,
-        ).message,
-      });
-      return;
+      return Errors.INVALID_TIMELOCK(
+        etherSwapValues.timelock,
+        timeoutBlockHeight,
+      ).message;
     }
 
     const expectedAmount = this.getSwapExpectedReceivingAmount(swap);
@@ -246,12 +213,8 @@ class EthereumNursery extends TypedEventEmitter<{
         BigInt(expectedAmount) * this.ethereumManager.networkDetails.decimals >
         etherSwapValues.amount
       ) {
-        this.emit('lockup.failed', {
-          swap,
-          reason: Errors.INSUFFICIENT_AMOUNT(actualAmountSat, expectedAmount)
-            .message,
-        });
-        return;
+        return Errors.INSUFFICIENT_AMOUNT(actualAmountSat, expectedAmount)
+          .message;
       }
 
       if (
@@ -261,133 +224,155 @@ class EthereumNursery extends TypedEventEmitter<{
           actualAmountSat,
         )
       ) {
-        this.emit('lockup.failed', {
-          swap,
-          reason: Errors.OVERPAID_AMOUNT(actualAmountSat, expectedAmount)
-            .message,
-        });
+        return Errors.OVERPAID_AMOUNT(actualAmountSat, expectedAmount).message;
+      }
+    }
+
+    const action = await this.transactionHook.hook(
+      swap.id,
+      this.ethereumManager.networkDetails.name,
+      transaction.hash!,
+      getHexBuffer(removeHexPrefix(Transaction.from(transaction).serialized!)),
+      true,
+      swap.type,
+    );
+    if (action === Action.Reject) {
+      return Errors.BLOCKED_ADDRESS().message;
+    }
+
+    return undefined;
+  };
+
+  public checkEtherSwapLockup = async (
+    swap: Swap | ChainSwapInfo,
+    transaction: Transaction | TransactionResponse,
+    etherSwapValues: EtherSwapValues,
+    logIndex: number,
+    options?: UserLockupTransactionOptions,
+  ) => {
+    if (
+      this.getSwapReceivingCurrency(swap) !==
+      this.ethereumManager.networkDetails.symbol
+    ) {
+      return;
+    }
+
+    await this.lock.acquire(swap.id, 'checkEtherSwapLockup', async () => {
+      this.logger.debug(
+        `Found lockup in ${this.ethereumManager.networkDetails.name} EtherSwap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
+      );
+
+      const lockupAmount = Number(etherSwapValues.amount / etherDecimals);
+
+      if (this.isCompetingLockup(swap, transaction.hash!, logIndex)) {
+        this.logger.debug(
+          `Ignoring competing lockup transaction ${transaction.hash} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
+        );
         return;
       }
-    }
 
-    {
-      const action = await this.transactionHook.hook(
-        swap.id,
-        this.ethereumManager.networkDetails.name,
-        transaction.hash!,
-        getHexBuffer(
-          removeHexPrefix(Transaction.from(transaction).serialized!),
-        ),
-        true,
-        swap.type,
+      const reason = await this.validateEtherSwapLockup(
+        swap,
+        transaction,
+        etherSwapValues,
       );
+      const status =
+        reason === undefined
+          ? SwapUpdateEvent.TransactionConfirmed
+          : SwapUpdateEvent.TransactionLockupFailed;
 
-      switch (action) {
-        case Action.Reject:
-          this.emit('lockup.failed', {
-            swap,
-            reason: Errors.BLOCKED_ADDRESS().message,
-          });
-          return;
+      const result =
+        swap.type === SwapType.Submarine
+          ? await SwapRepository.setLockupTransaction(
+              swap as Swap,
+              transaction.hash!,
+              lockupAmount,
+              status,
+              logIndex,
+            )
+          : await ChainSwapRepository.setUserLockupTransaction(
+              swap as ChainSwapInfo,
+              transaction.hash!,
+              lockupAmount,
+              status,
+              logIndex,
+              options,
+            );
+
+      if (result.outcome === LockupWriteOutcome.Rejected) {
+        this.logger.warn(
+          `Ignoring lockup transaction ${transaction.hash}:${logIndex} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because another lockup owns it`,
+        );
+        return;
       }
-    }
 
-    if (
-      swap.type === SwapType.Submarine &&
-      (swap as Swap).refundAddress !== etherSwapValues.refundAddress
-    ) {
-      swap = await SwapRepository.setRefundAddress(
-        swap as Swap,
-        etherSwapValues.refundAddress,
-      );
-    }
+      swap = result.swap;
 
-    this.emit('eth.lockup', {
-      swap,
-      etherSwapValues,
-      transactionHash: transaction.hash!,
+      if (
+        swap.type === SwapType.Submarine &&
+        (swap as Swap).refundAddress == null
+      ) {
+        swap = await SwapRepository.setRefundAddress(
+          swap as Swap,
+          etherSwapValues.refundAddress,
+        );
+      }
+
+      if (reason !== undefined) {
+        if (result.outcome === LockupWriteOutcome.Acquired) {
+          this.emit('lockup.failed', { swap, reason });
+        }
+        return;
+      }
+
+      if (
+        swap.type === SwapType.Chain &&
+        !ChainSwapRepository.canActOnUserLockup(swap as ChainSwapInfo, options)
+      ) {
+        this.logger.debug(
+          `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
+        );
+        return;
+      }
+
+      if (
+        swap.type === SwapType.Submarine &&
+        (swap as Swap).refundAddress !== etherSwapValues.refundAddress
+      ) {
+        swap = await SwapRepository.setRefundAddress(
+          swap as Swap,
+          etherSwapValues.refundAddress,
+        );
+      }
+
+      this.emit('eth.lockup', {
+        swap,
+        etherSwapValues,
+        logIndex,
+        transactionHash: transaction.hash!,
+      });
     });
   };
 
-  public checkErc20SwapLockup = async (
+  private validateErc20SwapLockup = async (
     swap: Swap | ChainSwapInfo,
     transaction: Transaction | TransactionResponse,
     erc20SwapValues: ERC20SwapValues,
-    options?: UserLockupTransactionOptions,
-  ) => {
-    const wallet = this.walletManager.wallets.get(
-      this.getSwapReceivingCurrency(swap),
-    );
-    if (wallet === undefined || wallet.type !== CurrencyType.ERC20) {
-      return;
-    }
-
-    const erc20Wallet = wallet.walletProvider as ERC20WalletProvider;
-
-    this.logger.debug(
-      `Found lockup in ${this.ethereumManager.networkDetails.name} ERC20Swap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
-    );
-
-    const lockupAmount = erc20Wallet.normalizeTokenAmount(
-      erc20SwapValues.amount,
-    );
-    swap =
-      swap.type === SwapType.Submarine
-        ? await SwapRepository.setLockupTransaction(
-            swap as Swap,
-            transaction.hash!,
-            lockupAmount,
-            true,
-          )
-        : await ChainSwapRepository.setUserLockupTransaction(
-            swap as ChainSwapInfo,
-            transaction.hash!,
-            lockupAmount,
-            true,
-            undefined,
-            options,
-          );
-
-    if (
-      swap.type === SwapType.Submarine &&
-      (swap as Swap).refundAddress == null
-    ) {
-      swap = await SwapRepository.setRefundAddress(
-        swap as Swap,
-        erc20SwapValues.refundAddress,
-      );
-    }
-
-    if (
-      swap.type === SwapType.Chain &&
-      !ChainSwapRepository.canActOnUserLockup(swap as ChainSwapInfo, options)
-    ) {
-      this.logger.debug(
-        `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
-      );
-      return;
-    }
-
+    symbol: string,
+    erc20Wallet: ERC20WalletProvider,
+  ): Promise<string | undefined> => {
     if (erc20SwapValues.claimAddress !== this.ethereumManager.address) {
-      this.emit('lockup.failed', {
-        swap,
-        reason: Errors.INVALID_CLAIM_ADDRESS(
-          erc20SwapValues.claimAddress,
-          this.ethereumManager.address,
-        ).message,
-      });
-      return;
+      return Errors.INVALID_CLAIM_ADDRESS(
+        erc20SwapValues.claimAddress,
+        this.ethereumManager.address,
+      ).message;
     }
 
     if (erc20SwapValues.tokenAddress !== erc20Wallet.tokenAddress) {
-      this.emit('lockup.failed', {
-        swap,
-        reason: Errors.INVALID_TOKEN_LOCKED(
-          erc20SwapValues.tokenAddress,
-          this.ethereumManager.address,
-        ).message,
-      });
-      return;
+      return Errors.INVALID_TOKEN_LOCKED(
+        erc20SwapValues.tokenAddress,
+        this.ethereumManager.address,
+      ).message;
     }
 
     const timeoutBlockHeight =
@@ -397,14 +382,10 @@ class EthereumNursery extends TypedEventEmitter<{
 
     // Commitment swaps can have timelocks longer than the swap timeout
     if (erc20SwapValues.timelock < timeoutBlockHeight) {
-      this.emit('lockup.failed', {
-        swap,
-        reason: Errors.INVALID_TIMELOCK(
-          erc20SwapValues.timelock,
-          timeoutBlockHeight,
-        ).message,
-      });
-      return;
+      return Errors.INVALID_TIMELOCK(
+        erc20SwapValues.timelock,
+        timeoutBlockHeight,
+      ).message;
     }
 
     const expectedAmount = this.getSwapExpectedReceivingAmount(swap);
@@ -416,12 +397,7 @@ class EthereumNursery extends TypedEventEmitter<{
       if (
         erc20Wallet.formatTokenAmount(expectedAmount) > erc20SwapValues.amount
       ) {
-        this.emit('lockup.failed', {
-          swap,
-          reason: Errors.INSUFFICIENT_AMOUNT(actualAmount, expectedAmount)
-            .message,
-        });
-        return;
+        return Errors.INSUFFICIENT_AMOUNT(actualAmount, expectedAmount).message;
       }
 
       if (
@@ -431,57 +407,146 @@ class EthereumNursery extends TypedEventEmitter<{
           actualAmount,
         )
       ) {
-        this.emit('lockup.failed', {
-          swap,
-          reason: Errors.OVERPAID_AMOUNT(actualAmount, expectedAmount).message,
-        });
+        return Errors.OVERPAID_AMOUNT(actualAmount, expectedAmount).message;
+      }
+    }
+
+    const action = await this.transactionHook.hook(
+      swap.id,
+      symbol,
+      transaction.hash!,
+      getHexBuffer(removeHexPrefix(Transaction.from(transaction).serialized!)),
+      true,
+      swap.type,
+    );
+    if (action === Action.Reject) {
+      return Errors.BLOCKED_ADDRESS().message;
+    }
+
+    return undefined;
+  };
+
+  public checkErc20SwapLockup = async (
+    swap: Swap | ChainSwapInfo,
+    transaction: Transaction | TransactionResponse,
+    erc20SwapValues: ERC20SwapValues,
+    logIndex: number,
+    options?: UserLockupTransactionOptions,
+  ) => {
+    const wallet = this.walletManager.wallets.get(
+      this.getSwapReceivingCurrency(swap),
+    );
+    if (wallet === undefined || wallet.type !== CurrencyType.ERC20) {
+      return;
+    }
+
+    const erc20Wallet = wallet.walletProvider as ERC20WalletProvider;
+
+    await this.lock.acquire(swap.id, 'checkErc20SwapLockup', async () => {
+      this.logger.debug(
+        `Found lockup in ${this.ethereumManager.networkDetails.name} ERC20Swap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
+      );
+
+      const lockupAmount = erc20Wallet.normalizeTokenAmount(
+        erc20SwapValues.amount,
+      );
+
+      if (this.isCompetingLockup(swap, transaction.hash!, logIndex)) {
+        this.logger.debug(
+          `Ignoring competing lockup transaction ${transaction.hash} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
+        );
         return;
       }
-    }
 
-    {
-      const action = await this.transactionHook.hook(
-        swap.id,
+      const reason = await this.validateErc20SwapLockup(
+        swap,
+        transaction,
+        erc20SwapValues,
         wallet.symbol,
-        transaction.hash!,
-        getHexBuffer(
-          removeHexPrefix(Transaction.from(transaction).serialized!),
-        ),
-        true,
-        swap.type,
+        erc20Wallet,
       );
+      const status =
+        reason === undefined
+          ? SwapUpdateEvent.TransactionConfirmed
+          : SwapUpdateEvent.TransactionLockupFailed;
 
-      switch (action) {
-        case Action.Reject:
-          this.emit('lockup.failed', {
-            swap,
-            reason: Errors.BLOCKED_ADDRESS().message,
-          });
-          return;
+      const result =
+        swap.type === SwapType.Submarine
+          ? await SwapRepository.setLockupTransaction(
+              swap as Swap,
+              transaction.hash!,
+              lockupAmount,
+              status,
+              logIndex,
+            )
+          : await ChainSwapRepository.setUserLockupTransaction(
+              swap as ChainSwapInfo,
+              transaction.hash!,
+              lockupAmount,
+              status,
+              logIndex,
+              options,
+            );
+
+      if (result.outcome === LockupWriteOutcome.Rejected) {
+        this.logger.warn(
+          `Ignoring lockup transaction ${transaction.hash}:${logIndex} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because another lockup owns it`,
+        );
+        return;
       }
-    }
 
-    if (
-      swap.type === SwapType.Submarine &&
-      (swap as Swap).refundAddress !== erc20SwapValues.refundAddress
-    ) {
-      swap = await SwapRepository.setRefundAddress(
-        swap as Swap,
-        erc20SwapValues.refundAddress,
-      );
-    }
+      swap = result.swap;
 
-    this.emit('erc20.lockup', {
-      swap,
-      erc20SwapValues,
-      transactionHash: transaction.hash!,
+      if (
+        swap.type === SwapType.Submarine &&
+        (swap as Swap).refundAddress == null
+      ) {
+        swap = await SwapRepository.setRefundAddress(
+          swap as Swap,
+          erc20SwapValues.refundAddress,
+        );
+      }
+
+      if (reason !== undefined) {
+        if (result.outcome === LockupWriteOutcome.Acquired) {
+          this.emit('lockup.failed', { swap, reason });
+        }
+        return;
+      }
+
+      if (
+        swap.type === SwapType.Chain &&
+        !ChainSwapRepository.canActOnUserLockup(swap as ChainSwapInfo, options)
+      ) {
+        this.logger.debug(
+          `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
+        );
+        return;
+      }
+
+      if (
+        swap.type === SwapType.Submarine &&
+        (swap as Swap).refundAddress !== erc20SwapValues.refundAddress
+      ) {
+        swap = await SwapRepository.setRefundAddress(
+          swap as Swap,
+          erc20SwapValues.refundAddress,
+        );
+      }
+
+      this.emit('erc20.lockup', {
+        swap,
+        erc20SwapValues,
+        logIndex,
+        transactionHash: transaction.hash!,
+      });
     });
   };
 
   private listenEtherSwap = () => {
     this.ethereumManager.contractEventHandler.on(
       'eth.lockup',
-      async ({ transaction, etherSwapValues }) => {
+      async ({ transaction, etherSwapValues, logIndex }) => {
         const swaps = await Promise.all([
           SwapRepository.getSwap({
             preimageHash: getHexString(etherSwapValues.preimageHash),
@@ -499,7 +564,12 @@ class EthereumNursery extends TypedEventEmitter<{
         ]);
 
         for (const swap of swaps.filter((s) => s !== null)) {
-          await this.checkEtherSwapLockup(swap!, transaction, etherSwapValues);
+          await this.checkEtherSwapLockup(
+            swap!,
+            transaction,
+            etherSwapValues,
+            logIndex,
+          );
         }
       },
     );
@@ -553,7 +623,7 @@ class EthereumNursery extends TypedEventEmitter<{
   private listenERC20Swap = () => {
     this.ethereumManager.contractEventHandler.on(
       'erc20.lockup',
-      async ({ transaction, erc20SwapValues }) => {
+      async ({ transaction, erc20SwapValues, logIndex }) => {
         const swaps = await Promise.all([
           SwapRepository.getSwap({
             preimageHash: getHexString(erc20SwapValues.preimageHash),
@@ -571,7 +641,12 @@ class EthereumNursery extends TypedEventEmitter<{
         ]);
 
         for (const swap of swaps.filter((s) => s !== null)) {
-          await this.checkErc20SwapLockup(swap!, transaction, erc20SwapValues);
+          await this.checkErc20SwapLockup(
+            swap!,
+            transaction,
+            erc20SwapValues,
+            logIndex,
+          );
         }
       },
     );

--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -184,7 +184,8 @@ class EthereumNursery extends TypedEventEmitter<{
     swap: Swap | ChainSwapInfo,
     outcome: LockupWriteOutcome,
   ): boolean =>
-    outcome === LockupWriteOutcome.Acquired || swap.failureReason == null;
+    swap.status === SwapUpdateEvent.TransactionLockupFailed &&
+    (outcome === LockupWriteOutcome.Acquired || swap.failureReason == null);
 
   private validateEtherSwapLockup = async (
     swap: Swap | ChainSwapInfo,

--- a/lib/swap/EthereumNursery.ts
+++ b/lib/swap/EthereumNursery.ts
@@ -180,6 +180,12 @@ class EthereumNursery extends TypedEventEmitter<{
       recordedStatus: swap.status as SwapUpdateEvent,
     });
 
+  private static shouldEmitLockupFailed = (
+    swap: Swap | ChainSwapInfo,
+    outcome: LockupWriteOutcome,
+  ): boolean =>
+    outcome === LockupWriteOutcome.Acquired || swap.failureReason == null;
+
   private validateEtherSwapLockup = async (
     swap: Swap | ChainSwapInfo,
     transaction: Transaction | TransactionResponse,
@@ -243,26 +249,33 @@ class EthereumNursery extends TypedEventEmitter<{
     return undefined;
   };
 
-  public checkEtherSwapLockup = async (
-    swap: Swap | ChainSwapInfo,
-    transaction: Transaction | TransactionResponse,
-    etherSwapValues: EtherSwapValues,
-    logIndex: number,
-    options?: UserLockupTransactionOptions,
-  ) => {
-    if (
-      this.getSwapReceivingCurrency(swap) !==
-      this.ethereumManager.networkDetails.symbol
-    ) {
-      return;
-    }
-
-    await this.lock.acquire(swap.id, 'checkEtherSwapLockup', async () => {
+  private processLockup = async ({
+    swap,
+    transaction,
+    logIndex,
+    lockReason,
+    contractName,
+    lockupAmount,
+    refundAddress,
+    validate,
+    emitLockup,
+    options,
+  }: {
+    swap: Swap | ChainSwapInfo;
+    transaction: Transaction | TransactionResponse;
+    logIndex: number;
+    lockReason: string;
+    contractName: string;
+    lockupAmount: number;
+    refundAddress: string;
+    validate: () => Promise<string | undefined>;
+    emitLockup: (swap: Swap | ChainSwapInfo) => void;
+    options?: UserLockupTransactionOptions;
+  }) =>
+    this.lock.acquire(swap.id, lockReason, async () => {
       this.logger.debug(
-        `Found lockup in ${this.ethereumManager.networkDetails.name} EtherSwap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
+        `Found lockup in ${this.ethereumManager.networkDetails.name} ${contractName} contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
       );
-
-      const lockupAmount = Number(etherSwapValues.amount / etherDecimals);
 
       if (this.isCompetingLockup(swap, transaction.hash!, logIndex)) {
         this.logger.debug(
@@ -271,11 +284,7 @@ class EthereumNursery extends TypedEventEmitter<{
         return;
       }
 
-      const reason = await this.validateEtherSwapLockup(
-        swap,
-        transaction,
-        etherSwapValues,
-      );
+      const reason = await validate();
       const status =
         reason === undefined
           ? SwapUpdateEvent.TransactionConfirmed
@@ -306,51 +315,84 @@ class EthereumNursery extends TypedEventEmitter<{
         return;
       }
 
-      swap = result.swap;
+      let updated = result.swap;
 
       if (
-        swap.type === SwapType.Submarine &&
-        (swap as Swap).refundAddress == null
+        updated.type === SwapType.Submarine &&
+        (updated as Swap).refundAddress == null
       ) {
-        swap = await SwapRepository.setRefundAddress(
-          swap as Swap,
-          etherSwapValues.refundAddress,
+        updated = await SwapRepository.setRefundAddress(
+          updated as Swap,
+          refundAddress,
         );
       }
 
       if (reason !== undefined) {
-        if (result.outcome === LockupWriteOutcome.Acquired) {
-          this.emit('lockup.failed', { swap, reason });
+        if (EthereumNursery.shouldEmitLockupFailed(updated, result.outcome)) {
+          this.emit('lockup.failed', { swap: updated, reason });
         }
         return;
       }
 
       if (
-        swap.type === SwapType.Chain &&
-        !ChainSwapRepository.canActOnUserLockup(swap as ChainSwapInfo, options)
+        updated.type === SwapType.Chain &&
+        !ChainSwapRepository.canActOnUserLockup(
+          updated as ChainSwapInfo,
+          options,
+        )
       ) {
         this.logger.debug(
-          `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
+          `Not acting on lockup transaction of ${swapTypeToPrettyString(updated.type)} Swap ${updated.id} because lockup failed already`,
         );
         return;
       }
 
       if (
-        swap.type === SwapType.Submarine &&
-        (swap as Swap).refundAddress !== etherSwapValues.refundAddress
+        updated.type === SwapType.Submarine &&
+        (updated as Swap).refundAddress !== refundAddress
       ) {
-        swap = await SwapRepository.setRefundAddress(
-          swap as Swap,
-          etherSwapValues.refundAddress,
+        updated = await SwapRepository.setRefundAddress(
+          updated as Swap,
+          refundAddress,
         );
       }
 
-      this.emit('eth.lockup', {
-        swap,
-        etherSwapValues,
-        logIndex,
-        transactionHash: transaction.hash!,
-      });
+      emitLockup(updated);
+    });
+
+  public checkEtherSwapLockup = async (
+    swap: Swap | ChainSwapInfo,
+    transaction: Transaction | TransactionResponse,
+    etherSwapValues: EtherSwapValues,
+    logIndex: number,
+    options?: UserLockupTransactionOptions,
+  ) => {
+    if (
+      this.getSwapReceivingCurrency(swap) !==
+      this.ethereumManager.networkDetails.symbol
+    ) {
+      return;
+    }
+
+    await this.processLockup({
+      swap,
+      transaction,
+      logIndex,
+      options,
+      lockReason: 'checkEtherSwapLockup',
+      contractName: 'EtherSwap',
+      lockupAmount: Number(etherSwapValues.amount / etherDecimals),
+      refundAddress: etherSwapValues.refundAddress,
+      validate: () =>
+        this.validateEtherSwapLockup(swap, transaction, etherSwapValues),
+      emitLockup: (updated) => {
+        this.emit('eth.lockup', {
+          swap: updated,
+          etherSwapValues,
+          logIndex,
+          transactionHash: transaction.hash!,
+        });
+      },
     });
   };
 
@@ -442,104 +484,31 @@ class EthereumNursery extends TypedEventEmitter<{
 
     const erc20Wallet = wallet.walletProvider as ERC20WalletProvider;
 
-    await this.lock.acquire(swap.id, 'checkErc20SwapLockup', async () => {
-      this.logger.debug(
-        `Found lockup in ${this.ethereumManager.networkDetails.name} ERC20Swap contract for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transaction.hash}`,
-      );
-
-      const lockupAmount = erc20Wallet.normalizeTokenAmount(
-        erc20SwapValues.amount,
-      );
-
-      if (this.isCompetingLockup(swap, transaction.hash!, logIndex)) {
-        this.logger.debug(
-          `Ignoring competing lockup transaction ${transaction.hash} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
-        );
-        return;
-      }
-
-      const reason = await this.validateErc20SwapLockup(
-        swap,
-        transaction,
-        erc20SwapValues,
-        wallet.symbol,
-        erc20Wallet,
-      );
-      const status =
-        reason === undefined
-          ? SwapUpdateEvent.TransactionConfirmed
-          : SwapUpdateEvent.TransactionLockupFailed;
-
-      const result =
-        swap.type === SwapType.Submarine
-          ? await SwapRepository.setLockupTransaction(
-              swap as Swap,
-              transaction.hash!,
-              lockupAmount,
-              status,
-              logIndex,
-            )
-          : await ChainSwapRepository.setUserLockupTransaction(
-              swap as ChainSwapInfo,
-              transaction.hash!,
-              lockupAmount,
-              status,
-              logIndex,
-              options,
-            );
-
-      if (result.outcome === LockupWriteOutcome.Rejected) {
-        this.logger.warn(
-          `Ignoring lockup transaction ${transaction.hash}:${logIndex} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because another lockup owns it`,
-        );
-        return;
-      }
-
-      swap = result.swap;
-
-      if (
-        swap.type === SwapType.Submarine &&
-        (swap as Swap).refundAddress == null
-      ) {
-        swap = await SwapRepository.setRefundAddress(
-          swap as Swap,
-          erc20SwapValues.refundAddress,
-        );
-      }
-
-      if (reason !== undefined) {
-        if (result.outcome === LockupWriteOutcome.Acquired) {
-          this.emit('lockup.failed', { swap, reason });
-        }
-        return;
-      }
-
-      if (
-        swap.type === SwapType.Chain &&
-        !ChainSwapRepository.canActOnUserLockup(swap as ChainSwapInfo, options)
-      ) {
-        this.logger.debug(
-          `Not acting on lockup transaction of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because lockup failed already`,
-        );
-        return;
-      }
-
-      if (
-        swap.type === SwapType.Submarine &&
-        (swap as Swap).refundAddress !== erc20SwapValues.refundAddress
-      ) {
-        swap = await SwapRepository.setRefundAddress(
-          swap as Swap,
-          erc20SwapValues.refundAddress,
-        );
-      }
-
-      this.emit('erc20.lockup', {
-        swap,
-        erc20SwapValues,
-        logIndex,
-        transactionHash: transaction.hash!,
-      });
+    await this.processLockup({
+      swap,
+      transaction,
+      logIndex,
+      options,
+      lockReason: 'checkErc20SwapLockup',
+      contractName: 'ERC20Swap',
+      lockupAmount: erc20Wallet.normalizeTokenAmount(erc20SwapValues.amount),
+      refundAddress: erc20SwapValues.refundAddress,
+      validate: () =>
+        this.validateErc20SwapLockup(
+          swap,
+          transaction,
+          erc20SwapValues,
+          wallet.symbol,
+          erc20Wallet,
+        ),
+      emitLockup: (updated) => {
+        this.emit('erc20.lockup', {
+          swap: updated,
+          erc20SwapValues,
+          logIndex,
+          transactionHash: transaction.hash!,
+        });
+      },
     });
   };
 

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -312,10 +312,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
             this.emit('zeroconf.rejected', {
               transaction,
-              swap: await SwapRepository.setSwapStatus(
-                swap,
-                SwapUpdateEvent.TransactionZeroConfRejected,
-              ),
+              swap,
             });
           },
         );
@@ -325,6 +322,9 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     this.utxoNursery.on(
       'swap.lockup',
       async ({ swap, transaction, confirmed }) => {
+        const eventTransactionId = TxView.of(transaction).id;
+        const eventTransactionVout = swap.lockupTransactionVout;
+
         await this.lock.acquire(
           SwapNursery.swapLock,
           'swap.lockup',
@@ -336,6 +336,16 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
               return;
             }
             swap = fetchedSwap;
+
+            if (
+              swap.lockupTransactionId !== eventTransactionId ||
+              swap.lockupTransactionVout !== eventTransactionVout
+            ) {
+              this.logger.warn(
+                `Not acting on lockup transaction ${eventTransactionId}:${eventTransactionVout} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because ${swap.lockupTransactionId}:${swap.lockupTransactionVout} owns it`,
+              );
+              return;
+            }
 
             if (swap.createdRefundSignature) {
               this.logger.warn(
@@ -709,10 +719,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
             this.emit('zeroconf.rejected', {
               transaction,
-              swap: await WrappedSwapRepository.setStatus(
-                swap,
-                SwapUpdateEvent.TransactionZeroConfRejected,
-              ),
+              swap,
             });
           },
         );
@@ -724,12 +731,17 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       transaction: Transaction | LiquidTransaction | string,
       confirmed: boolean,
     ) => {
+      const lockupTransactionId =
+        typeof transaction === 'string'
+          ? transaction
+          : TxView.of(transaction).id;
       await this.withSendApproval<ChainSwapInfo>({
         id: swap.id,
         symbolFor: (fetchedSwap) => fetchedSwap.sendingData.symbol,
         lock: SwapNursery.chainSwapLock,
         lockReason: 'chainSwap.lockup',
-        loadEligible: () => this.getChainSwapForLockup(swap),
+        loadEligible: () =>
+          this.getChainSwapForLockup(swap, lockupTransactionId),
         emitTransaction: { transaction, confirmed },
         proceed: (fetchedSwap, approval) =>
           this.handleChainSwapLockup(fetchedSwap, approval),
@@ -983,6 +995,10 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       swap.type === SwapType.Submarine
         ? (swap as Swap).lockupTransactionId
         : (swap as ChainSwapInfo).receivingData.transactionId;
+    const logIndexToClaim =
+      swap.type === SwapType.Submarine
+        ? (swap as Swap).lockupTransactionVout
+        : (swap as ChainSwapInfo).receivingData.transactionVout;
 
     switch (currency.type) {
       case CurrencyType.BitcoinLike:
@@ -1020,6 +1036,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
             contracts.etherSwap,
             txToClaim!,
             true,
+            logIndexToClaim ?? undefined,
           ),
           payRes.preimage,
         );
@@ -1045,6 +1062,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
             contracts.erc20Swap,
             txToClaim!,
             true,
+            logIndexToClaim ?? undefined,
           ),
           payRes.preimage,
         );
@@ -1237,6 +1255,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
   private getChainSwapForLockup = async (
     swap: ChainSwapInfo,
+    lockupTransactionId?: string,
   ): Promise<ChainSwapInfo | undefined> => {
     const fetchedSwap = await ChainSwapRepository.getChainSwap({
       id: swap.id,
@@ -1280,6 +1299,16 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       return undefined;
     }
 
+    if (
+      lockupTransactionId !== undefined &&
+      fetchedSwap.receivingData.transactionId !== lockupTransactionId
+    ) {
+      this.logger.warn(
+        `Not acting on lockup transaction ${lockupTransactionId} of ${swapTypeToPrettyString(fetchedSwap.type)} Swap ${fetchedSwap.id} because ${fetchedSwap.receivingData.transactionId} owns it`,
+      );
+      return undefined;
+    }
+
     return fetchedSwap;
   };
 
@@ -1315,7 +1344,8 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
           symbolFor: (fetchedSwap) => fetchedSwap.sendingData.symbol,
           lock: SwapNursery.chainSwapLock,
           lockReason: 'lockup',
-          loadEligible: () => this.getChainSwapForLockup(swap as ChainSwapInfo),
+          loadEligible: () =>
+            this.getChainSwapForLockup(swap as ChainSwapInfo, transactionHash),
           emitTransaction: { confirmed: true, transaction: transactionHash },
           proceed: (fetchedSwap, approval) =>
             this.handleChainSwapLockup(fetchedSwap, approval),
@@ -1332,6 +1362,13 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
         if (updatedSwap.status === SwapUpdateEvent.TransactionLockupFailed) {
           this.logger.warn(
             `Lockup already failed for ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}: ${transactionHash}`,
+          );
+          return;
+        }
+
+        if (updatedSwap.lockupTransactionId !== transactionHash) {
+          this.logger.warn(
+            `Not acting on lockup transaction ${transactionHash} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because ${updatedSwap.lockupTransactionId} owns it`,
           );
           return;
         }

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -321,9 +321,9 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
     this.utxoNursery.on(
       'swap.lockup',
-      async ({ swap, transaction, confirmed }) => {
+      async ({ swap, transaction, lockupTransactionVout, confirmed }) => {
         const eventTransactionId = TxView.of(transaction).id;
-        const eventTransactionVout = swap.lockupTransactionVout;
+        const eventTransactionVout = lockupTransactionVout;
 
         await this.lock.acquire(
           SwapNursery.swapLock,
@@ -402,57 +402,76 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       },
     );
 
-    this.arkNursery.on('swap.lockup', async ({ swap, lockupTransactionId }) => {
-      await this.lock.acquire(SwapNursery.swapLock, 'swap.lockup', async () => {
-        const fetchedSwap = await SwapRepository.getSwap({
-          id: swap.id,
-        });
-        if (fetchedSwap === null) {
-          return;
-        }
-        swap = fetchedSwap;
+    this.arkNursery.on(
+      'swap.lockup',
+      async ({ swap, lockupTransactionId, lockupTransactionVout }) => {
+        const eventTransactionVout = lockupTransactionVout;
 
-        if (swap.createdRefundSignature) {
-          this.logger.warn(
-            `Prevented ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} from paying an invoice because it already signed a refund`,
-          );
-          return;
-        }
+        await this.lock.acquire(
+          SwapNursery.swapLock,
+          'swap.lockup',
+          async () => {
+            const fetchedSwap = await SwapRepository.getSwap({
+              id: swap.id,
+            });
+            if (fetchedSwap === null) {
+              return;
+            }
+            swap = fetchedSwap;
 
-        if (swap.status !== SwapUpdateEvent.TransactionConfirmed) {
-          this.logger.debug(
-            `Not acting on ARK lockup of Submarine Swap ${swap.id} because it is already being processed with status ${swap.status}`,
-          );
-          return;
-        }
+            if (
+              swap.lockupTransactionId !== lockupTransactionId ||
+              swap.lockupTransactionVout !== eventTransactionVout
+            ) {
+              this.logger.warn(
+                `Not acting on lockup transaction ${lockupTransactionId}:${eventTransactionVout} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because ${swap.lockupTransactionId}:${swap.lockupTransactionVout} owns it`,
+              );
+              return;
+            }
 
-        this.emit('transaction', {
-          swap,
-          confirmed: true,
-          transaction: lockupTransactionId,
-        });
+            if (swap.createdRefundSignature) {
+              this.logger.warn(
+                `Prevented ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} from paying an invoice because it already signed a refund`,
+              );
+              return;
+            }
 
-        if (swap.invoice) {
-          const payRes = await this.payInvoice(swap);
-          if (payRes === undefined) {
-            return;
-          }
+            if (swap.status !== SwapUpdateEvent.TransactionConfirmed) {
+              this.logger.debug(
+                `Not acting on ARK lockup of Submarine Swap ${swap.id} because it is already being processed with status ${swap.status}`,
+              );
+              return;
+            }
 
-          const { base, quote } = splitPairId(swap.pair);
-          const chainSymbol = getChainCurrency(
-            base,
-            quote,
-            swap.orderSide,
-            false,
-          );
+            this.emit('transaction', {
+              swap,
+              confirmed: true,
+              transaction: lockupTransactionId,
+            });
 
-          const { arkNode } = this.currencies.get(chainSymbol)!;
-          await this.claimVtxo(swap, arkNode!, payRes.preimage);
-        } else {
-          await this.setSwapRate(swap);
-        }
-      });
-    });
+            if (swap.invoice) {
+              const payRes = await this.payInvoice(swap);
+              if (payRes === undefined) {
+                return;
+              }
+
+              const { base, quote } = splitPairId(swap.pair);
+              const chainSymbol = getChainCurrency(
+                base,
+                quote,
+                swap.orderSide,
+                false,
+              );
+
+              const { arkNode } = this.currencies.get(chainSymbol)!;
+              await this.claimVtxo(swap, arkNode!, payRes.preimage);
+            } else {
+              await this.setSwapRate(swap);
+            }
+          },
+        );
+      },
+    );
 
     this.arkNursery.on('swap.lockup.failed', async ({ swap, reason }) => {
       await this.lock.acquire(
@@ -729,6 +748,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     const handleIncomingChainSwapLockup = async (
       swap: ChainSwapInfo,
       transaction: Transaction | LiquidTransaction | string,
+      lockupTransactionVout: number,
       confirmed: boolean,
     ) => {
       const lockupTransactionId =
@@ -741,7 +761,11 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
         lock: SwapNursery.chainSwapLock,
         lockReason: 'chainSwap.lockup',
         loadEligible: () =>
-          this.getChainSwapForLockup(swap, lockupTransactionId),
+          this.getChainSwapForLockup(
+            swap,
+            lockupTransactionId,
+            lockupTransactionVout,
+          ),
         emitTransaction: { transaction, confirmed },
         proceed: (fetchedSwap, approval) =>
           this.handleChainSwapLockup(fetchedSwap, approval),
@@ -750,15 +774,25 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
     this.utxoNursery.on(
       'chainSwap.lockup',
-      async ({ swap, transaction, confirmed }) => {
-        await handleIncomingChainSwapLockup(swap, transaction, confirmed);
+      async ({ swap, transaction, lockupTransactionVout, confirmed }) => {
+        await handleIncomingChainSwapLockup(
+          swap,
+          transaction,
+          lockupTransactionVout,
+          confirmed,
+        );
       },
     );
 
     this.arkNursery.on(
       'chainSwap.lockup',
-      async ({ swap, lockupTransactionId }) => {
-        await handleIncomingChainSwapLockup(swap, lockupTransactionId, true);
+      async ({ swap, lockupTransactionId, lockupTransactionVout }) => {
+        await handleIncomingChainSwapLockup(
+          swap,
+          lockupTransactionId,
+          lockupTransactionVout,
+          true,
+        );
       },
     );
 
@@ -1037,6 +1071,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
             txToClaim!,
             true,
             logIndexToClaim ?? undefined,
+            this.logger,
           ),
           payRes.preimage,
         );
@@ -1063,6 +1098,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
             txToClaim!,
             true,
             logIndexToClaim ?? undefined,
+            this.logger,
           ),
           payRes.preimage,
         );
@@ -1256,6 +1292,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
   private getChainSwapForLockup = async (
     swap: ChainSwapInfo,
     lockupTransactionId?: string,
+    lockupTransactionVout?: number | null,
   ): Promise<ChainSwapInfo | undefined> => {
     const fetchedSwap = await ChainSwapRepository.getChainSwap({
       id: swap.id,
@@ -1301,10 +1338,12 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
 
     if (
       lockupTransactionId !== undefined &&
-      fetchedSwap.receivingData.transactionId !== lockupTransactionId
+      (fetchedSwap.receivingData.transactionId !== lockupTransactionId ||
+        (lockupTransactionVout !== undefined &&
+          fetchedSwap.receivingData.transactionVout !== lockupTransactionVout))
     ) {
       this.logger.warn(
-        `Not acting on lockup transaction ${lockupTransactionId} of ${swapTypeToPrettyString(fetchedSwap.type)} Swap ${fetchedSwap.id} because ${fetchedSwap.receivingData.transactionId} owns it`,
+        `Not acting on lockup transaction ${lockupTransactionId}:${lockupTransactionVout} of ${swapTypeToPrettyString(fetchedSwap.type)} Swap ${fetchedSwap.id} because ${fetchedSwap.receivingData.transactionId}:${fetchedSwap.receivingData.transactionVout} owns it`,
       );
       return undefined;
     }
@@ -1337,6 +1376,7 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
     const handleLockup = async (
       swap: Swap | ChainSwapInfo,
       transactionHash: string,
+      logIndex: number,
     ) => {
       if (swap.type === SwapType.Chain) {
         await this.withSendApproval<ChainSwapInfo>({
@@ -1345,7 +1385,11 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
           lock: SwapNursery.chainSwapLock,
           lockReason: 'lockup',
           loadEligible: () =>
-            this.getChainSwapForLockup(swap as ChainSwapInfo, transactionHash),
+            this.getChainSwapForLockup(
+              swap as ChainSwapInfo,
+              transactionHash,
+              logIndex,
+            ),
           emitTransaction: { confirmed: true, transaction: transactionHash },
           proceed: (fetchedSwap, approval) =>
             this.handleChainSwapLockup(fetchedSwap, approval),
@@ -1366,9 +1410,12 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
           return;
         }
 
-        if (updatedSwap.lockupTransactionId !== transactionHash) {
+        if (
+          updatedSwap.lockupTransactionId !== transactionHash ||
+          updatedSwap.lockupTransactionVout !== logIndex
+        ) {
           this.logger.warn(
-            `Not acting on lockup transaction ${transactionHash} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because ${updatedSwap.lockupTransactionId} owns it`,
+            `Not acting on lockup transaction ${transactionHash}:${logIndex} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because ${updatedSwap.lockupTransactionId}:${updatedSwap.lockupTransactionVout} owns it`,
           );
           return;
         }
@@ -1401,13 +1448,19 @@ class SwapNursery extends TypedEventEmitter<SwapNurseryEvents> {
       });
     };
 
-    ethereumNursery.on('eth.lockup', async ({ swap, transactionHash }) => {
-      await handleLockup(swap, transactionHash);
-    });
+    ethereumNursery.on(
+      'eth.lockup',
+      async ({ swap, transactionHash, logIndex }) => {
+        await handleLockup(swap, transactionHash, logIndex);
+      },
+    );
 
-    ethereumNursery.on('erc20.lockup', async ({ swap, transactionHash }) => {
-      await handleLockup(swap, transactionHash);
-    });
+    ethereumNursery.on(
+      'erc20.lockup',
+      async ({ swap, transactionHash, logIndex }) => {
+        await handleLockup(swap, transactionHash, logIndex);
+      },
+    );
 
     // Reverse Swap events
     ethereumNursery.on('reverseSwap.expired', async ({ reverseSwap }) => {

--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -25,6 +25,7 @@ import {
   swapTypeToPrettyString,
 } from '../consts/Enums';
 import TypedEventEmitter from '../consts/TypedEventEmitter';
+import { LockupWriteOutcome } from '../db/LockupIdentity';
 import type ReverseSwap from '../db/models/ReverseSwap';
 import type Swap from '../db/models/Swap';
 import type {
@@ -42,6 +43,7 @@ import { TransactionStatus } from '../sidecar/Sidecar';
 import type Wallet from '../wallet/Wallet';
 import type { Currency } from '../wallet/WalletManager';
 import type WalletManager from '../wallet/WalletManager';
+import { shouldIgnoreCompetingLockup } from './CompetingLockup';
 import Errors from './Errors';
 import type OverpaymentProtector from './OverpaymentProtector';
 import { Action } from './hooks/CreationHook';
@@ -161,14 +163,39 @@ class UtxoNursery extends TypedEventEmitter<{
       wallet,
       swapOutput as Parameters<typeof getOutputValue>[1],
     );
-    swap = await ChainSwapRepository.setUserLockupTransaction(
+
+    if (
+      shouldIgnoreCompetingLockup({
+        prevId: swap.receivingData.transactionId,
+        prevVout: swap.receivingData.transactionVout,
+        incomingId: TxView.of(transaction).id,
+        incomingVout: swapOutput.vout,
+        recordedStatus: swap.status as SwapUpdateEvent,
+      })
+    ) {
+      this.logger.debug(
+        `Ignoring competing lockup transaction ${TxView.of(transaction).id} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
+      );
+      return;
+    }
+
+    const lockupResult = await ChainSwapRepository.setUserLockupTransaction(
       swap,
       TxView.of(transaction).id,
       outputValue,
-      status === TransactionStatus.Confirmed,
+      status === TransactionStatus.Confirmed
+        ? SwapUpdateEvent.TransactionConfirmed
+        : SwapUpdateEvent.TransactionMempool,
       swapOutput.vout,
       options,
     );
+    if (lockupResult.outcome === LockupWriteOutcome.Rejected) {
+      this.logger.debug(
+        `Ignoring lockup transaction ${TxView.of(transaction).id} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because another lockup owns it`,
+      );
+      return;
+    }
+    swap = lockupResult.swap;
 
     if (!ChainSwapRepository.canActOnUserLockup(swap, options)) {
       this.logger.debug(
@@ -244,11 +271,20 @@ class UtxoNursery extends TypedEventEmitter<{
         status,
       );
       if (zeroConfRejectedReason !== undefined) {
-        this.emit('chainSwap.lockup.zeroconf.rejected', {
+        const rejectedSwap = await ChainSwapRepository.setZeroConfRejected(
           swap,
-          transaction,
-          reason: zeroConfRejectedReason,
-        });
+          TxView.of(transaction).id,
+          swapOutput.vout,
+        );
+        if (
+          rejectedSwap.status === SwapUpdateEvent.TransactionZeroConfRejected
+        ) {
+          this.emit('chainSwap.lockup.zeroconf.rejected', {
+            transaction,
+            swap: rejectedSwap,
+            reason: zeroConfRejectedReason,
+          });
+        }
         return;
       }
 
@@ -702,13 +738,38 @@ class UtxoNursery extends TypedEventEmitter<{
       wallet,
       swapOutput as Parameters<typeof getOutputValue>[1],
     );
-    const updatedSwap = await SwapRepository.setLockupTransaction(
+
+    if (
+      shouldIgnoreCompetingLockup({
+        prevId: swap.lockupTransactionId,
+        prevVout: swap.lockupTransactionVout,
+        incomingId: TxView.of(transaction).id,
+        incomingVout: swapOutput.vout,
+        recordedStatus: swap.status as SwapUpdateEvent,
+      })
+    ) {
+      this.logger.debug(
+        `Ignoring competing lockup transaction ${TxView.of(transaction).id} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id}`,
+      );
+      return;
+    }
+
+    const lockupResult = await SwapRepository.setLockupTransaction(
       swap,
       TxView.of(transaction).id,
       outputValue,
-      status === TransactionStatus.Confirmed,
+      status === TransactionStatus.Confirmed
+        ? SwapUpdateEvent.TransactionConfirmed
+        : SwapUpdateEvent.TransactionMempool,
       swapOutput.vout,
     );
+    if (lockupResult.outcome === LockupWriteOutcome.Rejected) {
+      this.logger.debug(
+        `Ignoring lockup transaction ${TxView.of(transaction).id} of ${swapTypeToPrettyString(swap.type)} Swap ${swap.id} because another lockup owns it`,
+      );
+      return;
+    }
+    const updatedSwap = lockupResult.swap;
 
     if (
       SwapRepository.lockupNonUpdatableStatuses.includes(
@@ -791,11 +852,20 @@ class UtxoNursery extends TypedEventEmitter<{
         status,
       );
       if (zeroConfRejectedReason !== undefined) {
-        this.emit('swap.lockup.zeroconf.rejected', {
-          transaction,
-          swap: updatedSwap,
-          reason: zeroConfRejectedReason,
-        });
+        const rejectedSwap = await SwapRepository.setZeroConfRejected(
+          updatedSwap,
+          TxView.of(transaction).id,
+          swapOutput.vout,
+        );
+        if (
+          rejectedSwap.status === SwapUpdateEvent.TransactionZeroConfRejected
+        ) {
+          this.emit('swap.lockup.zeroconf.rejected', {
+            transaction,
+            swap: rejectedSwap,
+            reason: zeroConfRejectedReason,
+          });
+        }
         return;
       }
 

--- a/lib/swap/UtxoNursery.ts
+++ b/lib/swap/UtxoNursery.ts
@@ -61,6 +61,7 @@ class UtxoNursery extends TypedEventEmitter<{
   'swap.lockup': {
     swap: Swap;
     transaction: Transaction | LiquidTransaction;
+    lockupTransactionVout: number;
     confirmed: boolean;
   };
 
@@ -79,6 +80,7 @@ class UtxoNursery extends TypedEventEmitter<{
   'chainSwap.lockup': {
     swap: ChainSwapInfo;
     transaction: Transaction | LiquidTransaction;
+    lockupTransactionVout: number;
     confirmed: boolean;
   };
   'chainSwap.lockup.failed': {
@@ -294,6 +296,7 @@ class UtxoNursery extends TypedEventEmitter<{
     this.emit('chainSwap.lockup', {
       swap,
       transaction,
+      lockupTransactionVout: swapOutput.vout,
       confirmed: status === TransactionStatus.Confirmed,
     });
   };
@@ -874,6 +877,7 @@ class UtxoNursery extends TypedEventEmitter<{
 
     this.emit('swap.lockup', {
       transaction,
+      lockupTransactionVout: swapOutput.vout,
       confirmed: status === TransactionStatus.Confirmed,
       swap: updatedSwap,
     });

--- a/lib/wallet/ethereum/ConsolidatedEventHandler.ts
+++ b/lib/wallet/ethereum/ConsolidatedEventHandler.ts
@@ -1,9 +1,7 @@
-import { createHash } from 'crypto';
 import InstrumentedLock from '../../InstrumentedLock';
 import type Logger from '../../Logger';
 import { mapConcurrent, stringify } from '../../Utils';
 import TypedEventEmitter from '../../consts/TypedEventEmitter';
-import type { ERC20SwapValues, EtherSwapValues } from '../../consts/Types';
 import type { NetworkDetails } from './EvmNetworks';
 import type InjectedProvider from './InjectedProvider';
 import type { Events } from './contracts/ContractEventHandler';
@@ -19,28 +17,8 @@ type PendingEvent = {
   event: LockupEventEntry;
 };
 
-const hashSwapValues = (values: EtherSwapValues | ERC20SwapValues): string => {
-  const h = createHash('sha256');
-  h.update(values.preimageHash);
-  h.update(values.amount.toString());
-  h.update(values.claimAddress);
-  h.update(values.refundAddress);
-  h.update(values.timelock.toString());
-
-  if ('tokenAddress' in values) {
-    h.update(values.tokenAddress);
-  }
-
-  return h.digest('hex');
-};
-
-const pendingEventKey = (pending: PendingEvent): string => {
-  const values =
-    pending.event.name === 'eth.lockup'
-      ? pending.event.payload.etherSwapValues
-      : pending.event.payload.erc20SwapValues;
-  return `${pending.event.name}:${pending.txHash}:${hashSwapValues(values)}`;
-};
+const pendingEventKey = (pending: PendingEvent): string =>
+  `${pending.event.name}:${pending.txHash}:${pending.event.payload.logIndex}`;
 
 const enum QueueAction {
   Queue = 0,

--- a/lib/wallet/ethereum/contracts/Commitments.ts
+++ b/lib/wallet/ethereum/contracts/Commitments.ts
@@ -288,6 +288,7 @@ class Commitments {
         await this.eventHandler.handleEvent('eth.lockup', {
           transaction,
           version: contractVersion,
+          logIndex: event.logIndex,
           etherSwapValues: {
             amount: event.amount,
             claimAddress: event.claimAddress,
@@ -300,6 +301,7 @@ class Commitments {
         await this.eventHandler.handleEvent('erc20.lockup', {
           transaction,
           version: contractVersion,
+          logIndex: event.logIndex,
           erc20SwapValues: {
             amount: event.amount,
             claimAddress: event.claimAddress,

--- a/lib/wallet/ethereum/contracts/ContractEventHandler.ts
+++ b/lib/wallet/ethereum/contracts/ContractEventHandler.ts
@@ -19,6 +19,7 @@ type Events = {
   'eth.lockup': {
     version: bigint;
     transaction: Transaction | TransactionResponse;
+    logIndex: number;
     etherSwapValues: EtherSwapValues;
   };
   'eth.claim': {
@@ -32,6 +33,7 @@ type Events = {
   'erc20.lockup': {
     version: bigint;
     transaction: Transaction | TransactionResponse;
+    logIndex: number;
     erc20SwapValues: ERC20SwapValues;
   };
   'erc20.claim': {
@@ -125,6 +127,7 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
       this.emit('eth.lockup', {
         version: this.version,
         transaction: await event.getTransaction(),
+        logIndex: event.index,
         etherSwapValues: formatEtherSwapValues(event.args!),
       });
     }
@@ -155,6 +158,7 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
       this.emit('erc20.lockup', {
         version: this.version,
         transaction: await event.getTransaction(),
+        logIndex: event.index,
         erc20SwapValues: formatERC20SwapValues(event.args!),
       });
     }
@@ -224,6 +228,7 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
         this.emit('eth.lockup', {
           version: this.version,
           transaction: await event.log.getTransaction(),
+          logIndex: event.log.index,
           etherSwapValues: {
             amount,
             claimAddress,
@@ -261,6 +266,7 @@ class ContractEventHandler extends TypedEventEmitter<Events> {
         this.emit('erc20.lockup', {
           version: this.version,
           transaction: await event.log.getTransaction(),
+          logIndex: event.log.index,
           erc20SwapValues: {
             amount,
             tokenAddress,

--- a/lib/wallet/ethereum/contracts/ContractUtils.ts
+++ b/lib/wallet/ethereum/contracts/ContractUtils.ts
@@ -1,4 +1,5 @@
 import type { Provider, Result } from 'ethers';
+import type Logger from '../../../Logger';
 import { getHexBuffer } from '../../../Utils';
 import type {
   AnySwap,
@@ -64,6 +65,7 @@ const querySwapValuesFromLock = async <T extends { preimageHash: Buffer }>(
   identifier: LockupIdentifier | undefined,
   formatValues: (args: Result) => T,
   logIndex?: number,
+  logger?: Logger,
 ): Promise<T> => {
   const lockTransactionReceipt =
     await provider.getTransactionReceipt(lockTransactionHash);
@@ -116,6 +118,9 @@ const querySwapValuesFromLock = async <T extends { preimageHash: Buffer }>(
       logIndex !== undefined &&
       identifier !== undefined
     ) {
+      logger?.warn(
+        `Recorded log index ${logIndex} of lockup transaction ${lockTransactionHash} did not resolve; falling back to searching the whole receipt`,
+      );
       lockupsFound = await findLockups(undefined);
     }
 
@@ -134,6 +139,7 @@ export const queryEtherSwapValuesFromLock = async (
   lockTransactionHash: string,
   lockedByUser: boolean,
   logIndex?: number,
+  logger?: Logger,
 ): Promise<EtherSwapValues> =>
   querySwapValuesFromLock(
     provider,
@@ -142,6 +148,7 @@ export const queryEtherSwapValuesFromLock = async (
     await getIdentifier(swap, lockedByUser),
     formatEtherSwapValues,
     logIndex,
+    logger,
   );
 
 export const queryERC20SwapValuesFromLock = async (
@@ -151,6 +158,7 @@ export const queryERC20SwapValuesFromLock = async (
   lockTransactionHash: string,
   lockedByUser: boolean,
   logIndex?: number,
+  logger?: Logger,
 ): Promise<ERC20SwapValues> =>
   querySwapValuesFromLock(
     provider,
@@ -159,6 +167,7 @@ export const queryERC20SwapValuesFromLock = async (
     await getIdentifier(swap, lockedByUser),
     formatERC20SwapValues,
     logIndex,
+    logger,
   );
 
 export const queryEtherSwapValuesFromTransaction = async (

--- a/lib/wallet/ethereum/contracts/ContractUtils.ts
+++ b/lib/wallet/ethereum/contracts/ContractUtils.ts
@@ -72,42 +72,51 @@ const querySwapValuesFromLock = async <T extends { preimageHash: Buffer }>(
   const contractAddress = (await contract.getAddress()).toLowerCase();
 
   if (lockTransactionReceipt) {
-    const lockupsFound: T[] = [];
+    const findLockups = async (index: number | undefined): Promise<T[]> => {
+      const lockupsFound: T[] = [];
 
-    for (const log of lockTransactionReceipt.logs) {
-      if (logIndex !== undefined && log.index !== logIndex) {
-        continue;
-      }
-
-      if (log.topics[0] !== topicHash) {
-        continue;
-      }
-      if (log.address.toLowerCase() !== contractAddress) {
-        continue;
-      }
-
-      const event = contract.interface.parseLog(log as any);
-      const values = formatValues(event!.args);
-
-      if (identifier !== undefined && 'preimageHash' in identifier) {
-        if (!values.preimageHash.equals(identifier.preimageHash)) {
+      for (const log of lockTransactionReceipt.logs) {
+        if (index !== undefined && log.index !== index) {
           continue;
         }
-      } else if (identifier !== undefined && 'lockupHash' in identifier) {
-        const computedHash = await computeLockupHash(
-          contract,
-          event!.args as unknown as LockupHashParams,
-        );
-        if (computedHash !== identifier.lockupHash) {
+
+        if (log.topics[0] !== topicHash) {
           continue;
         }
+        if (log.address.toLowerCase() !== contractAddress) {
+          continue;
+        }
+
+        const event = contract.interface.parseLog(log as any);
+        const values = formatValues(event!.args);
+
+        if (identifier !== undefined && 'preimageHash' in identifier) {
+          if (!values.preimageHash.equals(identifier.preimageHash)) {
+            continue;
+          }
+        } else if (identifier !== undefined && 'lockupHash' in identifier) {
+          const computedHash = await computeLockupHash(
+            contract,
+            event!.args as unknown as LockupHashParams,
+          );
+          if (computedHash !== identifier.lockupHash) {
+            continue;
+          }
+        }
+
+        lockupsFound.push(values);
       }
 
-      if (logIndex !== undefined || identifier !== undefined) {
-        return values;
-      }
+      return lockupsFound;
+    };
 
-      lockupsFound.push(values);
+    let lockupsFound = await findLockups(logIndex);
+    if (
+      lockupsFound.length === 0 &&
+      logIndex !== undefined &&
+      identifier !== undefined
+    ) {
+      lockupsFound = await findLockups(undefined);
     }
 
     if (lockupsFound.length === 1) {
@@ -124,6 +133,7 @@ export const queryEtherSwapValuesFromLock = async (
   etherSwap: EtherSwap,
   lockTransactionHash: string,
   lockedByUser: boolean,
+  logIndex?: number,
 ): Promise<EtherSwapValues> =>
   querySwapValuesFromLock(
     provider,
@@ -131,7 +141,7 @@ export const queryEtherSwapValuesFromLock = async (
     lockTransactionHash,
     await getIdentifier(swap, lockedByUser),
     formatEtherSwapValues,
-    undefined,
+    logIndex,
   );
 
 export const queryERC20SwapValuesFromLock = async (
@@ -140,6 +150,7 @@ export const queryERC20SwapValuesFromLock = async (
   erc20Swap: ERC20Swap,
   lockTransactionHash: string,
   lockedByUser: boolean,
+  logIndex?: number,
 ): Promise<ERC20SwapValues> =>
   querySwapValuesFromLock(
     provider,
@@ -147,7 +158,7 @@ export const queryERC20SwapValuesFromLock = async (
     lockTransactionHash,
     await getIdentifier(swap, lockedByUser),
     formatERC20SwapValues,
-    undefined,
+    logIndex,
   );
 
 export const queryEtherSwapValuesFromTransaction = async (

--- a/test/integration/db/repositories/ChainSwapRepository.spec.ts
+++ b/test/integration/db/repositories/ChainSwapRepository.spec.ts
@@ -465,6 +465,25 @@ describe('ChainSwapRepository', () => {
     },
   );
 
+  test('should reject when the receiving data cannot be found', async () => {
+    const swap = await createChainSwap();
+
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      {
+        id: swap.chainSwap.id,
+        receivingData: { symbol: 'NOT-A-SYMBOL' },
+      } as ChainSwapInfo,
+      'lockup-a',
+      1_000,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.SwapCreated);
+    expect(result.swap.receivingData.transactionId).toBeNull();
+  });
+
   test('should not let a different transaction replace a confirmed user lockup', async () => {
     const swap = await createChainSwap();
     const amount = swap.receivingData.expectedAmount! + 1;

--- a/test/integration/db/repositories/ChainSwapRepository.spec.ts
+++ b/test/integration/db/repositories/ChainSwapRepository.spec.ts
@@ -8,6 +8,7 @@ import {
   SwapVersion,
 } from '../../../../lib/consts/Enums';
 import Database from '../../../../lib/db/Database';
+import { LockupWriteOutcome } from '../../../../lib/db/LockupIdentity';
 import ChainSwap from '../../../../lib/db/models/ChainSwap';
 import type { ChainSwapDataType } from '../../../../lib/db/models/ChainSwapData';
 import ChainSwapData from '../../../../lib/db/models/ChainSwapData';
@@ -435,34 +436,233 @@ describe('ChainSwapRepository', () => {
   });
 
   test.each`
-    status                                  | confirmed
-    ${SwapUpdateEvent.TransactionMempool}   | ${false}
-    ${SwapUpdateEvent.TransactionConfirmed} | ${true}
+    status                                  | targetStatus
+    ${SwapUpdateEvent.TransactionMempool}   | ${SwapUpdateEvent.TransactionMempool}
+    ${SwapUpdateEvent.TransactionConfirmed} | ${SwapUpdateEvent.TransactionConfirmed}
   `(
-    'should set user lockup transaction (confirmed: $confirmed)',
-    async ({ status, confirmed }) => {
+    'should set user lockup transaction (status: $status)',
+    async ({ status, targetStatus }) => {
       const swap = await createChainSwap();
       const txId = 'tx';
       const vout = 1;
       const onchainAmount = swap.receivingData.expectedAmount! + 1;
 
-      const updated = await ChainSwapRepository.setUserLockupTransaction(
+      const result = await ChainSwapRepository.setUserLockupTransaction(
         (await ChainSwapRepository.getChainSwap({
           id: swap.chainSwap.id,
         }))!,
         txId,
         onchainAmount,
-        confirmed,
+        targetStatus,
         vout,
       );
 
-      expect(updated).not.toBeNull();
-      expect(updated!.chainSwap.status).toEqual(status);
-      expect(updated!.receivingData.transactionId).toEqual(txId);
-      expect(updated!.receivingData.amount).toEqual(onchainAmount);
-      expect(updated!.receivingData.transactionVout).toEqual(vout);
+      expect(result.outcome).toEqual(LockupWriteOutcome.Acquired);
+      expect(result.swap.chainSwap.status).toEqual(status);
+      expect(result.swap.receivingData.transactionId).toEqual(txId);
+      expect(result.swap.receivingData.amount).toEqual(onchainAmount);
+      expect(result.swap.receivingData.transactionVout).toEqual(vout);
     },
   );
+
+  test('should not let a different transaction replace a confirmed user lockup', async () => {
+    const swap = await createChainSwap();
+    const amount = swap.receivingData.expectedAmount! + 1;
+
+    await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
+    );
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-b',
+      1_000,
+      SwapUpdateEvent.TransactionConfirmed,
+      1,
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    expect(result.swap.receivingData.transactionId).toEqual('lockup-a');
+    expect(result.swap.receivingData.amount).toEqual(amount);
+    expect(result.swap.receivingData.transactionVout).toEqual(0);
+  });
+
+  test('should treat another log index of a confirmed transaction as competing', async () => {
+    const swap = await createChainSwap();
+    const amount = swap.receivingData.expectedAmount! + 1;
+
+    await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      5,
+    );
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      1_000,
+      SwapUpdateEvent.TransactionConfirmed,
+      7,
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+    expect(result.swap.receivingData.amount).toEqual(amount);
+    expect(result.swap.receivingData.transactionVout).toEqual(5);
+  });
+
+  test('should not downgrade a confirmed user lockup to lockup failed', async () => {
+    const swap = await createChainSwap();
+    const amount = swap.receivingData.expectedAmount! + 1;
+
+    await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
+    );
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionLockupFailed,
+      0,
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Idempotent);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    expect(result.swap.receivingData.transactionId).toEqual('lockup-a');
+  });
+
+  test('should not downgrade a confirmed user lockup to mempool', async () => {
+    const swap = await createChainSwap();
+    const amount = swap.receivingData.expectedAmount! + 1;
+
+    await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
+    );
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionMempool,
+      0,
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Idempotent);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    expect(result.swap.receivingData.transactionId).toEqual('lockup-a');
+  });
+
+  test('should not let a different transaction replace an unconfirmed user lockup', async () => {
+    const swap = await createChainSwap();
+    const amount = swap.receivingData.expectedAmount! + 1;
+
+    await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionMempool,
+      0,
+    );
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-b',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      1,
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionMempool);
+    expect(result.swap.receivingData.transactionId).toEqual('lockup-a');
+    expect(result.swap.receivingData.transactionVout).toEqual(0);
+  });
+
+  test('should let a valid user lockup take over from a zero-conf rejected one', async () => {
+    const swap = await createChainSwap();
+    const amount = swap.receivingData.expectedAmount! + 1;
+
+    const initial = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionMempool,
+      0,
+    );
+    await initial.swap.chainSwap.update({
+      status: SwapUpdateEvent.TransactionZeroConfRejected,
+    });
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-b',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      1,
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Acquired);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    expect(result.swap.receivingData.transactionId).toEqual('lockup-b');
+    expect(result.swap.receivingData.transactionVout).toEqual(1);
+  });
+
+  test('should not let a different transaction replace a confirmed user lockup even with the override', async () => {
+    const swap = await createChainSwap();
+    const amount = swap.receivingData.expectedAmount! + 1;
+
+    await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
+    );
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-b',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      1,
+      { allowLockupFailedUpdate: true },
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+    expect(result.swap.receivingData.transactionId).toEqual('lockup-a');
+    expect(result.swap.receivingData.transactionVout).toEqual(0);
+  });
+
+  test('should match and backfill when the stored user lockup has no vout', async () => {
+    const swap = await createChainSwap();
+    const amount = swap.receivingData.expectedAmount! + 1;
+
+    await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionMempool,
+    );
+    const result = await ChainSwapRepository.setUserLockupTransaction(
+      (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+      'lockup-a',
+      amount,
+      SwapUpdateEvent.TransactionConfirmed,
+      3,
+    );
+
+    expect(result.outcome).toEqual(LockupWriteOutcome.Idempotent);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    expect(result.swap.receivingData.transactionVout).toEqual(3);
+  });
 
   test('should not overwrite failed user lockup transactions by default', async () => {
     const swap = await createChainSwap(SwapUpdateEvent.TransactionLockupFailed);
@@ -470,18 +670,19 @@ describe('ChainSwapRepository', () => {
       id: swap.chainSwap.id,
     }))!;
 
-    const updated = await ChainSwapRepository.setUserLockupTransaction(
+    const result = await ChainSwapRepository.setUserLockupTransaction(
       queried,
       'tx',
       queried.receivingData.expectedAmount! + 1,
-      true,
+      SwapUpdateEvent.TransactionConfirmed,
       1,
     );
 
-    expect(updated.status).toEqual(SwapUpdateEvent.TransactionLockupFailed);
-    expect(updated.receivingData.transactionId).toBeNull();
-    expect(updated.receivingData.transactionVout).toBeNull();
-    expect(updated.receivingData.amount).toBeNull();
+    expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionLockupFailed);
+    expect(result.swap.receivingData.transactionId).toBeNull();
+    expect(result.swap.receivingData.transactionVout).toBeNull();
+    expect(result.swap.receivingData.amount).toBeNull();
   });
 
   test('should update failed user lockup transactions when explicitly allowed', async () => {
@@ -491,19 +692,94 @@ describe('ChainSwapRepository', () => {
     }))!;
     const onchainAmount = queried.receivingData.expectedAmount! + 1;
 
-    const updated = await ChainSwapRepository.setUserLockupTransaction(
+    const result = await ChainSwapRepository.setUserLockupTransaction(
       queried,
       'tx',
       onchainAmount,
-      true,
+      SwapUpdateEvent.TransactionConfirmed,
       1,
       { allowLockupFailedUpdate: true },
     );
 
-    expect(updated.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
-    expect(updated.receivingData.transactionId).toEqual('tx');
-    expect(updated.receivingData.transactionVout).toEqual(1);
-    expect(updated.receivingData.amount).toEqual(onchainAmount);
+    expect(result.outcome).toEqual(LockupWriteOutcome.Acquired);
+    expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    expect(result.swap.receivingData.transactionId).toEqual('tx');
+    expect(result.swap.receivingData.transactionVout).toEqual(1);
+    expect(result.swap.receivingData.amount).toEqual(onchainAmount);
+  });
+
+  describe('setZeroConfRejected', () => {
+    test('should reject the recorded mempool user lockup', async () => {
+      const swap = await createChainSwap();
+      await ChainSwapRepository.setUserLockupTransaction(
+        (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+        'lockup-a',
+        swap.receivingData.expectedAmount! + 1,
+        SwapUpdateEvent.TransactionMempool,
+        0,
+      );
+
+      const updated = await ChainSwapRepository.setZeroConfRejected(
+        (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+        'lockup-a',
+        0,
+      );
+
+      expect(updated.status).toEqual(
+        SwapUpdateEvent.TransactionZeroConfRejected,
+      );
+    });
+
+    test('should not downgrade a confirmed user lockup', async () => {
+      const swap = await createChainSwap();
+      await ChainSwapRepository.setUserLockupTransaction(
+        (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+        'lockup-a',
+        swap.receivingData.expectedAmount! + 1,
+        SwapUpdateEvent.TransactionConfirmed,
+        0,
+      );
+
+      const updated = await ChainSwapRepository.setZeroConfRejected(
+        (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+        'lockup-a',
+        0,
+      );
+
+      expect(updated.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    });
+
+    test('should ignore rejections from a transaction that does not own the lockup', async () => {
+      const swap = await createChainSwap();
+      await ChainSwapRepository.setUserLockupTransaction(
+        (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+        'lockup-a',
+        swap.receivingData.expectedAmount! + 1,
+        SwapUpdateEvent.TransactionMempool,
+        0,
+      );
+
+      const updated = await ChainSwapRepository.setZeroConfRejected(
+        (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+        'lockup-b',
+        1,
+      );
+
+      expect(updated.status).toEqual(SwapUpdateEvent.TransactionMempool);
+      expect(updated.receivingData.transactionId).toEqual('lockup-a');
+    });
+
+    test('should ignore rejections when no user lockup is recorded', async () => {
+      const swap = await createChainSwap();
+
+      const updated = await ChainSwapRepository.setZeroConfRejected(
+        (await ChainSwapRepository.getChainSwap({ id: swap.chainSwap.id }))!,
+        'lockup-a',
+        0,
+      );
+
+      expect(updated.status).toEqual(SwapUpdateEvent.SwapCreated);
+    });
   });
 
   test('should set expected amounts', async () => {

--- a/test/integration/db/repositories/SwapRepository.spec.ts
+++ b/test/integration/db/repositories/SwapRepository.spec.ts
@@ -163,6 +163,22 @@ describe('SwapRepository', () => {
       expect(result.swap.lockupTransactionVout).toEqual(0);
     });
 
+    test('should reject when the swap does not exist anymore', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+      await swap.destroy();
+
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        0,
+      );
+
+      expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+      expect(result.swap).toEqual(swap);
+    });
+
     test.each([
       SwapUpdateEvent.InvoicePending,
       SwapUpdateEvent.InvoicePaid,

--- a/test/integration/db/repositories/SwapRepository.spec.ts
+++ b/test/integration/db/repositories/SwapRepository.spec.ts
@@ -1,6 +1,7 @@
 import Logger from '../../../../lib/Logger';
 import { SwapUpdateEvent } from '../../../../lib/consts/Enums';
 import Database from '../../../../lib/db/Database';
+import { LockupWriteOutcome } from '../../../../lib/db/LockupIdentity';
 import Pair from '../../../../lib/db/models/Pair';
 import Swap from '../../../../lib/db/models/Swap';
 import SwapRepository from '../../../../lib/db/repositories/SwapRepository';
@@ -144,10 +145,31 @@ describe('SwapRepository', () => {
   });
 
   describe('setLockupTransaction', () => {
+    test('should acquire an ownerless lockup', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        0,
+      );
+
+      expect(result.outcome).toEqual(LockupWriteOutcome.Acquired);
+      expect(result.swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(result.swap.lockupTransactionId).toEqual('lockup-a');
+      expect(result.swap.onchainAmount).toEqual(100_000);
+      expect(result.swap.lockupTransactionVout).toEqual(0);
+    });
+
     test.each([
+      SwapUpdateEvent.InvoicePending,
       SwapUpdateEvent.InvoicePaid,
+      SwapUpdateEvent.InvoiceFailedToPay,
       SwapUpdateEvent.TransactionClaimPending,
       SwapUpdateEvent.TransactionClaimed,
+      SwapUpdateEvent.SwapExpired,
     ])('should not downgrade status from %s', async (status) => {
       const swap = await Swap.create(createSubmarineSwapData());
 
@@ -155,26 +177,366 @@ describe('SwapRepository', () => {
         swap,
         'initial-lockup',
         123_000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         1,
       );
       await SwapRepository.setSwapStatus(swap, status);
 
-      const updated = await SwapRepository.setLockupTransaction(
+      const result = await SwapRepository.setLockupTransaction(
         swap,
         'stale-lockup',
         321_000,
-        false,
+        SwapUpdateEvent.TransactionMempool,
         2,
       );
 
       await swap.reload();
 
-      expect(updated.status).toEqual(status);
+      expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+      expect(result.swap.status).toEqual(status);
       expect(swap.status).toEqual(status);
       expect(swap.lockupTransactionId).toEqual('initial-lockup');
       expect(swap.onchainAmount).toEqual(123_000);
       expect(swap.lockupTransactionVout).toEqual(1);
+    });
+
+    test.each([SwapUpdateEvent.InvoicePending, SwapUpdateEvent.InvoicePaid])(
+      'should not acquire an ownerless lockup in status %s',
+      async (status) => {
+        const swap = await Swap.create(createSubmarineSwapData());
+        await SwapRepository.setSwapStatus(swap, status);
+
+        const result = await SwapRepository.setLockupTransaction(
+          swap,
+          'lockup-a',
+          100_000,
+          SwapUpdateEvent.TransactionConfirmed,
+          0,
+        );
+
+        expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+        expect(result.swap.lockupTransactionId).toBeNull();
+      },
+    );
+
+    test('should not let a different transaction replace a confirmed lockup', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        0,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-b',
+        1_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        1,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(swap.lockupTransactionId).toEqual('lockup-a');
+      expect(swap.onchainAmount).toEqual(100_000);
+      expect(swap.lockupTransactionVout).toEqual(0);
+    });
+
+    test('should treat another log index of a confirmed transaction as competing', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        5,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        1_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        7,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+      expect(swap.onchainAmount).toEqual(100_000);
+      expect(swap.lockupTransactionVout).toEqual(5);
+    });
+
+    test('should not let a different transaction replace an unconfirmed lockup', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionMempool,
+        0,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-b',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        1,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Rejected);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionMempool);
+      expect(swap.lockupTransactionId).toEqual('lockup-a');
+      expect(swap.lockupTransactionVout).toEqual(0);
+    });
+
+    test('should let a valid lockup take over from a failed one', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        1_000,
+        SwapUpdateEvent.TransactionLockupFailed,
+        0,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-b',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        1,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Acquired);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(swap.lockupTransactionId).toEqual('lockup-b');
+    });
+
+    test('should let a valid lockup take over from a zero-conf rejected one', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionMempool,
+        0,
+      );
+      await SwapRepository.setSwapStatus(
+        swap,
+        SwapUpdateEvent.TransactionZeroConfRejected,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-b',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        1,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Acquired);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(swap.lockupTransactionId).toEqual('lockup-b');
+      expect(swap.lockupTransactionVout).toEqual(1);
+    });
+
+    test('should allow the same transaction to transition to confirmed', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionMempool,
+        0,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        0,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Idempotent);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(swap.lockupTransactionId).toEqual('lockup-a');
+    });
+
+    test('should not downgrade a confirmed lockup to lockup failed', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        0,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionLockupFailed,
+        0,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Idempotent);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(swap.lockupTransactionId).toEqual('lockup-a');
+    });
+
+    test('should not downgrade a confirmed lockup to mempool', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        0,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionMempool,
+        0,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Idempotent);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(swap.lockupTransactionId).toEqual('lockup-a');
+    });
+
+    test('should match and backfill when the stored lockup has no vout', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionMempool,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        3,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Idempotent);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(swap.lockupTransactionVout).toEqual(3);
+    });
+
+    test('should keep the stored vout when a redelivery has none', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionMempool,
+        2,
+      );
+      const result = await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+      );
+
+      await swap.reload();
+      expect(result.outcome).toEqual(LockupWriteOutcome.Idempotent);
+      expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+      expect(swap.lockupTransactionVout).toEqual(2);
+    });
+  });
+
+  describe('setZeroConfRejected', () => {
+    test('should reject the recorded mempool lockup', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionMempool,
+        0,
+      );
+
+      const updated = await SwapRepository.setZeroConfRejected(
+        swap,
+        'lockup-a',
+        0,
+      );
+
+      expect(updated.status).toEqual(
+        SwapUpdateEvent.TransactionZeroConfRejected,
+      );
+    });
+
+    test('should not downgrade a confirmed lockup', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionConfirmed,
+        0,
+      );
+
+      const updated = await SwapRepository.setZeroConfRejected(
+        swap,
+        'lockup-a',
+        0,
+      );
+
+      expect(updated.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    });
+
+    test('should ignore rejections from a transaction that does not own the lockup', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+      await SwapRepository.setLockupTransaction(
+        swap,
+        'lockup-a',
+        100_000,
+        SwapUpdateEvent.TransactionMempool,
+        0,
+      );
+
+      const updated = await SwapRepository.setZeroConfRejected(
+        swap,
+        'lockup-b',
+        1,
+      );
+
+      expect(updated.status).toEqual(SwapUpdateEvent.TransactionMempool);
+      expect(updated.lockupTransactionId).toEqual('lockup-a');
+    });
+
+    test('should ignore rejections when no lockup is recorded', async () => {
+      const swap = await Swap.create(createSubmarineSwapData());
+
+      const updated = await SwapRepository.setZeroConfRejected(
+        swap,
+        'lockup-a',
+        0,
+      );
+
+      expect(updated.status).toEqual(SwapUpdateEvent.SwapCreated);
     });
   });
 

--- a/test/integration/service/Renegotiator.spec.ts
+++ b/test/integration/service/Renegotiator.spec.ts
@@ -570,6 +570,81 @@ describe('Renegotiator', () => {
         );
       });
 
+      test.each`
+        name          | offset | shouldFind
+        ${'resolves'} | ${0}   | ${true}
+        ${'is stale'} | ${100} | ${false}
+      `(
+        'should select the lockup event by the recorded log index when it $name',
+        async ({ offset, shouldFind }) => {
+          const { etherBase, signer } = await getSigner();
+          const { etherSwap } = await getContracts(etherBase);
+
+          const preimageHash = randomBytes(32);
+          const timelock = 21;
+          const amount = 212_212n;
+
+          const transaction = await etherSwap['lock(bytes32,address,uint256)'](
+            preimageHash,
+            await signer.getAddress(),
+            timelock,
+            {
+              value: amount,
+            },
+          );
+          const receipt = await transaction.wait(1);
+          const logIndex = receipt!.logs[0].index;
+
+          ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue({
+            chainSwap: {},
+            acceptZeroConf: true,
+            receivingData: {
+              symbol: 'RBTC',
+              amount: 100_000,
+              transactionId: transaction.hash,
+              transactionVout: logIndex + offset,
+            },
+            sendingData: {
+              symbol: 'BTC',
+            },
+          });
+          ChainSwapRepository.setExpectedAmounts = jest
+            .fn()
+            .mockImplementation(async (swap) => swap);
+
+          negotiator['validateEligibility'] = jest
+            .fn()
+            .mockImplementation(async () => {});
+
+          const acceptQuote = negotiator.acceptQuote('someId', 94_877);
+
+          if (!shouldFind) {
+            await expect(acceptQuote).rejects.toEqual(
+              Errors.LOCKUP_NOT_REJECTED(),
+            );
+            expect(
+              swapNursery.ethereumNurseries[0].checkEtherSwapLockup,
+            ).not.toHaveBeenCalled();
+            return;
+          }
+
+          await acceptQuote;
+
+          expect(
+            swapNursery.ethereumNurseries[0].checkEtherSwapLockup,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            swapNursery.ethereumNurseries[0].checkEtherSwapLockup,
+          ).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            expect.objectContaining({ amount, timelock, preimageHash }),
+            logIndex,
+            { allowLockupFailedUpdate: true },
+          );
+        },
+      );
+
       test('should handle ERC20 lockups', async () => {
         const { etherBase, signer } = await getSigner();
         const { token, erc20Swap } = await getContracts(etherBase);

--- a/test/integration/service/Renegotiator.spec.ts
+++ b/test/integration/service/Renegotiator.spec.ts
@@ -565,6 +565,7 @@ describe('Renegotiator', () => {
             claimAddress: await signer.getAddress(),
             refundAddress: await etherBase.getAddress(),
           },
+          expect.any(Number),
           { allowLockupFailedUpdate: true },
         );
       });
@@ -656,6 +657,7 @@ describe('Renegotiator', () => {
             claimAddress: await signer.getAddress(),
             refundAddress: await etherBase.getAddress(),
           },
+          expect.any(Number),
           { allowLockupFailedUpdate: true },
         );
       });

--- a/test/integration/swap/EthereumNursery.spec.ts
+++ b/test/integration/swap/EthereumNursery.spec.ts
@@ -1,0 +1,339 @@
+import { randomBytes } from 'crypto';
+import { Transaction } from 'ethers';
+import Logger from '../../../lib/Logger';
+import { generateSwapId, getHexString } from '../../../lib/Utils';
+import {
+  CurrencyType,
+  OrderSide,
+  SwapUpdateEvent,
+  SwapVersion,
+} from '../../../lib/consts/Enums';
+import Database from '../../../lib/db/Database';
+import Pair from '../../../lib/db/models/Pair';
+import Swap from '../../../lib/db/models/Swap';
+import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
+import SwapRepository from '../../../lib/db/repositories/SwapRepository';
+import Errors from '../../../lib/swap/Errors';
+import EthereumNursery from '../../../lib/swap/EthereumNursery';
+import OverpaymentProtector from '../../../lib/swap/OverpaymentProtector';
+import { Action } from '../../../lib/swap/hooks/CreationHook';
+import type TransactionHook from '../../../lib/swap/hooks/TransactionHook';
+import { networks } from '../../../lib/wallet/ethereum/EvmNetworks';
+
+describe('EthereumNursery', () => {
+  let database: Database;
+
+  const mockAddress = '0x735Ec659CB2E2D2B778F8D4178ce2a521D617119';
+
+  const exampleTransaction = Transaction.from(
+    '0x02f8732103843b9aca0084a6fb2cd482520894f39fd6e51aad88f6f4ce6ab8827279cfffb92266893635c9adc5dea0000080c001a03321cede5d110b71d670aaea8353427dea69e67b74f3f3f0fb85c3b682b3cbf4a0240a9787a8807fe07255f0e541ad94b271821660aa3e786699c29c9dd1399d56',
+  );
+
+  let releaseHook: () => void;
+  let hookGate: Promise<void>;
+
+  const transactionHook = {
+    hook: jest.fn(),
+  } as unknown as TransactionHook;
+
+  const nursery = new EthereumNursery(
+    Logger.disabledLogger,
+    {
+      wallets: new Map<string, any>([
+        ['ETH', { symbol: 'ETH', type: CurrencyType.Ether }],
+      ]),
+    } as any,
+    {
+      address: mockAddress,
+      networkDetails: networks.Ethereum,
+      hasSymbol: () => true,
+      provider: {},
+      contractEventHandler: { on: () => {} },
+    } as any,
+    transactionHook,
+    new OverpaymentProtector(Logger.disabledLogger),
+  );
+
+  const validEtherSwapValues = (timeoutBlockHeight: number) =>
+    ({
+      claimAddress: mockAddress,
+      refundAddress: mockAddress,
+      amount: BigInt('100000000000'),
+      preimageHash: getHexString(randomBytes(32)),
+      timelock: timeoutBlockHeight,
+    }) as any;
+
+  beforeAll(async () => {
+    database = new Database(Logger.disabledLogger, Database.memoryDatabase);
+    await database.init();
+    await Pair.create({
+      base: 'ETH',
+      quote: 'BTC',
+      id: 'ETH/BTC',
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nursery.removeAllListeners();
+
+    hookGate = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    transactionHook.hook = jest.fn().mockImplementation(async () => {
+      await hookGate;
+      return Action.Accept;
+    });
+  });
+
+  afterAll(async () => {
+    await database.close();
+  });
+
+  test('should emit nothing when an invalid lockup takes a chain swap while a valid one is validating', async () => {
+    const id = generateSwapId(SwapVersion.Taproot);
+    await ChainSwapRepository.addChainSwap({
+      chainSwap: {
+        id,
+        fee: 1,
+        pair: 'ETH/BTC',
+        acceptZeroConf: false,
+        orderSide: OrderSide.SELL,
+        status: SwapUpdateEvent.SwapCreated,
+        preimageHash: getHexString(randomBytes(32)),
+        createdRefundSignature: false,
+      },
+      sendingData: {
+        swapId: id,
+        symbol: 'BTC',
+        lockupAddress: 'bc1',
+        timeoutBlockHeight: 1,
+        expectedAmount: 9,
+      },
+      receivingData: {
+        swapId: id,
+        symbol: 'ETH',
+        lockupAddress: mockAddress,
+        timeoutBlockHeight: 1,
+        expectedAmount: 10,
+      },
+    });
+    const swap = (await ChainSwapRepository.getChainSwap({ id }))!;
+
+    const events = jest.fn();
+    nursery.on('eth.lockup', events);
+    nursery.on('lockup.failed', events);
+
+    const validCheck = nursery.checkEtherSwapLockup(
+      swap,
+      exampleTransaction,
+      validEtherSwapValues(swap.receivingData.timeoutBlockHeight),
+      5,
+    );
+    await new Promise(setImmediate);
+
+    await ChainSwapRepository.setUserLockupTransaction(
+      swap,
+      'competing-lockup',
+      1,
+      SwapUpdateEvent.TransactionLockupFailed,
+      7,
+    );
+
+    releaseHook();
+    await validCheck;
+
+    expect(events).not.toHaveBeenCalled();
+
+    const updated = (await ChainSwapRepository.getChainSwap({ id }))!;
+    expect(updated.status).toEqual(SwapUpdateEvent.TransactionLockupFailed);
+    expect(updated.receivingData.transactionId).toEqual('competing-lockup');
+    expect(updated.receivingData.transactionVout).toEqual(7);
+  });
+
+  test('should emit lockup.failed when a fresh chain swap lockup fails validation', async () => {
+    const id = generateSwapId(SwapVersion.Taproot);
+    await ChainSwapRepository.addChainSwap({
+      chainSwap: {
+        id,
+        fee: 1,
+        pair: 'ETH/BTC',
+        acceptZeroConf: false,
+        orderSide: OrderSide.SELL,
+        status: SwapUpdateEvent.SwapCreated,
+        preimageHash: getHexString(randomBytes(32)),
+        createdRefundSignature: false,
+      },
+      sendingData: {
+        swapId: id,
+        symbol: 'BTC',
+        lockupAddress: 'bc1',
+        timeoutBlockHeight: 1,
+        expectedAmount: 9,
+      },
+      receivingData: {
+        swapId: id,
+        symbol: 'ETH',
+        lockupAddress: mockAddress,
+        timeoutBlockHeight: 1,
+        expectedAmount: 10,
+      },
+    });
+    const swap = (await ChainSwapRepository.getChainSwap({ id }))!;
+
+    const lockupEvents = jest.fn();
+    const failedEvents = jest.fn();
+    nursery.on('eth.lockup', lockupEvents);
+    nursery.on('lockup.failed', failedEvents);
+
+    const underpaidValues = validEtherSwapValues(
+      swap.receivingData.timeoutBlockHeight,
+    );
+    underpaidValues.amount = BigInt('90000000000');
+
+    await nursery.checkEtherSwapLockup(
+      swap,
+      exampleTransaction,
+      underpaidValues,
+      5,
+    );
+
+    expect(lockupEvents).not.toHaveBeenCalled();
+    expect(failedEvents).toHaveBeenCalledTimes(1);
+    expect(failedEvents.mock.calls[0][0].reason).toEqual(
+      Errors.INSUFFICIENT_AMOUNT(9, 10).message,
+    );
+    expect(failedEvents.mock.calls[0][0].swap.status).toEqual(
+      SwapUpdateEvent.TransactionLockupFailed,
+    );
+
+    const updated = (await ChainSwapRepository.getChainSwap({ id }))!;
+    expect(updated.status).toEqual(SwapUpdateEvent.TransactionLockupFailed);
+    expect(updated.receivingData.transactionId).toEqual(
+      exampleTransaction.hash,
+    );
+    expect(updated.receivingData.transactionVout).toEqual(5);
+
+    await nursery.checkEtherSwapLockup(
+      updated,
+      exampleTransaction,
+      underpaidValues,
+      5,
+    );
+    expect(failedEvents).toHaveBeenCalledTimes(1);
+  });
+
+  test('should emit only its own identity when a valid submarine lockup takes over from a failed one', async () => {
+    const swapData = {
+      fee: 1,
+      pair: 'ETH/BTC',
+      acceptZeroConf: false,
+      lockupAddress: mockAddress,
+      timeoutBlockHeight: 1,
+      orderSide: OrderSide.SELL,
+      version: SwapVersion.Taproot,
+      status: SwapUpdateEvent.SwapCreated,
+      id: generateSwapId(SwapVersion.Taproot),
+      preimageHash: getHexString(randomBytes(32)),
+      createdRefundSignature: false,
+      expectedAmount: 10,
+    };
+    const swap = await Swap.create(swapData);
+
+    const lockupEvents = jest.fn();
+    const failedEvents = jest.fn();
+    nursery.on('eth.lockup', lockupEvents);
+    nursery.on('lockup.failed', failedEvents);
+
+    const validCheck = nursery.checkEtherSwapLockup(
+      swap,
+      exampleTransaction,
+      validEtherSwapValues(swapData.timeoutBlockHeight),
+      5,
+    );
+    await new Promise(setImmediate);
+
+    await SwapRepository.setLockupTransaction(
+      swap,
+      'competing-lockup',
+      1,
+      SwapUpdateEvent.TransactionLockupFailed,
+      7,
+    );
+
+    releaseHook();
+    await validCheck;
+
+    expect(failedEvents).not.toHaveBeenCalled();
+    expect(lockupEvents).toHaveBeenCalledTimes(1);
+
+    const emitted = lockupEvents.mock.calls[0][0];
+    expect(emitted.transactionHash).toEqual(exampleTransaction.hash);
+    expect(emitted.logIndex).toEqual(5);
+    expect(emitted.swap.lockupTransactionId).toEqual(exampleTransaction.hash);
+    expect(emitted.swap.lockupTransactionVout).toEqual(5);
+    expect(emitted.swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+
+    await swap.reload();
+    expect(swap.lockupTransactionId).toEqual(exampleTransaction.hash);
+    expect(swap.lockupTransactionVout).toEqual(5);
+  });
+
+  test('should serialize concurrent callbacks for the same swap', async () => {
+    const swapData = {
+      fee: 1,
+      pair: 'ETH/BTC',
+      acceptZeroConf: false,
+      lockupAddress: mockAddress,
+      timeoutBlockHeight: 1,
+      orderSide: OrderSide.SELL,
+      version: SwapVersion.Taproot,
+      status: SwapUpdateEvent.SwapCreated,
+      id: generateSwapId(SwapVersion.Taproot),
+      preimageHash: getHexString(randomBytes(32)),
+      createdRefundSignature: false,
+      expectedAmount: 10,
+    };
+    const swap = await Swap.create(swapData);
+
+    const competingTransaction = exampleTransaction.clone();
+    competingTransaction.nonce = exampleTransaction.nonce + 1;
+    expect(competingTransaction.hash).not.toEqual(exampleTransaction.hash);
+
+    const lockupEvents = jest.fn();
+    const failedEvents = jest.fn();
+    nursery.on('eth.lockup', lockupEvents);
+    nursery.on('lockup.failed', failedEvents);
+
+    const checkA = nursery.checkEtherSwapLockup(
+      swap,
+      exampleTransaction,
+      validEtherSwapValues(swapData.timeoutBlockHeight),
+      5,
+    );
+    const checkB = nursery.checkEtherSwapLockup(
+      swap,
+      competingTransaction,
+      validEtherSwapValues(swapData.timeoutBlockHeight),
+      7,
+    );
+    await new Promise(setImmediate);
+
+    expect(transactionHook.hook).toHaveBeenCalledTimes(1);
+
+    releaseHook();
+    await Promise.all([checkA, checkB]);
+
+    expect(failedEvents).not.toHaveBeenCalled();
+    expect(lockupEvents).toHaveBeenCalledTimes(1);
+
+    const emitted = lockupEvents.mock.calls[0][0];
+    expect(emitted.transactionHash).toEqual(exampleTransaction.hash);
+    expect(emitted.logIndex).toEqual(5);
+
+    await swap.reload();
+    expect(swap.status).toEqual(SwapUpdateEvent.TransactionConfirmed);
+    expect(swap.lockupTransactionId).toEqual(exampleTransaction.hash);
+    expect(swap.lockupTransactionVout).toEqual(5);
+  });
+});

--- a/test/integration/swap/EthereumNursery.spec.ts
+++ b/test/integration/swap/EthereumNursery.spec.ts
@@ -13,6 +13,7 @@ import Pair from '../../../lib/db/models/Pair';
 import Swap from '../../../lib/db/models/Swap';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
 import SwapRepository from '../../../lib/db/repositories/SwapRepository';
+import WrappedSwapRepository from '../../../lib/db/repositories/WrappedSwapRepository';
 import Errors from '../../../lib/swap/Errors';
 import EthereumNursery from '../../../lib/swap/EthereumNursery';
 import OverpaymentProtector from '../../../lib/swap/OverpaymentProtector';
@@ -214,13 +215,93 @@ describe('EthereumNursery', () => {
     );
     expect(updated.receivingData.transactionVout).toEqual(5);
 
-    await nursery.checkEtherSwapLockup(
+    // What SwapNursery does when it handles the "lockup.failed" event
+    const withReason = await WrappedSwapRepository.setStatus(
       updated,
+      SwapUpdateEvent.TransactionLockupFailed,
+      Errors.INSUFFICIENT_AMOUNT(9, 10).message,
+    );
+
+    await nursery.checkEtherSwapLockup(
+      withReason,
       exampleTransaction,
       underpaidValues,
       5,
     );
     expect(failedEvents).toHaveBeenCalledTimes(1);
+  });
+
+  test('should emit lockup.failed again when a renegotiated lockup still fails', async () => {
+    const id = generateSwapId(SwapVersion.Taproot);
+    await ChainSwapRepository.addChainSwap({
+      chainSwap: {
+        id,
+        fee: 1,
+        pair: 'ETH/BTC',
+        acceptZeroConf: false,
+        orderSide: OrderSide.SELL,
+        status: SwapUpdateEvent.SwapCreated,
+        preimageHash: getHexString(randomBytes(32)),
+        createdRefundSignature: false,
+      },
+      sendingData: {
+        swapId: id,
+        symbol: 'BTC',
+        lockupAddress: 'bc1',
+        timeoutBlockHeight: 1,
+        expectedAmount: 9,
+      },
+      receivingData: {
+        swapId: id,
+        symbol: 'ETH',
+        lockupAddress: mockAddress,
+        timeoutBlockHeight: 1,
+        expectedAmount: 10,
+      },
+    });
+    const swap = (await ChainSwapRepository.getChainSwap({ id }))!;
+
+    const failedEvents = jest.fn();
+    nursery.on('lockup.failed', failedEvents);
+
+    const underpaidValues = validEtherSwapValues(
+      swap.receivingData.timeoutBlockHeight,
+    );
+    underpaidValues.amount = BigInt('90000000000');
+
+    releaseHook();
+    await nursery.checkEtherSwapLockup(
+      swap,
+      exampleTransaction,
+      underpaidValues,
+      5,
+    );
+    expect(failedEvents).toHaveBeenCalledTimes(1);
+
+    const failed = await WrappedSwapRepository.setStatus(
+      (await ChainSwapRepository.getChainSwap({ id }))!,
+      SwapUpdateEvent.TransactionLockupFailed,
+      Errors.INSUFFICIENT_AMOUNT(9, 10).message,
+    );
+
+    // Renegotiating clears the failure reason, but the amount is still too low
+    const renegotiated = await ChainSwapRepository.setExpectedAmounts(
+      failed,
+      1,
+      10,
+      9,
+      false,
+    );
+    expect(renegotiated.failureReason).toBeNull();
+
+    await nursery.checkEtherSwapLockup(
+      renegotiated,
+      exampleTransaction,
+      underpaidValues,
+      5,
+      { allowLockupFailedUpdate: true },
+    );
+    expect(failedEvents).toHaveBeenCalledTimes(2);
   });
 
   test('should emit only its own identity when a valid submarine lockup takes over from a failed one', async () => {

--- a/test/integration/wallet/ethereum/ConsolidatedEventHandler.spec.ts
+++ b/test/integration/wallet/ethereum/ConsolidatedEventHandler.spec.ts
@@ -79,22 +79,28 @@ describe('ConsolidatedEventHandler integration', () => {
     tokenAddress: '0xtoken',
   });
 
-  const ethLockupPayload = async (): Promise<Events['eth.lockup']> => {
+  const ethLockupPayload = async (
+    logIndex: number = 0,
+  ): Promise<Events['eth.lockup']> => {
     const transaction = await sendTransaction();
 
     return {
       version: 4n,
       transaction,
+      logIndex,
       etherSwapValues: etherSwapValues(),
     };
   };
 
-  const erc20LockupPayload = async (): Promise<Events['erc20.lockup']> => {
+  const erc20LockupPayload = async (
+    logIndex: number = 0,
+  ): Promise<Events['erc20.lockup']> => {
     const transaction = await sendTransaction();
 
     return {
       version: 4n,
       transaction,
+      logIndex,
       erc20SwapValues: erc20SwapValues(),
     };
   };
@@ -202,6 +208,7 @@ describe('ConsolidatedEventHandler integration', () => {
 
     await consolidated.handleEvent('eth.lockup', {
       version: 4n,
+      logIndex: 0,
       transaction: { hash: null } as any,
       etherSwapValues: etherSwapValues(),
     } as Events['eth.lockup']);
@@ -210,6 +217,49 @@ describe('ConsolidatedEventHandler integration', () => {
     await mineAndNotify();
 
     expect(emitted).not.toHaveBeenCalled();
+
+    destroy();
+  });
+
+  test('queues lockup events of the same transaction with different log indices separately', async () => {
+    const { consolidated, mineAndNotify, destroy } = createConsolidated(2);
+
+    const emitted = jest.fn();
+    consolidated.on('eth.lockup', emitted);
+
+    const payload = await ethLockupPayload(1);
+    await consolidated.handleEvent('eth.lockup', payload);
+    await consolidated.handleEvent('eth.lockup', {
+      ...payload,
+      logIndex: 2,
+    });
+
+    await mineAndNotify();
+
+    expect(emitted).toHaveBeenCalledTimes(2);
+    expect(emitted).toHaveBeenCalledWith(
+      expect.objectContaining({ logIndex: 1 }),
+    );
+    expect(emitted).toHaveBeenCalledWith(
+      expect.objectContaining({ logIndex: 2 }),
+    );
+
+    destroy();
+  });
+
+  test('deduplicates redeliveries of the same lockup log', async () => {
+    const { consolidated, mineAndNotify, destroy } = createConsolidated(2);
+
+    const emitted = jest.fn();
+    consolidated.on('eth.lockup', emitted);
+
+    const payload = await ethLockupPayload(1);
+    await consolidated.handleEvent('eth.lockup', payload);
+    await consolidated.handleEvent('eth.lockup', payload);
+
+    await mineAndNotify();
+
+    expect(emitted).toHaveBeenCalledTimes(1);
 
     destroy();
   });

--- a/test/integration/wallet/ethereum/contracts/ContractUtils.spec.ts
+++ b/test/integration/wallet/ethereum/contracts/ContractUtils.spec.ts
@@ -196,6 +196,92 @@ describe('ContractUtils', () => {
     });
   });
 
+  describe('multiple lockups in one transaction', () => {
+    const multiLockTransactionHash = '0xmulti';
+
+    const multiLockProvider = async (amounts: bigint[]) => {
+      const address = await etherSwap.getAddress();
+      const logs = amounts.map((amount, i) => {
+        const encoded = etherSwap.interface.encodeEventLog('Lockup', [
+          etherSwapValues.preimageHash,
+          amount,
+          etherSwapValues.claimAddress,
+          etherSwapValues.refundAddress,
+          etherSwapValues.timelock,
+        ]);
+        return {
+          address,
+          topics: encoded.topics,
+          data: encoded.data,
+          index: i + 1,
+        };
+      });
+
+      return {
+        getTransactionReceipt: async () => ({ logs }),
+      } as any;
+    };
+
+    beforeEach(() => {
+      getBySwapIdSpy.mockResolvedValue(null as any);
+    });
+
+    test('should resolve the exact lockup by logIndex', async () => {
+      const values = await queryEtherSwapValuesFromLock(
+        swap,
+        await multiLockProvider([1n, 999n]),
+        etherSwap,
+        multiLockTransactionHash,
+        true,
+        2,
+      );
+
+      expect(values.amount).toEqual(999n);
+    });
+
+    test('should fail closed without a logIndex when multiple lockups match the preimageHash', async () => {
+      await expect(
+        queryEtherSwapValuesFromLock(
+          swap,
+          await multiLockProvider([1n, 999n]),
+          etherSwap,
+          multiLockTransactionHash,
+          true,
+        ),
+      ).rejects.toEqual(
+        Errors.INVALID_LOCKUP_TRANSACTION(multiLockTransactionHash),
+      );
+    });
+
+    test('should fail closed when the logIndex is stale and multiple lockups match', async () => {
+      await expect(
+        queryEtherSwapValuesFromLock(
+          swap,
+          await multiLockProvider([1n, 999n]),
+          etherSwap,
+          multiLockTransactionHash,
+          true,
+          99,
+        ),
+      ).rejects.toEqual(
+        Errors.INVALID_LOCKUP_TRANSACTION(multiLockTransactionHash),
+      );
+    });
+
+    test('should fall back to a unique match when the logIndex is stale', async () => {
+      const values = await queryEtherSwapValuesFromLock(
+        swap,
+        await multiLockProvider([999n]),
+        etherSwap,
+        multiLockTransactionHash,
+        true,
+        99,
+      );
+
+      expect(values.amount).toEqual(999n);
+    });
+  });
+
   describe('with lockupHash identifier', () => {
     test('should query EtherSwap values by lockupHash', async () => {
       getBySwapIdSpy.mockResolvedValue({

--- a/test/integration/wallet/ethereum/contracts/ContractUtils.spec.ts
+++ b/test/integration/wallet/ethereum/contracts/ContractUtils.spec.ts
@@ -1,6 +1,7 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 import { randomBytes } from 'crypto';
 import { MaxUint256 } from 'ethers';
+import type Logger from '../../../../../lib/Logger';
 import type {
   AnySwap,
   ERC20SwapValues,
@@ -269,6 +270,8 @@ describe('ContractUtils', () => {
     });
 
     test('should fall back to a unique match when the logIndex is stale', async () => {
+      const logger = { warn: jest.fn() } as unknown as Logger;
+
       const values = await queryEtherSwapValuesFromLock(
         swap,
         await multiLockProvider([999n]),
@@ -276,9 +279,29 @@ describe('ContractUtils', () => {
         multiLockTransactionHash,
         true,
         99,
+        logger,
       );
 
       expect(values.amount).toEqual(999n);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Recorded log index 99'),
+      );
+    });
+
+    test('should not warn when the logIndex resolves', async () => {
+      const logger = { warn: jest.fn() } as unknown as Logger;
+
+      await queryEtherSwapValuesFromLock(
+        swap,
+        await multiLockProvider([1n, 999n]),
+        etherSwap,
+        multiLockTransactionHash,
+        true,
+        2,
+        logger,
+      );
+
+      expect(logger.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/db/LockupIdentity.spec.ts
+++ b/test/unit/db/LockupIdentity.spec.ts
@@ -1,0 +1,354 @@
+import { SwapUpdateEvent } from '../../../lib/consts/Enums';
+import type { LockupTargetStatus } from '../../../lib/db/LockupIdentity';
+import {
+  LockupWriteOutcome,
+  canTakeOverLockup,
+  decideLockupWrite,
+  isSameLockup,
+  shouldWriteZeroConfRejection,
+} from '../../../lib/db/LockupIdentity';
+
+describe('LockupIdentity', () => {
+  const owner = { transactionId: 'a'.repeat(64), vout: 1 };
+  const other = { transactionId: 'b'.repeat(64), vout: 0 };
+
+  describe('isSameLockup', () => {
+    test('should match identical lockups', () => {
+      expect(isSameLockup(owner, { ...owner })).toEqual(true);
+    });
+
+    test('should not match different transactions', () => {
+      expect(isSameLockup(owner, other)).toEqual(false);
+    });
+
+    test('should not match another vout of the same transaction', () => {
+      expect(
+        isSameLockup(owner, { transactionId: owner.transactionId, vout: 2 }),
+      ).toEqual(false);
+    });
+
+    test.each`
+      existingVout | incomingVout
+      ${null}      | ${2}
+      ${undefined} | ${2}
+      ${2}         | ${null}
+      ${2}         | ${undefined}
+      ${null}      | ${null}
+    `(
+      'should match when a vout is missing ($existingVout, $incomingVout)',
+      ({ existingVout, incomingVout }) => {
+        expect(
+          isSameLockup(
+            { transactionId: owner.transactionId, vout: existingVout },
+            { transactionId: owner.transactionId, vout: incomingVout },
+          ),
+        ).toEqual(true);
+      },
+    );
+  });
+
+  describe('canTakeOverLockup', () => {
+    test.each([
+      SwapUpdateEvent.TransactionLockupFailed,
+      SwapUpdateEvent.TransactionZeroConfRejected,
+    ])('should allow a takeover from %s', (status) => {
+      expect(canTakeOverLockup(status)).toEqual(true);
+    });
+
+    test.each([
+      SwapUpdateEvent.SwapCreated,
+      SwapUpdateEvent.InvoiceSet,
+      SwapUpdateEvent.TransactionMempool,
+      SwapUpdateEvent.TransactionConfirmed,
+      SwapUpdateEvent.InvoicePending,
+      SwapUpdateEvent.InvoicePaid,
+      SwapUpdateEvent.TransactionClaimPending,
+      SwapUpdateEvent.TransactionClaimed,
+      SwapUpdateEvent.SwapExpired,
+    ])('should not allow a takeover from %s', (status) => {
+      expect(canTakeOverLockup(status)).toEqual(false);
+    });
+  });
+
+  describe('decideLockupWrite', () => {
+    const decide = (params: Partial<Parameters<typeof decideLockupWrite>[0]>) =>
+      decideLockupWrite({
+        existing: null,
+        incoming: owner,
+        currentStatus: SwapUpdateEvent.SwapCreated,
+        targetStatus: SwapUpdateEvent.TransactionConfirmed,
+        updatable: true,
+        ...params,
+      } as Parameters<typeof decideLockupWrite>[0]);
+
+    describe('without a recorded lockup', () => {
+      test('should acquire the lockup', () => {
+        expect(decide({ existing: null })).toEqual({
+          outcome: LockupWriteOutcome.Acquired,
+          write: true,
+          vout: owner.vout,
+        });
+      });
+
+      test('should acquire a lockup without a vout', () => {
+        expect(
+          decide({
+            existing: null,
+            incoming: { transactionId: owner.transactionId },
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Acquired,
+          write: true,
+          vout: null,
+        });
+      });
+
+      test('should reject when the swap is not updatable', () => {
+        expect(decide({ existing: null, updatable: false })).toEqual({
+          outcome: LockupWriteOutcome.Rejected,
+          write: false,
+          vout: null,
+        });
+      });
+    });
+
+    describe('with the same lockup recorded', () => {
+      test('should write idempotently', () => {
+        expect(decide({ existing: owner, incoming: { ...owner } })).toEqual({
+          outcome: LockupWriteOutcome.Idempotent,
+          write: true,
+          vout: owner.vout,
+        });
+      });
+
+      test('should backfill a missing stored vout', () => {
+        expect(
+          decide({
+            existing: { transactionId: owner.transactionId, vout: null },
+            incoming: owner,
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Idempotent,
+          write: true,
+          vout: owner.vout,
+        });
+      });
+
+      test('should keep the stored vout when the incoming one is missing', () => {
+        expect(
+          decide({
+            existing: owner,
+            incoming: { transactionId: owner.transactionId },
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Idempotent,
+          write: true,
+          vout: owner.vout,
+        });
+      });
+
+      test('should resolve to no vout when neither side has one', () => {
+        expect(
+          decide({
+            existing: { transactionId: owner.transactionId, vout: null },
+            incoming: { transactionId: owner.transactionId },
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Idempotent,
+          write: true,
+          vout: null,
+        });
+      });
+
+      test('should not write when the swap is not updatable', () => {
+        expect(
+          decide({
+            existing: owner,
+            incoming: { ...owner },
+            updatable: false,
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Idempotent,
+          write: false,
+          vout: owner.vout,
+        });
+      });
+
+      test.each<LockupTargetStatus>([
+        SwapUpdateEvent.TransactionMempool,
+        SwapUpdateEvent.TransactionLockupFailed,
+      ])('should not downgrade a confirmed lockup to %s', (targetStatus) => {
+        expect(
+          decide({
+            existing: owner,
+            incoming: { ...owner },
+            currentStatus: SwapUpdateEvent.TransactionConfirmed,
+            targetStatus,
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Idempotent,
+          write: false,
+          vout: owner.vout,
+        });
+      });
+
+      test('should write a confirmation of a confirmed lockup', () => {
+        expect(
+          decide({
+            existing: owner,
+            incoming: { ...owner },
+            currentStatus: SwapUpdateEvent.TransactionConfirmed,
+            targetStatus: SwapUpdateEvent.TransactionConfirmed,
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Idempotent,
+          write: true,
+          vout: owner.vout,
+        });
+      });
+
+      test.each<LockupTargetStatus>([
+        SwapUpdateEvent.TransactionMempool,
+        SwapUpdateEvent.TransactionLockupFailed,
+      ])('should write %s for a lockup in the mempool', (targetStatus) => {
+        expect(
+          decide({
+            existing: owner,
+            incoming: { ...owner },
+            currentStatus: SwapUpdateEvent.TransactionMempool,
+            targetStatus,
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Idempotent,
+          write: true,
+          vout: owner.vout,
+        });
+      });
+    });
+
+    describe('with a competing lockup recorded', () => {
+      test.each([
+        SwapUpdateEvent.TransactionLockupFailed,
+        SwapUpdateEvent.TransactionZeroConfRejected,
+      ])('should take over from %s', (currentStatus) => {
+        expect(
+          decide({ existing: other, incoming: owner, currentStatus }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Acquired,
+          write: true,
+          vout: owner.vout,
+        });
+      });
+
+      test('should take over without a vout', () => {
+        expect(
+          decide({
+            existing: other,
+            incoming: { transactionId: owner.transactionId },
+            currentStatus: SwapUpdateEvent.TransactionZeroConfRejected,
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Acquired,
+          write: true,
+          vout: null,
+        });
+      });
+
+      test.each([
+        SwapUpdateEvent.SwapCreated,
+        SwapUpdateEvent.InvoiceSet,
+        SwapUpdateEvent.TransactionMempool,
+        SwapUpdateEvent.TransactionConfirmed,
+        SwapUpdateEvent.InvoicePending,
+        SwapUpdateEvent.TransactionClaimPending,
+        SwapUpdateEvent.TransactionClaimed,
+      ])('should reject a takeover from %s', (currentStatus) => {
+        expect(
+          decide({ existing: other, incoming: owner, currentStatus }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Rejected,
+          write: false,
+          vout: null,
+        });
+      });
+
+      test('should reject a takeover when the swap is not updatable', () => {
+        expect(
+          decide({
+            existing: other,
+            incoming: owner,
+            currentStatus: SwapUpdateEvent.TransactionLockupFailed,
+            updatable: false,
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Rejected,
+          write: false,
+          vout: null,
+        });
+      });
+
+      test('should treat another vout of the same transaction as competing', () => {
+        expect(
+          decide({
+            existing: owner,
+            incoming: { transactionId: owner.transactionId, vout: 2 },
+            currentStatus: SwapUpdateEvent.TransactionConfirmed,
+          }),
+        ).toEqual({
+          outcome: LockupWriteOutcome.Rejected,
+          write: false,
+          vout: null,
+        });
+      });
+    });
+  });
+
+  describe('shouldWriteZeroConfRejection', () => {
+    const check = (
+      params: Partial<Parameters<typeof shouldWriteZeroConfRejection>[0]>,
+    ) =>
+      shouldWriteZeroConfRejection({
+        existing: owner,
+        incoming: { ...owner },
+        currentStatus: SwapUpdateEvent.TransactionMempool,
+        ...params,
+      } as Parameters<typeof shouldWriteZeroConfRejection>[0]);
+
+    test('should write for the recorded lockup in the mempool', () => {
+      expect(check({})).toEqual(true);
+    });
+
+    test('should write when a vout is missing on either side', () => {
+      expect(
+        check({
+          existing: { transactionId: owner.transactionId, vout: null },
+        }),
+      ).toEqual(true);
+    });
+
+    test('should not write when no lockup is recorded', () => {
+      expect(check({ existing: null })).toEqual(false);
+    });
+
+    test('should not write for a competing transaction', () => {
+      expect(check({ incoming: other })).toEqual(false);
+    });
+
+    test('should not write for another vout of the same transaction', () => {
+      expect(
+        check({ incoming: { transactionId: owner.transactionId, vout: 2 } }),
+      ).toEqual(false);
+    });
+
+    test.each([
+      SwapUpdateEvent.SwapCreated,
+      SwapUpdateEvent.TransactionConfirmed,
+      SwapUpdateEvent.TransactionZeroConfRejected,
+      SwapUpdateEvent.TransactionLockupFailed,
+      SwapUpdateEvent.InvoicePending,
+      SwapUpdateEvent.TransactionClaimed,
+    ])('should not write in status %s', (currentStatus) => {
+      expect(check({ currentStatus })).toEqual(false);
+    });
+  });
+});

--- a/test/unit/swap/ArkNursery.spec.ts
+++ b/test/unit/swap/ArkNursery.spec.ts
@@ -670,6 +670,79 @@ describe('ArkNursery', () => {
       expect(lockupListener).not.toHaveBeenCalled();
       expect(failedListener).not.toHaveBeenCalled();
     });
+
+    test('should not act when the chain swap lockup write was rejected', async () => {
+      const chainSwap = {
+        id: 'chain',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.SwapCreated,
+        receivingData: {
+          symbol: 'ARK',
+          expectedAmount: 100000,
+        },
+      };
+
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(chainSwap);
+      // The swap was taken over between the guard and the write
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Rejected,
+          swap: chainSwap,
+        });
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('chainSwap.lockup', lockupListener);
+      nursery.on('chainSwap.lockup.failed', failedListener);
+
+      await nursery.checkChainSwapLockup(mockArkNode, {
+        address: 'ark_chain_address',
+        txId: 'lockup-tx',
+        vout: 0,
+        amount: 100000,
+      } as any);
+
+      expect(
+        ChainSwapRepository.setUserLockupTransaction,
+      ).toHaveBeenCalledTimes(1);
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
+    });
+
+    test('should not act when the submarine lockup write was rejected', async () => {
+      const swap = {
+        id: 'swap123',
+        type: SwapType.Submarine,
+        expectedAmount: 100000,
+        status: SwapUpdateEvent.SwapCreated,
+      };
+
+      SwapRepository.getSwap = jest.fn().mockResolvedValue(swap);
+      // The swap was taken over between the guard and the write
+      SwapRepository.setLockupTransaction = jest.fn().mockResolvedValue({
+        outcome: LockupWriteOutcome.Rejected,
+        swap,
+      });
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+      nursery.on('swap.lockup.failed', failedListener);
+
+      await nursery['checkSubmarineLockup'](mockArkNode, {
+        address: 'ark_address',
+        txId: 'lockup-tx',
+        vout: 0,
+        amount: 100000,
+      } as any);
+
+      expect(SwapRepository.setLockupTransaction).toHaveBeenCalledTimes(1);
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
+    });
   });
 
   describe('checkSubmarineLockup', () => {

--- a/test/unit/swap/ArkNursery.spec.ts
+++ b/test/unit/swap/ArkNursery.spec.ts
@@ -8,6 +8,7 @@ import {
   SwapType,
   SwapUpdateEvent,
 } from '../../../lib/consts/Enums';
+import { LockupWriteOutcome } from '../../../lib/db/LockupIdentity';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
 import ReverseSwapRepository from '../../../lib/db/repositories/ReverseSwapRepository';
 import SwapRepository from '../../../lib/db/repositories/SwapRepository';
@@ -411,9 +412,10 @@ describe('ArkNursery', () => {
       };
 
       SwapRepository.getSwap = jest.fn().mockResolvedValue(swap);
-      SwapRepository.setLockupTransaction = jest
-        .fn()
-        .mockResolvedValue(updatedSwap);
+      SwapRepository.setLockupTransaction = jest.fn().mockResolvedValue({
+        outcome: LockupWriteOutcome.Acquired,
+        swap: updatedSwap,
+      });
       ChainSwapRepository.getChainSwapByData = jest
         .fn()
         .mockResolvedValue(null);
@@ -479,7 +481,10 @@ describe('ArkNursery', () => {
         .mockResolvedValue(chainSwap);
       ChainSwapRepository.setUserLockupTransaction = jest
         .fn()
-        .mockResolvedValue(updatedChainSwap);
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: updatedChainSwap,
+        });
 
       let emittedEvent: any = null;
       nursery.once('chainSwap.lockup', (data) => {
@@ -588,6 +593,85 @@ describe('ArkNursery', () => {
     });
   });
 
+  describe('competing lockup guard', () => {
+    const mockArkNode = {
+      symbol: 'ARK',
+      subscription: {
+        unsubscribeAddress: jest.fn(),
+      },
+    } as unknown as ArkClient;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      nursery.removeAllListeners();
+    });
+
+    test('should ignore a competing chain swap lockup once confirmed', async () => {
+      const chainSwap = {
+        id: 'chain',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.TransactionConfirmed,
+        receivingData: {
+          symbol: 'ARK',
+          expectedAmount: 100000,
+          transactionId: 'already-recorded',
+        },
+      };
+
+      ChainSwapRepository.getChainSwapByData = jest
+        .fn()
+        .mockResolvedValue(chainSwap);
+      ChainSwapRepository.setUserLockupTransaction = jest.fn();
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('chainSwap.lockup', lockupListener);
+      nursery.on('chainSwap.lockup.failed', failedListener);
+
+      await nursery.checkChainSwapLockup(mockArkNode, {
+        address: 'ark_chain_address',
+        txId: 'different-tx',
+        vout: 0,
+        amount: 100000,
+      } as any);
+
+      expect(
+        ChainSwapRepository.setUserLockupTransaction,
+      ).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
+    });
+
+    test('should ignore a competing submarine lockup once confirmed', async () => {
+      const swap = {
+        id: 'swap123',
+        type: SwapType.Submarine,
+        expectedAmount: 100000,
+        lockupTransactionId: 'already-recorded',
+        status: SwapUpdateEvent.TransactionConfirmed,
+      };
+
+      SwapRepository.getSwap = jest.fn().mockResolvedValue(swap);
+      SwapRepository.setLockupTransaction = jest.fn();
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+      nursery.on('swap.lockup.failed', failedListener);
+
+      await nursery['checkSubmarineLockup'](mockArkNode, {
+        address: 'ark_address',
+        txId: 'different-tx',
+        vout: 0,
+        amount: 100000,
+      } as any);
+
+      expect(SwapRepository.setLockupTransaction).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
+    });
+  });
+
   describe('checkSubmarineLockup', () => {
     const mockArkNode = {
       symbol: 'ARK',
@@ -637,9 +721,10 @@ describe('ArkNursery', () => {
       };
 
       SwapRepository.getSwap = jest.fn().mockResolvedValue(swap);
-      SwapRepository.setLockupTransaction = jest
-        .fn()
-        .mockResolvedValue(updatedSwap);
+      SwapRepository.setLockupTransaction = jest.fn().mockResolvedValue({
+        outcome: LockupWriteOutcome.Acquired,
+        swap: updatedSwap,
+      });
 
       let emittedEvent: any = null;
       nursery.once('swap.lockup.failed', (data) => {
@@ -660,7 +745,7 @@ describe('ArkNursery', () => {
         swap,
         'txid',
         50000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
       );
       expect(emittedEvent).not.toBeNull();
@@ -684,9 +769,10 @@ describe('ArkNursery', () => {
       };
 
       SwapRepository.getSwap = jest.fn().mockResolvedValue(swap);
-      SwapRepository.setLockupTransaction = jest
-        .fn()
-        .mockResolvedValue(updatedSwap);
+      SwapRepository.setLockupTransaction = jest.fn().mockResolvedValue({
+        outcome: LockupWriteOutcome.Acquired,
+        swap: updatedSwap,
+      });
 
       const protector = new OverpaymentProtector(Logger.disabledLogger, {
         exemptAmount: 1000,
@@ -713,7 +799,7 @@ describe('ArkNursery', () => {
         swap,
         'txid',
         150000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
       );
       expect(emittedEvent).not.toBeNull();
@@ -736,9 +822,12 @@ describe('ArkNursery', () => {
       SwapRepository.setLockupTransaction = jest.fn().mockImplementation(() => {
         callOrder.push('setLockupTransaction');
         return Promise.resolve({
-          ...swap,
-          lockupTransactionId: 'txid',
-          onchainAmount: 50000,
+          outcome: LockupWriteOutcome.Acquired,
+          swap: {
+            ...swap,
+            lockupTransactionId: 'txid',
+            onchainAmount: 50000,
+          },
         });
       });
 
@@ -784,9 +873,10 @@ describe('ArkNursery', () => {
       };
 
       SwapRepository.getSwap = jest.fn().mockResolvedValue(swap);
-      SwapRepository.setLockupTransaction = jest
-        .fn()
-        .mockResolvedValue(updatedSwap);
+      SwapRepository.setLockupTransaction = jest.fn().mockResolvedValue({
+        outcome: LockupWriteOutcome.Acquired,
+        swap: updatedSwap,
+      });
 
       let emittedEvent: any = null;
       nursery.once('swap.lockup', (data) => {
@@ -807,7 +897,7 @@ describe('ArkNursery', () => {
         swap,
         'txid',
         100000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
       );
       expect(emittedEvent).not.toBeNull();
@@ -829,9 +919,10 @@ describe('ArkNursery', () => {
       };
 
       SwapRepository.getSwap = jest.fn().mockResolvedValue(swap);
-      SwapRepository.setLockupTransaction = jest
-        .fn()
-        .mockResolvedValue(updatedSwap);
+      SwapRepository.setLockupTransaction = jest.fn().mockResolvedValue({
+        outcome: LockupWriteOutcome.Acquired,
+        swap: updatedSwap,
+      });
 
       let emittedEvent: any = null;
       nursery.once('swap.lockup', (data) => {
@@ -914,7 +1005,10 @@ describe('ArkNursery', () => {
         .mockResolvedValue(swap);
       ChainSwapRepository.setUserLockupTransaction = jest
         .fn()
-        .mockResolvedValue(updatedSwap);
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: updatedSwap,
+        });
 
       let emittedEvent: any = null;
       nursery.once('chainSwap.lockup.failed', (data) => {
@@ -935,7 +1029,7 @@ describe('ArkNursery', () => {
         swap,
         'txid',
         50000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
         undefined,
       );
@@ -970,7 +1064,10 @@ describe('ArkNursery', () => {
         .mockResolvedValue(swap);
       ChainSwapRepository.setUserLockupTransaction = jest
         .fn()
-        .mockResolvedValue(updatedSwap);
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: updatedSwap,
+        });
 
       const protector = new OverpaymentProtector(Logger.disabledLogger, {
         exemptAmount: 1000,
@@ -997,7 +1094,7 @@ describe('ArkNursery', () => {
         swap,
         'txid',
         150000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
         undefined,
       );
@@ -1024,8 +1121,11 @@ describe('ArkNursery', () => {
       ChainSwapRepository.setUserLockupTransaction = jest
         .fn()
         .mockResolvedValue({
-          ...swap,
-          status: SwapUpdateEvent.TransactionLockupFailed,
+          outcome: LockupWriteOutcome.Idempotent,
+          swap: {
+            ...swap,
+            status: SwapUpdateEvent.TransactionLockupFailed,
+          },
         });
 
       const emitSpy = jest.spyOn(nursery, 'emit');
@@ -1041,7 +1141,7 @@ describe('ArkNursery', () => {
         swap,
         'txid',
         150000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
         undefined,
       );
@@ -1083,7 +1183,10 @@ describe('ArkNursery', () => {
         .mockResolvedValue(swap);
       ChainSwapRepository.setUserLockupTransaction = jest
         .fn()
-        .mockResolvedValue(updatedSwap);
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: updatedSwap,
+        });
 
       let emittedEvent: any = null;
       nursery.once('chainSwap.lockup', (data) => {
@@ -1105,7 +1208,7 @@ describe('ArkNursery', () => {
         swap,
         'txid',
         100000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
         { allowLockupFailedUpdate: true },
       );
@@ -1138,7 +1241,10 @@ describe('ArkNursery', () => {
         .mockResolvedValue(swap);
       ChainSwapRepository.setUserLockupTransaction = jest
         .fn()
-        .mockResolvedValue(updatedSwap);
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: updatedSwap,
+        });
 
       let emittedEvent: any = null;
       nursery.once('chainSwap.lockup', (data) => {
@@ -1159,7 +1265,7 @@ describe('ArkNursery', () => {
         swap,
         'txid',
         100000,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
         undefined,
       );

--- a/test/unit/swap/CompetingLockup.spec.ts
+++ b/test/unit/swap/CompetingLockup.spec.ts
@@ -1,0 +1,89 @@
+import { SwapUpdateEvent } from '../../../lib/consts/Enums';
+import { shouldIgnoreCompetingLockup } from '../../../lib/swap/CompetingLockup';
+
+describe('shouldIgnoreCompetingLockup', () => {
+  const base = {
+    prevId: 'a'.repeat(64),
+    incomingId: 'b'.repeat(64),
+    recordedStatus: SwapUpdateEvent.TransactionMempool,
+  };
+
+  test('should proceed when no lockup is recorded yet', () => {
+    expect(shouldIgnoreCompetingLockup({ ...base, prevId: undefined })).toEqual(
+      false,
+    );
+    expect(shouldIgnoreCompetingLockup({ ...base, prevId: null })).toEqual(
+      false,
+    );
+  });
+
+  test('should proceed for the same transaction and vout', () => {
+    expect(
+      shouldIgnoreCompetingLockup({
+        ...base,
+        incomingId: base.prevId,
+        prevVout: 5,
+        incomingVout: 5,
+      }),
+    ).toEqual(false);
+  });
+
+  test('should treat another vout of the same transaction as competing', () => {
+    expect(
+      shouldIgnoreCompetingLockup({
+        ...base,
+        incomingId: base.prevId,
+        prevVout: 5,
+        incomingVout: 7,
+      }),
+    ).toEqual(true);
+  });
+
+  test('should treat a missing vout on either side as the same lockup', () => {
+    expect(
+      shouldIgnoreCompetingLockup({
+        ...base,
+        incomingId: base.prevId,
+        prevVout: null,
+        incomingVout: 7,
+      }),
+    ).toEqual(false);
+    expect(
+      shouldIgnoreCompetingLockup({
+        ...base,
+        incomingId: base.prevId,
+        prevVout: 5,
+        incomingVout: undefined,
+      }),
+    ).toEqual(false);
+  });
+
+  test.each([
+    SwapUpdateEvent.TransactionLockupFailed,
+    SwapUpdateEvent.TransactionZeroConfRejected,
+  ])('should allow takeover from explicitly rejected status %s', (status) => {
+    expect(
+      shouldIgnoreCompetingLockup({
+        ...base,
+        recordedStatus: status,
+      }),
+    ).toEqual(false);
+  });
+
+  test.each([
+    SwapUpdateEvent.SwapCreated,
+    SwapUpdateEvent.InvoiceSet,
+    SwapUpdateEvent.TransactionMempool,
+    SwapUpdateEvent.TransactionConfirmed,
+    SwapUpdateEvent.InvoicePending,
+    SwapUpdateEvent.TransactionClaimPending,
+    SwapUpdateEvent.TransactionClaimed,
+  ])('should protect a recorded owner in status %s', (status) => {
+    expect(
+      shouldIgnoreCompetingLockup({
+        ...base,
+        recordedStatus: status,
+      }),
+    ).toEqual(true);
+  });
+});

--- a/test/unit/swap/EthereumNursery.spec.ts
+++ b/test/unit/swap/EthereumNursery.spec.ts
@@ -14,6 +14,7 @@ import type {
   ERC20SwapValues,
   EtherSwapValues,
 } from '../../../lib/consts/Types';
+import { LockupWriteOutcome } from '../../../lib/db/LockupIdentity';
 import type Swap from '../../../lib/db/models/Swap';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
 import ClaimTransactionRepository from '../../../lib/db/repositories/ClaimTransactionRepository';
@@ -41,10 +42,12 @@ type claimCallback = (args: {
 
 type ethLockupCallback = (args: {
   transaction: any;
+  logIndex: number;
   etherSwapValues: EtherSwapValues;
 }) => void;
 type erc20LockupCallback = (args: {
   transaction: any;
+  logIndex: number;
   erc20SwapValues: ERC20SwapValues;
 }) => void;
 
@@ -179,9 +182,12 @@ const mockSetLockupTransaction = jest
   .mockImplementation(
     async (swap: Swap, lockupTransactionId: string, onchainAmount: number) => {
       return {
-        ...swap,
-        onchainAmount,
-        lockupTransactionId,
+        outcome: LockupWriteOutcome.Acquired,
+        swap: {
+          ...swap,
+          onchainAmount,
+          lockupTransactionId,
+        },
       };
     },
   );
@@ -412,6 +418,115 @@ describe('EthereumNursery', () => {
     expect(scanSpy).toHaveBeenCalledTimes(2);
   });
 
+  test('should ignore a competing EtherSwap lockup once one is recorded', async () => {
+    const swap = {
+      pair: 'ETH/BTC',
+      type: SwapType.Submarine,
+      orderSide: OrderSide.SELL,
+      expectedAmount: 10,
+      timeoutBlockHeight: 11102219,
+      lockupTransactionId: 'already-recorded',
+      status: SwapUpdateEvent.TransactionConfirmed,
+    } as any;
+
+    const suppliedEtherSwapValues = {
+      claimAddress: mockAddress,
+      refundAddress: mockAddress,
+      amount: BigInt('100000000000'),
+      preimageHash: getHexString(examplePreimageHash),
+      timelock: swap.timeoutBlockHeight,
+    } as any;
+
+    const lockupListener = jest.fn();
+    const failedListener = jest.fn();
+    nursery.on('eth.lockup', lockupListener);
+    nursery.on('lockup.failed', failedListener);
+
+    await nursery.checkEtherSwapLockup(
+      swap,
+      exampleTransaction,
+      suppliedEtherSwapValues,
+      0,
+    );
+
+    expect(mockSetLockupTransaction).not.toHaveBeenCalled();
+    expect(lockupListener).not.toHaveBeenCalled();
+    expect(failedListener).not.toHaveBeenCalled();
+  });
+
+  test('should emit nothing when the EtherSwap lockup write is rejected', async () => {
+    const swap = {
+      pair: 'ETH/BTC',
+      type: SwapType.Submarine,
+      orderSide: OrderSide.SELL,
+      expectedAmount: 10,
+      timeoutBlockHeight: 11102219,
+    } as any;
+
+    mockSetLockupTransaction.mockResolvedValueOnce({
+      outcome: LockupWriteOutcome.Rejected,
+      swap: { ...swap, lockupTransactionId: 'other-owner' },
+    });
+
+    const emitSpy = jest.spyOn(nursery, 'emit');
+
+    await nursery.checkEtherSwapLockup(
+      swap,
+      exampleTransaction,
+      {
+        claimAddress: mockAddress,
+        refundAddress: mockAddress,
+        amount: BigInt('100000000000'),
+        preimageHash: getHexString(examplePreimageHash),
+        timelock: swap.timeoutBlockHeight,
+      } as any,
+      0,
+    );
+
+    expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
+    expect(emitSpy).not.toHaveBeenCalled();
+
+    emitSpy.mockRestore();
+  });
+
+  test('should emit nothing when the ERC20Swap chain lockup write is rejected', async () => {
+    const chainSwap = {
+      id: 'chain-erc20-rejected',
+      type: SwapType.Chain,
+      receivingData: {
+        symbol: 'USDT',
+        expectedAmount: 10,
+        timeoutBlockHeight: 11102222,
+      },
+    };
+
+    const setUserLockupTransaction = jest.fn().mockResolvedValue({
+      outcome: LockupWriteOutcome.Rejected,
+      swap: chainSwap,
+    });
+    ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
+
+    const emitSpy = jest.spyOn(nursery, 'emit');
+
+    await nursery.checkErc20SwapLockup(
+      chainSwap as any,
+      exampleTransaction as any,
+      {
+        amount: BigInt('1000'),
+        claimAddress: mockAddress,
+        tokenAddress: mockTokenAddress,
+        timelock: chainSwap.receivingData.timeoutBlockHeight,
+        preimageHash: getHexString(examplePreimageHash),
+      } as any,
+      0,
+    );
+
+    expect(setUserLockupTransaction).toHaveBeenCalledTimes(1);
+    expect(emitSpy).not.toHaveBeenCalled();
+
+    emitSpy.mockRestore();
+  });
+
   test('should listen for EtherSwap lockup events', async () => {
     ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
 
@@ -443,6 +558,7 @@ describe('EthereumNursery', () => {
 
     await emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues: suppliedEtherSwapValues,
     });
 
@@ -459,7 +575,8 @@ describe('EthereumNursery', () => {
       mockGetSwapResult,
       exampleTransaction.hash,
       10,
-      true,
+      SwapUpdateEvent.TransactionConfirmed,
+      21,
     );
 
     expect(mockSetRefundAddress).toHaveBeenCalledTimes(1);
@@ -498,6 +615,7 @@ describe('EthereumNursery', () => {
 
     await emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues: suppliedEtherSwapValues,
     });
 
@@ -523,6 +641,7 @@ describe('EthereumNursery', () => {
 
     await emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues: suppliedEtherSwapValues,
     });
 
@@ -545,6 +664,7 @@ describe('EthereumNursery', () => {
 
     await emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues: suppliedEtherSwapValues,
     });
 
@@ -579,6 +699,7 @@ describe('EthereumNursery', () => {
 
     await emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues: suppliedEtherSwapValues,
     });
 
@@ -593,6 +714,7 @@ describe('EthereumNursery', () => {
 
     await emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues: suppliedEtherSwapValues,
     });
 
@@ -624,6 +746,7 @@ describe('EthereumNursery', () => {
 
     emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues: {
         claimAddress: mockAddress,
         refundAddress: mockAddress,
@@ -674,6 +797,7 @@ describe('EthereumNursery', () => {
 
     emitEthLockup({
       transaction: { ...exampleTransaction },
+      logIndex: 21,
       etherSwapValues: {
         amount: sentAmount,
         claimAddress: mockAddress,
@@ -713,6 +837,7 @@ describe('EthereumNursery', () => {
 
     await emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues,
     });
 
@@ -728,6 +853,7 @@ describe('EthereumNursery', () => {
 
     await emitEthLockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       etherSwapValues,
     });
 
@@ -884,6 +1010,43 @@ describe('EthereumNursery', () => {
     });
   });
 
+  test('should ignore a competing ERC20Swap lockup once one is recorded', async () => {
+    const swap = {
+      pair: 'BTC/USDT',
+      type: SwapType.Submarine,
+      orderSide: OrderSide.BUY,
+      expectedAmount: 10,
+      timeoutBlockHeight: 11102222,
+      lockupTransactionId: 'already-recorded',
+      status: SwapUpdateEvent.TransactionConfirmed,
+    } as any;
+
+    const suppliedERC20SwapValues = {
+      amount: BigInt('1000'),
+      claimAddress: mockAddress,
+      refundAddress: mockAddress,
+      tokenAddress: mockTokenAddress,
+      timelock: swap.timeoutBlockHeight,
+      preimageHash: getHexString(examplePreimageHash),
+    } as any;
+
+    const lockupListener = jest.fn();
+    const failedListener = jest.fn();
+    nursery.on('erc20.lockup', lockupListener);
+    nursery.on('lockup.failed', failedListener);
+
+    await nursery.checkErc20SwapLockup(
+      swap,
+      exampleTransaction,
+      suppliedERC20SwapValues,
+      0,
+    );
+
+    expect(mockSetLockupTransaction).not.toHaveBeenCalled();
+    expect(lockupListener).not.toHaveBeenCalled();
+    expect(failedListener).not.toHaveBeenCalled();
+  });
+
   test('should listen for ERC20Swap lockup events', async () => {
     let lockupEmitted = false;
     let lockupFailed = 0;
@@ -914,6 +1077,7 @@ describe('EthereumNursery', () => {
 
     await emitErc20Lockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       erc20SwapValues: suppliedERC20SwapValues,
     });
 
@@ -935,7 +1099,8 @@ describe('EthereumNursery', () => {
       mockGetSwapResult,
       exampleTransaction.hash,
       10,
-      true,
+      SwapUpdateEvent.TransactionConfirmed,
+      21,
     );
 
     expect(mockSetRefundAddress).toHaveBeenCalledTimes(1);
@@ -979,6 +1144,7 @@ describe('EthereumNursery', () => {
 
     await emitErc20Lockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       erc20SwapValues: suppliedERC20SwapValues,
     });
 
@@ -1004,6 +1170,7 @@ describe('EthereumNursery', () => {
 
     await emitErc20Lockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       erc20SwapValues: suppliedERC20SwapValues,
     });
 
@@ -1029,6 +1196,7 @@ describe('EthereumNursery', () => {
 
     await emitErc20Lockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       erc20SwapValues: suppliedERC20SwapValues,
     });
 
@@ -1051,6 +1219,7 @@ describe('EthereumNursery', () => {
 
     await emitErc20Lockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       erc20SwapValues: suppliedERC20SwapValues,
     });
 
@@ -1087,6 +1256,7 @@ describe('EthereumNursery', () => {
 
     await emitErc20Lockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       erc20SwapValues: suppliedERC20SwapValues,
     });
 
@@ -1101,6 +1271,7 @@ describe('EthereumNursery', () => {
 
     await emitErc20Lockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       erc20SwapValues: suppliedERC20SwapValues,
     });
 
@@ -1132,6 +1303,7 @@ describe('EthereumNursery', () => {
 
     emitErc20Lockup({
       transaction: exampleTransaction,
+      logIndex: 21,
       erc20SwapValues: {
         claimAddress: mockAddress,
         refundAddress: mockAddress,
@@ -1183,6 +1355,7 @@ describe('EthereumNursery', () => {
 
     emitErc20Lockup({
       transaction: { ...exampleTransaction },
+      logIndex: 21,
       erc20SwapValues: {
         amount: sentAmount,
         claimAddress: mockAddress,
@@ -1208,8 +1381,11 @@ describe('EthereumNursery', () => {
     };
 
     const setUserLockupTransaction = jest.fn().mockResolvedValue({
-      ...chainSwap,
-      status: SwapUpdateEvent.TransactionLockupFailed,
+      outcome: LockupWriteOutcome.Acquired,
+      swap: {
+        ...chainSwap,
+        status: SwapUpdateEvent.TransactionLockupFailed,
+      },
     });
     ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
 
@@ -1224,14 +1400,15 @@ describe('EthereumNursery', () => {
         preimageHash: getHexString(examplePreimageHash),
         timelock: chainSwap.receivingData.timeoutBlockHeight,
       } as any,
+      0,
     );
 
     expect(setUserLockupTransaction).toHaveBeenCalledWith(
       chainSwap,
       exampleTransaction.hash,
       10,
-      true,
-      undefined,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
       undefined,
     );
     expect(emitSpy).not.toHaveBeenCalledWith('eth.lockup', expect.anything());
@@ -1259,7 +1436,10 @@ describe('EthereumNursery', () => {
       status: SwapUpdateEvent.TransactionConfirmed,
     };
 
-    const setUserLockupTransaction = jest.fn().mockResolvedValue(updatedSwap);
+    const setUserLockupTransaction = jest.fn().mockResolvedValue({
+      outcome: LockupWriteOutcome.Acquired,
+      swap: updatedSwap,
+    });
     ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
 
     const lockupPromise = new Promise<void>((resolve) => {
@@ -1279,6 +1459,7 @@ describe('EthereumNursery', () => {
         preimageHash: getHexString(examplePreimageHash),
         timelock: chainSwap.receivingData.timeoutBlockHeight,
       } as any,
+      0,
       { allowLockupFailedUpdate: true },
     );
 
@@ -1286,8 +1467,8 @@ describe('EthereumNursery', () => {
       chainSwap,
       exampleTransaction.hash,
       10,
-      true,
-      undefined,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
       { allowLockupFailedUpdate: true },
     );
     await lockupPromise;
@@ -1306,10 +1487,13 @@ describe('EthereumNursery', () => {
 
     const updatedSwap = {
       ...chainSwap,
-      status: SwapUpdateEvent.TransactionConfirmed,
+      status: SwapUpdateEvent.TransactionLockupFailed,
     };
 
-    const setUserLockupTransaction = jest.fn().mockResolvedValue(updatedSwap);
+    const setUserLockupTransaction = jest.fn().mockResolvedValue({
+      outcome: LockupWriteOutcome.Acquired,
+      swap: updatedSwap,
+    });
     ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
 
     const emitSpy = jest.spyOn(nursery, 'emit');
@@ -1323,14 +1507,15 @@ describe('EthereumNursery', () => {
         preimageHash: getHexString(examplePreimageHash),
         timelock: chainSwap.receivingData.timeoutBlockHeight,
       } as any,
+      0,
     );
 
     expect(setUserLockupTransaction).toHaveBeenCalledWith(
       chainSwap,
       exampleTransaction.hash,
       9,
-      true,
-      undefined,
+      SwapUpdateEvent.TransactionLockupFailed,
+      0,
       undefined,
     );
     expect(emitSpy).toHaveBeenCalledWith('lockup.failed', {
@@ -1366,10 +1551,13 @@ describe('EthereumNursery', () => {
     };
     const updatedSwap = {
       ...chainSwap,
-      status: SwapUpdateEvent.TransactionConfirmed,
+      status: SwapUpdateEvent.TransactionLockupFailed,
     };
 
-    const setUserLockupTransaction = jest.fn().mockResolvedValue(updatedSwap);
+    const setUserLockupTransaction = jest.fn().mockResolvedValue({
+      outcome: LockupWriteOutcome.Acquired,
+      swap: updatedSwap,
+    });
     ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
 
     const emitSpy = jest.spyOn(nursery, 'emit');
@@ -1379,8 +1567,8 @@ describe('EthereumNursery', () => {
       chainSwap,
       exampleTransaction.hash,
       10,
-      true,
-      undefined,
+      SwapUpdateEvent.TransactionLockupFailed,
+      0,
       undefined,
     );
     expect(emitSpy).toHaveBeenCalledWith('lockup.failed', {
@@ -1399,13 +1587,18 @@ describe('EthereumNursery', () => {
       lockupEvent: 'eth.lockup',
       timeoutBlockHeight: 11102219,
       checkLockup: (chainSwap) =>
-        nursery.checkEtherSwapLockup(chainSwap as any, exampleTransaction, {
-          claimAddress: mockAddress,
-          refundAddress: mockAddress,
-          amount: 10n * etherDecimals,
-          preimageHash: examplePreimageHash,
-          timelock: chainSwap.receivingData.timeoutBlockHeight,
-        }),
+        nursery.checkEtherSwapLockup(
+          chainSwap as any,
+          exampleTransaction,
+          {
+            claimAddress: mockAddress,
+            refundAddress: mockAddress,
+            amount: 10n * etherDecimals,
+            preimageHash: examplePreimageHash,
+            timelock: chainSwap.receivingData.timeoutBlockHeight,
+          },
+          0,
+        ),
     });
   });
 
@@ -1421,8 +1614,11 @@ describe('EthereumNursery', () => {
     };
 
     const setUserLockupTransaction = jest.fn().mockResolvedValue({
-      ...chainSwap,
-      status: SwapUpdateEvent.TransactionLockupFailed,
+      outcome: LockupWriteOutcome.Acquired,
+      swap: {
+        ...chainSwap,
+        status: SwapUpdateEvent.TransactionLockupFailed,
+      },
     });
     ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
 
@@ -1438,14 +1634,15 @@ describe('EthereumNursery', () => {
         timelock: chainSwap.receivingData.timeoutBlockHeight,
         preimageHash: getHexString(examplePreimageHash),
       } as any,
+      0,
     );
 
     expect(setUserLockupTransaction).toHaveBeenCalledWith(
       chainSwap,
       exampleTransaction.hash,
       10,
-      true,
-      undefined,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
       undefined,
     );
     expect(emitSpy).not.toHaveBeenCalledWith('erc20.lockup', expect.anything());
@@ -1473,7 +1670,10 @@ describe('EthereumNursery', () => {
       status: SwapUpdateEvent.TransactionConfirmed,
     };
 
-    const setUserLockupTransaction = jest.fn().mockResolvedValue(updatedSwap);
+    const setUserLockupTransaction = jest.fn().mockResolvedValue({
+      outcome: LockupWriteOutcome.Acquired,
+      swap: updatedSwap,
+    });
     ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
 
     const lockupPromise = new Promise<void>((resolve) => {
@@ -1494,6 +1694,7 @@ describe('EthereumNursery', () => {
         timelock: chainSwap.receivingData.timeoutBlockHeight,
         preimageHash: getHexString(examplePreimageHash),
       } as any,
+      0,
       { allowLockupFailedUpdate: true },
     );
 
@@ -1501,8 +1702,8 @@ describe('EthereumNursery', () => {
       chainSwap,
       exampleTransaction.hash,
       10,
-      true,
-      undefined,
+      SwapUpdateEvent.TransactionConfirmed,
+      0,
       { allowLockupFailedUpdate: true },
     );
     await lockupPromise;
@@ -1521,10 +1722,13 @@ describe('EthereumNursery', () => {
 
     const updatedSwap = {
       ...chainSwap,
-      status: SwapUpdateEvent.TransactionConfirmed,
+      status: SwapUpdateEvent.TransactionLockupFailed,
     };
 
-    const setUserLockupTransaction = jest.fn().mockResolvedValue(updatedSwap);
+    const setUserLockupTransaction = jest.fn().mockResolvedValue({
+      outcome: LockupWriteOutcome.Acquired,
+      swap: updatedSwap,
+    });
     ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
 
     const emitSpy = jest.spyOn(nursery, 'emit');
@@ -1539,14 +1743,15 @@ describe('EthereumNursery', () => {
         timelock: chainSwap.receivingData.timeoutBlockHeight,
         preimageHash: getHexString(examplePreimageHash),
       } as any,
+      0,
     );
 
     expect(setUserLockupTransaction).toHaveBeenCalledWith(
       chainSwap,
       exampleTransaction.hash,
       9,
-      true,
-      undefined,
+      SwapUpdateEvent.TransactionLockupFailed,
+      0,
       undefined,
     );
     expect(emitSpy).toHaveBeenCalledWith('lockup.failed', {
@@ -1565,14 +1770,19 @@ describe('EthereumNursery', () => {
       lockupEvent: 'erc20.lockup',
       timeoutBlockHeight: 11102222,
       checkLockup: (chainSwap) =>
-        nursery.checkErc20SwapLockup(chainSwap as any, exampleTransaction, {
-          amount: BigInt('1000'),
-          claimAddress: mockAddress,
-          refundAddress: mockAddress,
-          tokenAddress: mockTokenAddress,
-          timelock: chainSwap.receivingData.timeoutBlockHeight,
-          preimageHash: examplePreimageHash,
-        }),
+        nursery.checkErc20SwapLockup(
+          chainSwap as any,
+          exampleTransaction,
+          {
+            amount: BigInt('1000'),
+            claimAddress: mockAddress,
+            refundAddress: mockAddress,
+            tokenAddress: mockTokenAddress,
+            timelock: chainSwap.receivingData.timeoutBlockHeight,
+            preimageHash: examplePreimageHash,
+          },
+          0,
+        ),
     });
   });
 

--- a/test/unit/swap/EthereumNursery.spec.ts
+++ b/test/unit/swap/EthereumNursery.spec.ts
@@ -182,11 +182,17 @@ const mockGetSwapsExpirable = jest.fn().mockImplementation(async () => {
 const mockSetLockupTransaction = jest
   .fn()
   .mockImplementation(
-    async (swap: Swap, lockupTransactionId: string, onchainAmount: number) => {
+    async (
+      swap: Swap,
+      lockupTransactionId: string,
+      onchainAmount: number,
+      status: SwapUpdateEvent,
+    ) => {
       return {
         outcome: LockupWriteOutcome.Acquired,
         swap: {
           ...swap,
+          status,
           onchainAmount,
           lockupTransactionId,
         },
@@ -529,6 +535,165 @@ describe('EthereumNursery', () => {
     emitSpy.mockRestore();
   });
 
+  describe('lockup failure emission', () => {
+    // Already has a refund address set to keep "setRefundAddress" out of the
+    // way of the emitted swap
+    const swap = {
+      id: 'lockupFailureEmission',
+      pair: 'ETH/BTC',
+      type: SwapType.Submarine,
+      orderSide: OrderSide.SELL,
+      expectedAmount: 10,
+      timeoutBlockHeight: 11102219,
+      refundAddress: mockRefundAddress,
+    } as any;
+
+    // Locks up 9 when 10 is expected, to always fail the validation
+    const etherSwapValues = {
+      claimAddress: mockAddress,
+      refundAddress: mockRefundAddress,
+      amount: BigInt('99999999999'),
+      preimageHash: getHexString(examplePreimageHash),
+      timelock: swap.timeoutBlockHeight,
+    } as any;
+
+    test.each`
+      status                                     | outcome                          | failureReason           | emits    | description
+      ${SwapUpdateEvent.TransactionConfirmed}    | ${LockupWriteOutcome.Idempotent} | ${undefined}            | ${false} | ${'not emit when the write to downgrade a confirmed lockup was refused'}
+      ${SwapUpdateEvent.InvoicePaid}             | ${LockupWriteOutcome.Idempotent} | ${undefined}            | ${false} | ${'not emit when the write was refused because the swap advanced already'}
+      ${SwapUpdateEvent.TransactionClaimed}      | ${LockupWriteOutcome.Idempotent} | ${undefined}            | ${false} | ${'not emit when the write was refused because the swap was claimed already'}
+      ${SwapUpdateEvent.TransactionLockupFailed} | ${LockupWriteOutcome.Idempotent} | ${undefined}            | ${true}  | ${'emit when the failure was written but no reason was recorded yet'}
+      ${SwapUpdateEvent.TransactionLockupFailed} | ${LockupWriteOutcome.Idempotent} | ${'recorded already'}   | ${false} | ${'not emit again when the reason was recorded already'}
+      ${SwapUpdateEvent.TransactionLockupFailed} | ${LockupWriteOutcome.Acquired}   | ${'of the prior owner'} | ${true}  | ${'emit when a new lockup acquired the swap'}
+      ${SwapUpdateEvent.TransactionLockupFailed} | ${LockupWriteOutcome.Acquired}   | ${undefined}            | ${true}  | ${'emit when the first lockup of the swap failed'}
+    `(
+      'should $description',
+      async ({ status, outcome, failureReason, emits }) => {
+        const writtenSwap = { ...swap, status, failureReason };
+        mockSetLockupTransaction.mockResolvedValueOnce({
+          outcome,
+          swap: writtenSwap,
+        });
+
+        const failedListener = jest.fn();
+        const lockupListener = jest.fn();
+        nursery.on('lockup.failed', failedListener);
+        nursery.on('eth.lockup', lockupListener);
+
+        await nursery.checkEtherSwapLockup(
+          swap,
+          exampleTransaction,
+          etherSwapValues,
+          0,
+        );
+
+        // The write is always attempted; only announcing it is guarded
+        expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
+        expect(mockSetLockupTransaction).toHaveBeenCalledWith(
+          swap,
+          exampleTransaction.hash,
+          9,
+          SwapUpdateEvent.TransactionLockupFailed,
+          0,
+        );
+        expect(mockSetRefundAddress).not.toHaveBeenCalled();
+        expect(lockupListener).not.toHaveBeenCalled();
+
+        if (emits) {
+          expect(failedListener).toHaveBeenCalledTimes(1);
+          expect(failedListener).toHaveBeenCalledWith({
+            swap: writtenSwap,
+            reason: Errors.INSUFFICIENT_AMOUNT(9, 10).message,
+          });
+        } else {
+          expect(failedListener).not.toHaveBeenCalled();
+        }
+      },
+    );
+
+    test('should not emit a refused ERC20Swap lockup failure either', async () => {
+      const erc20Swap = {
+        id: 'lockupFailureEmissionErc20',
+        pair: 'BTC/USDT',
+        type: SwapType.Submarine,
+        orderSide: OrderSide.BUY,
+        expectedAmount: 10,
+        timeoutBlockHeight: 11102222,
+        refundAddress: mockRefundAddress,
+      } as any;
+
+      mockSetLockupTransaction.mockResolvedValueOnce({
+        outcome: LockupWriteOutcome.Idempotent,
+        swap: { ...erc20Swap, status: SwapUpdateEvent.TransactionConfirmed },
+      });
+
+      const emitSpy = jest.spyOn(nursery, 'emit');
+
+      await nursery.checkErc20SwapLockup(
+        erc20Swap,
+        exampleTransaction as any,
+        {
+          amount: BigInt('900'),
+          claimAddress: mockAddress,
+          refundAddress: mockRefundAddress,
+          tokenAddress: mockTokenAddress,
+          timelock: erc20Swap.timeoutBlockHeight,
+          preimageHash: getHexString(examplePreimageHash),
+        } as any,
+        0,
+      );
+
+      expect(mockSetLockupTransaction).toHaveBeenCalledWith(
+        erc20Swap,
+        exampleTransaction.hash,
+        9,
+        SwapUpdateEvent.TransactionLockupFailed,
+        0,
+      );
+      expect(emitSpy).not.toHaveBeenCalled();
+
+      emitSpy.mockRestore();
+    });
+
+    test('should not emit a refused chain swap lockup failure either', async () => {
+      const chainSwap = {
+        id: 'lockupFailureEmissionChain',
+        type: SwapType.Chain,
+        receivingData: {
+          symbol: 'ETH',
+          expectedAmount: 10,
+          timeoutBlockHeight: 11102219,
+        },
+      };
+
+      const setUserLockupTransaction = jest.fn().mockResolvedValue({
+        outcome: LockupWriteOutcome.Idempotent,
+        swap: { ...chainSwap, status: SwapUpdateEvent.TransactionConfirmed },
+      });
+      ChainSwapRepository.setUserLockupTransaction = setUserLockupTransaction;
+
+      const emitSpy = jest.spyOn(nursery, 'emit');
+
+      await nursery.checkEtherSwapLockup(
+        chainSwap as any,
+        exampleTransaction as any,
+        {
+          claimAddress: mockAddress,
+          refundAddress: mockRefundAddress,
+          amount: BigInt('99999999999'),
+          preimageHash: getHexString(examplePreimageHash),
+          timelock: chainSwap.receivingData.timeoutBlockHeight,
+        } as any,
+        0,
+      );
+
+      expect(setUserLockupTransaction).toHaveBeenCalledTimes(1);
+      expect(emitSpy).not.toHaveBeenCalled();
+
+      emitSpy.mockRestore();
+    });
+  });
+
   test('should listen for EtherSwap lockup events', async () => {
     ChainSwapRepository.getChainSwap = jest.fn().mockResolvedValue(null);
 
@@ -585,6 +750,7 @@ describe('EthereumNursery', () => {
     expect(mockSetRefundAddress).toHaveBeenCalledWith(
       {
         ...mockGetSwapResult,
+        status: SwapUpdateEvent.TransactionConfirmed,
         onchainAmount: 10,
         lockupTransactionId: exampleTransaction.hash,
       },
@@ -864,6 +1030,7 @@ describe('EthereumNursery', () => {
     expect(mockSetRefundAddress).toHaveBeenCalledWith(
       {
         ...mockGetSwapResult,
+        status: SwapUpdateEvent.TransactionConfirmed,
         onchainAmount: 10,
         lockupTransactionId: exampleTransaction.hash,
       },
@@ -1103,6 +1270,7 @@ describe('EthereumNursery', () => {
     expect(mockSetRefundAddress).toHaveBeenCalledWith(
       {
         ...mockGetSwapResult,
+        status: SwapUpdateEvent.TransactionConfirmed,
         onchainAmount: 10,
         lockupTransactionId: exampleTransaction.hash,
       },
@@ -1170,6 +1338,7 @@ describe('EthereumNursery', () => {
     expect(mockSetRefundAddress).toHaveBeenCalledWith(
       {
         ...mockGetSwapResult,
+        status: SwapUpdateEvent.TransactionConfirmed,
         onchainAmount: 10,
         lockupTransactionId: exampleTransaction.hash,
       },

--- a/test/unit/swap/EthereumNursery.spec.ts
+++ b/test/unit/swap/EthereumNursery.spec.ts
@@ -139,6 +139,8 @@ const mockOnContractEventHandler = jest
   });
 
 const mockAddress = '0x735Ec659CB2E2D2B778F8D4178ce2a521D617119';
+// Has to differ from the claim address to catch the two being mixed up
+const mockRefundAddress = '0x9F8C2A1b3D4e5f60718293A4b5c6d7e8F9a0b1c2';
 let mockHasSymbolSymbols = [networks.Ethereum.symbol, 'USDT'];
 const mockHasSymbol = jest
   .fn()
@@ -543,7 +545,7 @@ describe('EthereumNursery', () => {
 
     const suppliedEtherSwapValues = {
       claimAddress: mockAddress,
-      refundAddress: mockAddress,
+      refundAddress: mockRefundAddress,
       amount: BigInt('100000000000'),
       preimageHash: getHexString(examplePreimageHash),
       timelock: mockGetSwapResult.timeoutBlockHeight,
@@ -824,7 +826,7 @@ describe('EthereumNursery', () => {
 
     const etherSwapValues = {
       claimAddress: mockAddress,
-      refundAddress: mockAddress,
+      refundAddress: mockRefundAddress,
       amount: BigInt('99999999999'),
       preimageHash: getHexString(examplePreimageHash),
       timelock: mockGetSwapResult.timeoutBlockHeight,
@@ -1024,7 +1026,7 @@ describe('EthereumNursery', () => {
     const suppliedERC20SwapValues = {
       amount: BigInt('1000'),
       claimAddress: mockAddress,
-      refundAddress: mockAddress,
+      refundAddress: mockRefundAddress,
       tokenAddress: mockTokenAddress,
       timelock: swap.timeoutBlockHeight,
       preimageHash: getHexString(examplePreimageHash),
@@ -1047,6 +1049,67 @@ describe('EthereumNursery', () => {
     expect(failedListener).not.toHaveBeenCalled();
   });
 
+  test('should only overwrite an already set ERC20 refund address on valid lockups', async () => {
+    const existingRefundAddress = '0x6981698B1275eD7727B7F5C3C54d9FE4d8ffEd5E';
+
+    mockGetSwapResult = {
+      pair: 'BTC/USDT',
+      expectedAmount: 10,
+      type: SwapType.Submarine,
+      orderSide: OrderSide.BUY,
+      timeoutBlockHeight: 11102222,
+      refundAddress: existingRefundAddress,
+    };
+
+    const suppliedERC20SwapValues = {
+      amount: BigInt('1000'),
+      claimAddress: mockAddress,
+      refundAddress: mockRefundAddress,
+      tokenAddress: mockTokenAddress,
+      timelock: mockGetSwapResult.timeoutBlockHeight,
+      preimageHash: getHexString(examplePreimageHash),
+    } as any;
+
+    let lockupFailed = 0;
+    nursery.once('lockup.failed', () => {
+      lockupFailed += 1;
+    });
+
+    suppliedERC20SwapValues.claimAddress = 'not-us';
+    await emitErc20Lockup({
+      transaction: exampleTransaction,
+      logIndex: 21,
+      erc20SwapValues: suppliedERC20SwapValues,
+    });
+
+    expect(lockupFailed).toEqual(1);
+    expect(mockSetRefundAddress).not.toHaveBeenCalled();
+
+    suppliedERC20SwapValues.claimAddress = mockAddress;
+
+    let lockupEmitted = false;
+    nursery.once('erc20.lockup', () => {
+      lockupEmitted = true;
+    });
+
+    await emitErc20Lockup({
+      transaction: exampleTransaction,
+      logIndex: 21,
+      erc20SwapValues: suppliedERC20SwapValues,
+    });
+
+    expect(lockupEmitted).toEqual(true);
+    expect(mockSetRefundAddress).toHaveBeenCalledTimes(1);
+    expect(mockSetRefundAddress).toHaveBeenCalledWith(
+      {
+        ...mockGetSwapResult,
+        onchainAmount: 10,
+        lockupTransactionId: exampleTransaction.hash,
+      },
+      suppliedERC20SwapValues.refundAddress,
+    );
+  });
+
   test('should listen for ERC20Swap lockup events', async () => {
     let lockupEmitted = false;
     let lockupFailed = 0;
@@ -1062,7 +1125,7 @@ describe('EthereumNursery', () => {
     const suppliedERC20SwapValues = {
       amount: BigInt('1000'),
       claimAddress: mockAddress,
-      refundAddress: mockAddress,
+      refundAddress: mockRefundAddress,
       tokenAddress: mockTokenAddress,
       timelock: mockGetSwapResult.timeoutBlockHeight,
       preimageHash: getHexString(examplePreimageHash),

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -1518,6 +1518,7 @@ describe('SwapNursery', () => {
         },
         receivingData: {
           transactionId: 'chain-lockup-transaction',
+          transactionVout: 0,
         },
       } as unknown as ChainSwapInfo;
 
@@ -1552,6 +1553,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
         swap: baseMockChainSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockChainSwap.receivingData.transactionVout!,
         confirmed: true,
       });
 
@@ -1584,6 +1586,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
         swap: baseMockChainSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockChainSwap.receivingData.transactionVout!,
         confirmed: true,
       });
       await eventPromise;
@@ -1602,6 +1605,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
         swap: baseMockChainSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockChainSwap.receivingData.transactionVout!,
         confirmed: true,
       });
 
@@ -1626,6 +1630,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
         swap: baseMockChainSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockChainSwap.receivingData.transactionVout!,
         confirmed: true,
       });
 
@@ -1658,6 +1663,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
         swap: baseMockChainSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockChainSwap.receivingData.transactionVout!,
         confirmed: true,
       });
 
@@ -1684,19 +1690,52 @@ describe('SwapNursery', () => {
         ...baseMockChainSwap,
         receivingData: {
           transactionId: 'other-lockup-transaction',
+          transactionVout: 0,
         },
       };
 
       (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
         swap: baseMockChainSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockChainSwap.receivingData.transactionVout!,
         confirmed: true,
       });
 
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('because other-lockup-transaction owns it'),
+        expect.stringContaining('because other-lockup-transaction:'),
+      );
+      expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'transaction',
+        expect.anything(),
+      );
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        baseMockChainSwap.id,
+      );
+    });
+
+    test('should not lock up when another output of the event transaction owns the swap', async () => {
+      mockGetChainSwapResult = {
+        ...baseMockChainSwap,
+        receivingData: {
+          transactionId: 'chain-lockup-transaction',
+          transactionVout: 1,
+        },
+      };
+
+      (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
+        swap: baseMockChainSwap,
+        transaction: mockTransaction,
+        lockupTransactionVout: 0,
+        confirmed: true,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('because chain-lockup-transaction:1 owns it'),
       );
       expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
       expect(swapNursery.emit).not.toHaveBeenCalledWith(
@@ -1722,6 +1761,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
         swap: baseMockChainSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockChainSwap.receivingData.transactionVout!,
         confirmed: true,
       });
       await new Promise((resolve) => setImmediate(resolve));
@@ -1763,6 +1803,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
         swap: baseMockChainSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockChainSwap.receivingData.transactionVout!,
         confirmed: true,
       });
       await new Promise((resolve) => setImmediate(resolve));
@@ -1881,10 +1922,11 @@ describe('SwapNursery', () => {
       await listeners['eth.lockup']({
         swap: chainSwap,
         transactionHash: '0xevent',
+        logIndex: 3,
       });
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('because 0xother-owner owns it'),
+        expect.stringContaining('because 0xother-owner:'),
       );
       expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
       expect(swapNursery.emit).not.toHaveBeenCalledWith(
@@ -2010,6 +2052,7 @@ describe('SwapNursery', () => {
         invoice: 'lnbcrt1',
         createdRefundSignature: false,
         lockupTransactionId: '0xsubmarine',
+        lockupTransactionVout: 2,
       } as unknown as Swap;
       mockGetSwapResult = submarineSwap;
       (swapNursery as any).sendApprovalHook = { hook: jest.fn() };
@@ -2021,6 +2064,7 @@ describe('SwapNursery', () => {
       await listeners['eth.lockup']({
         swap: submarineSwap,
         transactionHash: '0xsubmarine',
+        logIndex: 2,
       });
 
       expect(ChainSwapRepository.getChainSwap).not.toHaveBeenCalled();
@@ -2050,6 +2094,7 @@ describe('SwapNursery', () => {
         invoice: 'lnbcrt1',
         createdRefundSignature: false,
         lockupTransactionId: '0xother-owner',
+        lockupTransactionVout: 2,
       } as unknown as Swap;
       mockGetSwapResult = submarineSwap;
       const attemptSettleSwapSpy = jest
@@ -2061,8 +2106,58 @@ describe('SwapNursery', () => {
       await listeners['eth.lockup']({
         swap: submarineSwap,
         transactionHash: '0xsubmarine',
+        logIndex: 2,
       });
 
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('because 0xother-owner:2 owns it'),
+      );
+      expect(attemptSettleSwapSpy).not.toHaveBeenCalled();
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        'transaction',
+        expect.anything(),
+      );
+
+      emitSpy.mockRestore();
+    });
+
+    test('should not pay when another log of the event transaction owns the swap', async () => {
+      const listeners: Record<string, (...args: any[]) => Promise<void>> = {};
+      const ethereumNursery = {
+        on: jest.fn(
+          (event: string, callback: (...args: any[]) => Promise<void>) => {
+            listeners[event] = callback;
+          },
+        ),
+        init: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const submarineSwap = {
+        id: 'submarine-swap-id',
+        pair: 'BTC/BTC',
+        type: SwapType.Submarine,
+        orderSide: OrderSide.BUY,
+        invoice: 'lnbcrt1',
+        createdRefundSignature: false,
+        lockupTransactionId: '0xsubmarine',
+        lockupTransactionVout: 3,
+      } as unknown as Swap;
+      mockGetSwapResult = submarineSwap;
+      const attemptSettleSwapSpy = jest
+        .spyOn(swapNursery, 'attemptSettleSwap')
+        .mockResolvedValue(undefined);
+      const emitSpy = jest.spyOn(swapNursery, 'emit');
+
+      await (swapNursery as any).listenEthereumNursery(ethereumNursery);
+      await listeners['eth.lockup']({
+        swap: submarineSwap,
+        transactionHash: '0xsubmarine',
+        logIndex: 1,
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('because 0xsubmarine:3 owns it'),
+      );
       expect(attemptSettleSwapSpy).not.toHaveBeenCalled();
       expect(emitSpy).not.toHaveBeenCalledWith(
         'transaction',
@@ -2131,6 +2226,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
         confirmed: true,
       });
 
@@ -2170,6 +2266,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('swap.lockup', {
         swap: swapWithoutInvoice,
         transaction: mockTransaction,
+        lockupTransactionVout: swapWithoutInvoice.lockupTransactionVout,
         confirmed: true,
       });
 
@@ -2190,6 +2287,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
         confirmed: true,
       });
 
@@ -2217,6 +2315,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
         confirmed: false,
       });
 
@@ -2243,6 +2342,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
         confirmed: true,
       });
 
@@ -2270,6 +2370,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
         confirmed: true,
       });
 
@@ -2304,6 +2405,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).utxoNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         transaction: mockTransaction,
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
         confirmed: true,
       });
 
@@ -2429,6 +2531,8 @@ describe('SwapNursery', () => {
         createdRefundSignature: false,
         invoice: 'lnbc123...',
         status: SwapUpdateEvent.TransactionConfirmed,
+        lockupTransactionId: 'ark-lockup-id',
+        lockupTransactionVout: 1,
       };
 
       mockPayInvoice = jest
@@ -2469,6 +2573,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).arkNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         lockupTransactionId: 'ark-lockup-id',
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
       });
 
       await eventPromise;
@@ -2495,6 +2600,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).arkNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         lockupTransactionId: 'ark-lockup-id',
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
       });
 
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -2523,6 +2629,7 @@ describe('SwapNursery', () => {
       (swapNursery as any).arkNursery.emit('swap.lockup', {
         swap: baseMockSwap,
         lockupTransactionId: 'ark-lockup-id',
+        lockupTransactionVout: baseMockSwap.lockupTransactionVout,
       });
 
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -2541,6 +2648,39 @@ describe('SwapNursery', () => {
         expect.anything(),
       );
     });
+
+    test.each`
+      name                | fetched
+      ${'transaction id'} | ${{ lockupTransactionId: 'other-lockup-id' }}
+      ${'vout'}           | ${{ lockupTransactionVout: 2 }}
+    `(
+      'should not act when the recorded $name no longer matches the event',
+      async ({ fetched }) => {
+        mockGetSwapResult = {
+          ...baseMockSwap,
+          ...fetched,
+        };
+
+        (swapNursery as any).arkNursery.emit('swap.lockup', {
+          swap: baseMockSwap,
+          lockupTransactionId: 'ark-lockup-id',
+          lockupTransactionVout: baseMockSwap.lockupTransactionVout,
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('owns it'),
+        );
+        expect(mockPayInvoice).not.toHaveBeenCalled();
+        expect(mockClaimVtxo).not.toHaveBeenCalled();
+        expect(mockSetSwapRate).not.toHaveBeenCalled();
+        expect(swapNursery.emit).not.toHaveBeenCalledWith(
+          'transaction',
+          expect.anything(),
+        );
+      },
+    );
   });
 
   describe('server.lockup.confirmed', () => {

--- a/test/unit/swap/SwapNursery.spec.ts
+++ b/test/unit/swap/SwapNursery.spec.ts
@@ -1516,9 +1516,14 @@ describe('SwapNursery', () => {
           expectedAmount: 100_000,
           symbol: 'BTC',
         },
+        receivingData: {
+          transactionId: 'chain-lockup-transaction',
+        },
       } as unknown as ChainSwapInfo;
 
-      mockTransaction = {};
+      mockTransaction = {
+        getId: jest.fn().mockReturnValue('chain-lockup-transaction'),
+      };
 
       mockHandleChainSwapLockup = jest
         .spyOn(swapNursery as any, 'handleChainSwapLockup')
@@ -1674,6 +1679,35 @@ describe('SwapNursery', () => {
       );
     });
 
+    test('should not lock up when the recorded lockup does not match the event transaction', async () => {
+      mockGetChainSwapResult = {
+        ...baseMockChainSwap,
+        receivingData: {
+          transactionId: 'other-lockup-transaction',
+        },
+      };
+
+      (swapNursery as any).utxoNursery.emit('chainSwap.lockup', {
+        swap: baseMockChainSwap,
+        transaction: mockTransaction,
+        confirmed: true,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('because other-lockup-transaction owns it'),
+      );
+      expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'transaction',
+        expect.anything(),
+      );
+      expect(SendApprovalHoldRepository.remove).toHaveBeenCalledWith(
+        baseMockChainSwap.id,
+      );
+    });
+
     test('should not lock up when the chain swap becomes final while approval is pending', async () => {
       mockGetChainSwapResult = baseMockChainSwap;
       let resolveApproval!: (action: SendApprovalAction) => void;
@@ -1812,6 +1846,53 @@ describe('SwapNursery', () => {
       );
     });
 
+    test('should not lock up the chain swap when the recorded lockup does not match the event transaction', async () => {
+      const listeners: Record<string, (...args: any[]) => Promise<void>> = {};
+      const ethereumNursery = {
+        on: jest.fn(
+          (event: string, callback: (...args: any[]) => Promise<void>) => {
+            listeners[event] = callback;
+          },
+        ),
+        init: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const chainSwap = {
+        id: 'test-chain-swap-id',
+        pair: 'BTC/BTC',
+        type: SwapType.Chain,
+        status: SwapUpdateEvent.SwapCreated,
+        sendingData: {
+          transactionId: null,
+          expectedAmount: 100_000,
+          symbol: 'BTC',
+        },
+        receivingData: {
+          transactionId: '0xother-owner',
+        },
+      } as unknown as ChainSwapInfo;
+      mockGetChainSwapResult = chainSwap;
+      const mockHandleChainSwapLockup = jest
+        .spyOn(swapNursery as any, 'handleChainSwapLockup')
+        .mockResolvedValue(undefined);
+      jest.spyOn(swapNursery, 'emit');
+
+      await (swapNursery as any).listenEthereumNursery(ethereumNursery);
+      await listeners['eth.lockup']({
+        swap: chainSwap,
+        transactionHash: '0xevent',
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('because 0xother-owner owns it'),
+      );
+      expect(mockHandleChainSwapLockup).not.toHaveBeenCalled();
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'transaction',
+        expect.anything(),
+      );
+    });
+
     test('should thread the resolved approval into the chain lockup', async () => {
       const listeners: Record<string, (...args: any[]) => Promise<void>> = {};
       const ethereumNursery = {
@@ -1832,6 +1913,9 @@ describe('SwapNursery', () => {
           transactionId: null,
           expectedAmount: 100_000,
           symbol: 'BTC',
+        },
+        receivingData: {
+          transactionId: '0xaccept',
         },
       } as unknown as ChainSwapInfo;
       mockGetChainSwapResult = chainSwap;
@@ -1882,6 +1966,9 @@ describe('SwapNursery', () => {
           expectedAmount: 100_000,
           symbol: 'BTC',
         },
+        receivingData: {
+          transactionId: '0xhold',
+        },
       } as unknown as ChainSwapInfo;
       mockGetChainSwapResult = chainSwap;
       (swapNursery as any).sendApprovalHook = {
@@ -1922,6 +2009,7 @@ describe('SwapNursery', () => {
         orderSide: OrderSide.BUY,
         invoice: 'lnbcrt1',
         createdRefundSignature: false,
+        lockupTransactionId: '0xsubmarine',
       } as unknown as Swap;
       mockGetSwapResult = submarineSwap;
       (swapNursery as any).sendApprovalHook = { hook: jest.fn() };
@@ -1942,6 +2030,47 @@ describe('SwapNursery', () => {
         submarineSwap,
       );
     });
+
+    test('should not pay when the recorded lockup does not match the event transaction', async () => {
+      const listeners: Record<string, (...args: any[]) => Promise<void>> = {};
+      const ethereumNursery = {
+        on: jest.fn(
+          (event: string, callback: (...args: any[]) => Promise<void>) => {
+            listeners[event] = callback;
+          },
+        ),
+        init: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const submarineSwap = {
+        id: 'submarine-swap-id',
+        pair: 'BTC/BTC',
+        type: SwapType.Submarine,
+        orderSide: OrderSide.BUY,
+        invoice: 'lnbcrt1',
+        createdRefundSignature: false,
+        lockupTransactionId: '0xother-owner',
+      } as unknown as Swap;
+      mockGetSwapResult = submarineSwap;
+      const attemptSettleSwapSpy = jest
+        .spyOn(swapNursery, 'attemptSettleSwap')
+        .mockResolvedValue(undefined);
+      const emitSpy = jest.spyOn(swapNursery, 'emit');
+
+      await (swapNursery as any).listenEthereumNursery(ethereumNursery);
+      await listeners['eth.lockup']({
+        swap: submarineSwap,
+        transactionHash: '0xsubmarine',
+      });
+
+      expect(attemptSettleSwapSpy).not.toHaveBeenCalled();
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        'transaction',
+        expect.anything(),
+      );
+
+      emitSpy.mockRestore();
+    });
   });
 
   describe('swap.lockup', () => {
@@ -1959,9 +2088,13 @@ describe('SwapNursery', () => {
         orderSide: OrderSide.BUY,
         createdRefundSignature: false,
         invoice: 'lnbc123...',
+        lockupTransactionId: 'event-owner',
+        lockupTransactionVout: 0,
       };
 
-      mockTransaction = {};
+      mockTransaction = {
+        getId: jest.fn().mockReturnValue('event-owner'),
+      };
 
       mockPayInvoice = jest
         .spyOn(swapNursery as any, 'payInvoice')
@@ -2074,6 +2207,33 @@ describe('SwapNursery', () => {
       );
     });
 
+    test('should not act when the event transaction no longer owns the swap', async () => {
+      mockGetSwapResult = {
+        ...baseMockSwap,
+        lockupTransactionId: 'different-owner',
+        lockupTransactionVout: 1,
+      };
+
+      (swapNursery as any).utxoNursery.emit('swap.lockup', {
+        swap: baseMockSwap,
+        transaction: mockTransaction,
+        confirmed: false,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('different-owner:1 owns it'),
+      );
+      expect(mockPayInvoice).not.toHaveBeenCalled();
+      expect(mockClaimUtxo).not.toHaveBeenCalled();
+      expect(mockSetSwapRate).not.toHaveBeenCalled();
+      expect(swapNursery.emit).not.toHaveBeenCalledWith(
+        'transaction',
+        expect.anything(),
+      );
+    });
+
     test('should prevent invoice payment when createdRefundSignature is true', async () => {
       mockGetSwapResult = {
         ...baseMockSwap,
@@ -2150,6 +2310,105 @@ describe('SwapNursery', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(mockPayInvoice).toHaveBeenCalled();
+    });
+  });
+
+  describe('zeroconf rejected', () => {
+    let mockTransaction: any;
+
+    beforeEach(async () => {
+      mockTransaction = {
+        getId: jest.fn().mockReturnValue('rejected-lockup'),
+      };
+
+      jest.spyOn(swapNursery, 'emit');
+
+      await swapNursery.init([mockCurrency]);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('should re-emit swap zero-conf rejections without writing the status', async () => {
+      const mockSwap = {
+        id: 'zeroconf-swap',
+        type: SwapType.Submarine,
+        invoice: 'lnbc123...',
+        lockupTransactionId: 'rejected-lockup',
+        lockupTransactionVout: 0,
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      } as any;
+
+      (swapNursery as any).utxoNursery.emit('swap.lockup.zeroconf.rejected', {
+        swap: mockSwap,
+        transaction: mockTransaction,
+        reason: 'greedy fees',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(swapNursery.emit).toHaveBeenCalledWith('zeroconf.rejected', {
+        transaction: mockTransaction,
+        swap: mockSwap,
+      });
+      expect(SwapRepository.setSwapStatus).not.toHaveBeenCalled();
+    });
+
+    test('should set the swap rate for rejected swaps without an invoice', async () => {
+      const mockSetSwapRate = jest
+        .spyOn(swapNursery as any, 'setSwapRate')
+        .mockResolvedValue(undefined);
+
+      const mockSwap = {
+        id: 'zeroconf-swap-no-invoice',
+        type: SwapType.Submarine,
+        invoice: null,
+        lockupTransactionId: 'rejected-lockup',
+        lockupTransactionVout: 0,
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      } as any;
+
+      (swapNursery as any).utxoNursery.emit('swap.lockup.zeroconf.rejected', {
+        swap: mockSwap,
+        transaction: mockTransaction,
+        reason: 'greedy fees',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockSetSwapRate).toHaveBeenCalledWith(mockSwap);
+      expect(swapNursery.emit).toHaveBeenCalledWith('zeroconf.rejected', {
+        transaction: mockTransaction,
+        swap: mockSwap,
+      });
+      expect(SwapRepository.setSwapStatus).not.toHaveBeenCalled();
+    });
+
+    test('should re-emit chain swap zero-conf rejections without writing the status', async () => {
+      const mockChainSwap = {
+        type: SwapType.Chain,
+        chainSwap: { id: 'zeroconf-chain-swap' },
+        receivingData: { transactionVout: 0 },
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      } as any;
+
+      (swapNursery as any).utxoNursery.emit(
+        'chainSwap.lockup.zeroconf.rejected',
+        {
+          swap: mockChainSwap,
+          transaction: mockTransaction,
+          reason: 'greedy fees',
+        },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(swapNursery.emit).toHaveBeenCalledWith('zeroconf.rejected', {
+        transaction: mockTransaction,
+        swap: mockChainSwap,
+      });
+      expect(WrappedSwapRepository.setStatus).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/swap/UtxoNursery.spec.ts
+++ b/test/unit/swap/UtxoNursery.spec.ts
@@ -31,6 +31,7 @@ import {
   SwapUpdateEvent,
   SwapVersion,
 } from '../../../lib/consts/Enums';
+import { LockupWriteOutcome } from '../../../lib/db/LockupIdentity';
 import ChainSwapRepository from '../../../lib/db/repositories/ChainSwapRepository';
 import ClaimTransactionRepository from '../../../lib/db/repositories/ClaimTransactionRepository';
 import RefundTransactionRepository from '../../../lib/db/repositories/RefundTransactionRepository';
@@ -188,9 +189,15 @@ const mockGetSwapsExpirable = jest.fn().mockImplementation(async () => {
   return mockGetSwapsExpirableResult;
 });
 
-const mockSetLockupTransaction = jest
-  .fn()
-  .mockImplementation(async (arg) => arg);
+const mockSetLockupTransaction = jest.fn().mockImplementation(async (arg) => ({
+  outcome: LockupWriteOutcome.Acquired,
+  swap: arg,
+}));
+
+const mockSetZeroConfRejected = jest.fn().mockImplementation(async (arg) => ({
+  ...arg,
+  status: SwapUpdateEvent.TransactionZeroConfRejected,
+}));
 
 let mockGetReverseSwapResult: any = null;
 const mockGetReverseSwap = jest.fn().mockImplementation(async () => {
@@ -250,6 +257,7 @@ describe('UtxoNursery', () => {
     SwapRepository.getSwap = mockGetSwap;
     SwapRepository.getSwapsExpirable = mockGetSwapsExpirable;
     SwapRepository.setLockupTransaction = mockSetLockupTransaction;
+    SwapRepository.setZeroConfRejected = mockSetZeroConfRejected;
 
     ReverseSwapRepository.getReverseSwap = mockGetReverseSwap;
     ReverseSwapRepository.getReverseSwaps = mockGetReverseSwaps;
@@ -344,7 +352,7 @@ describe('UtxoNursery', () => {
       mockGetSwapResult,
       transaction.id,
       Number(transaction.getOutput(0).amount),
-      true,
+      SwapUpdateEvent.TransactionConfirmed,
       0,
     );
 
@@ -455,8 +463,11 @@ describe('UtxoNursery', () => {
         ),
       };
       mockSetLockupTransaction.mockResolvedValueOnce({
-        ...mockGetSwapResult,
-        status,
+        outcome: LockupWriteOutcome.Idempotent,
+        swap: {
+          ...mockGetSwapResult,
+          status,
+        },
       });
 
       const lockupListener = jest.fn();
@@ -473,6 +484,547 @@ describe('UtxoNursery', () => {
       expect(lockupListener).not.toHaveBeenCalled();
     },
   );
+
+  describe('competing lockup guard', () => {
+    const submarineSwap = (overrides: Record<string, any>) => {
+      const transaction = parseTx(sampleTransactions.lockup);
+      mockGetSwapResult = {
+        id: 'competing',
+        type: SwapType.Submarine,
+        redeemScript: sampleRedeemScript,
+        lockupAddress: encodeAddress(
+          Buffer.from(transaction.getOutput(0).script!),
+        ),
+        ...overrides,
+      };
+    };
+
+    test('should ignore a competing lockup once the recorded lockup is confirmed', async () => {
+      const checkSwapOutputs = nursery['checkOutputs'];
+      const transaction = parseTx(sampleTransactions.lockup);
+
+      submarineSwap({
+        expectedAmount: Number(transaction.getOutput(0).amount),
+        lockupTransactionId: 'already-recorded',
+        status: SwapUpdateEvent.TransactionConfirmed,
+      });
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+      nursery.on('swap.lockup.failed', failedListener);
+
+      await checkSwapOutputs(
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(mockSetLockupTransaction).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
+    });
+
+    test('should ignore an insufficient competing lockup while unconfirmed', async () => {
+      const checkSwapOutputs = nursery['checkOutputs'];
+      const transaction = parseTx(sampleTransactions.lockup);
+
+      submarineSwap({
+        expectedAmount: Number(transaction.getOutput(0).amount) + 1,
+        lockupTransactionId: 'already-recorded',
+        status: SwapUpdateEvent.TransactionMempool,
+      });
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+      nursery.on('swap.lockup.failed', failedListener);
+
+      await checkSwapOutputs(
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(mockSetLockupTransaction).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
+    });
+
+    test('should ignore a sufficient replacement while the recorded lockup is unconfirmed', async () => {
+      const checkSwapOutputs = nursery['checkOutputs'];
+      const transaction = parseTx(sampleTransactions.lockup);
+
+      submarineSwap({
+        expectedAmount: Number(transaction.getOutput(0).amount),
+        lockupTransactionId: 'to-be-replaced',
+        status: SwapUpdateEvent.TransactionMempool,
+      });
+
+      const lockupListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+
+      await checkSwapOutputs(
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(mockSetLockupTransaction).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+    });
+
+    test('should accept a replacement after the recorded lockup was rejected for zero-conf', async () => {
+      const checkSwapOutputs = nursery['checkOutputs'];
+      const transaction = parseTx(sampleTransactions.lockup);
+
+      submarineSwap({
+        expectedAmount: Number(transaction.getOutput(0).amount),
+        lockupTransactionId: 'rejected-lockup',
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      });
+
+      const lockupListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+
+      await checkSwapOutputs(
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
+      expect(lockupListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('should accept the same lockup transaction transitioning to confirmed', async () => {
+      const checkSwapOutputs = nursery['checkOutputs'];
+      const transaction = parseTx(sampleTransactions.lockup);
+
+      submarineSwap({
+        expectedAmount: Number(transaction.getOutput(0).amount),
+        lockupTransactionId: transaction.id,
+        status: SwapUpdateEvent.TransactionMempool,
+      });
+
+      const lockupListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+
+      await checkSwapOutputs(
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
+      expect(lockupListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('should still fail a first insufficient lockup', async () => {
+      const checkSwapOutputs = nursery['checkOutputs'];
+      const transaction = parseTx(sampleTransactions.lockup);
+
+      submarineSwap({
+        expectedAmount: Number(transaction.getOutput(0).amount) + 1,
+        lockupTransactionId: undefined,
+        status: SwapUpdateEvent.SwapCreated,
+      });
+
+      const failedListener = jest.fn();
+      nursery.on('swap.lockup.failed', failedListener);
+
+      await checkSwapOutputs(
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
+      expect(failedListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('should ignore a competing lockup when the amount is not known yet', async () => {
+      const checkSwapOutputs = nursery['checkOutputs'];
+      const transaction = parseTx(sampleTransactions.lockup);
+
+      submarineSwap({
+        expectedAmount: undefined,
+        lockupTransactionId: 'already-recorded',
+        status: SwapUpdateEvent.TransactionMempool,
+      });
+
+      const lockupListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+
+      await checkSwapOutputs(
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(mockSetLockupTransaction).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+    });
+
+    const chainLockupTransaction = () => {
+      const ourKeys = makeKeys();
+      const theirPublicKey = Buffer.from(makeKeys().publicKey);
+      const tree = swapTree(
+        false,
+        randomBytes(32),
+        Buffer.from(ourKeys.publicKey),
+        theirPublicKey,
+        210,
+      );
+
+      const transaction = new Transaction();
+      transaction.addOutput({
+        script: Buffer.from(
+          Scripts.p2trOutput(
+            Buffer.from(
+              tweakMusig(
+                CurrencyType.BitcoinLike,
+                createMusig(ourKeys, theirPublicKey),
+                tree,
+              ).aggPubkey,
+            ),
+          ),
+        ),
+        amount: BigInt(123),
+      });
+
+      mockGetKeysByIndexResult = ourKeys;
+
+      return { transaction, theirPublicKey, tree };
+    };
+
+    const chainSwap = (
+      transaction: ReturnType<typeof chainLockupTransaction>,
+      receivingData: Record<string, any>,
+      status?: SwapUpdateEvent,
+    ) => ({
+      id: 'testChainSwap',
+      type: SwapType.Chain,
+      status,
+      receivingData: {
+        keyIndex: 123,
+        theirPublicKey: transaction.theirPublicKey.toString('hex'),
+        swapTree: JSON.stringify(
+          SwapTreeSerializer.serializeSwapTree(transaction.tree),
+        ),
+        ...receivingData,
+      },
+    });
+
+    test('should ignore a competing chain swap lockup once confirmed', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+      const tx = chainLockupTransaction();
+      const mockChainSwap = chainSwap(
+        tx,
+        { expectedAmount: 123, transactionId: 'already-recorded' },
+        SwapUpdateEvent.TransactionConfirmed,
+      );
+
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: mockChainSwap,
+        });
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(123);
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('chainSwap.lockup', lockupListener);
+      nursery.on('chainSwap.lockup.failed', failedListener);
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        tx.transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(
+        ChainSwapRepository.setUserLockupTransaction,
+      ).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
+
+      getOutputValueSpy.mockRestore();
+    });
+
+    test('should ignore a sufficient chain swap replacement while unconfirmed', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+      const tx = chainLockupTransaction();
+      const mockChainSwap = chainSwap(
+        tx,
+        { expectedAmount: 123, transactionId: 'to-be-replaced' },
+        SwapUpdateEvent.TransactionMempool,
+      );
+
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: mockChainSwap,
+        });
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(123);
+
+      const lockupListener = jest.fn();
+      nursery.on('chainSwap.lockup', lockupListener);
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        tx.transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(
+        ChainSwapRepository.setUserLockupTransaction,
+      ).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+
+      getOutputValueSpy.mockRestore();
+    });
+
+    test('should accept a chain swap replacement after zero-conf rejection', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+      const tx = chainLockupTransaction();
+      const mockChainSwap = chainSwap(
+        tx,
+        { expectedAmount: 123, transactionId: 'rejected-lockup' },
+        SwapUpdateEvent.TransactionZeroConfRejected,
+      );
+
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: mockChainSwap,
+        });
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(123);
+
+      const lockupListener = jest.fn();
+      nursery.on('chainSwap.lockup', lockupListener);
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        tx.transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(
+        ChainSwapRepository.setUserLockupTransaction,
+      ).toHaveBeenCalledTimes(1);
+      expect(lockupListener).toHaveBeenCalledTimes(1);
+
+      getOutputValueSpy.mockRestore();
+    });
+
+    test('should allow re-pointing a failed chain swap lockup when the renegotiation override is set', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+      const tx = chainLockupTransaction();
+      const mockChainSwap = chainSwap(
+        tx,
+        { expectedAmount: 123, transactionId: 'already-recorded' },
+        SwapUpdateEvent.TransactionLockupFailed,
+      );
+
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: mockChainSwap,
+        });
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(123);
+
+      const lockupListener = jest.fn();
+      nursery.on('chainSwap.lockup', lockupListener);
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        tx.transaction,
+        TransactionStatus.Confirmed,
+        { allowLockupFailedUpdate: true },
+      );
+
+      expect(
+        ChainSwapRepository.setUserLockupTransaction,
+      ).toHaveBeenCalledTimes(1);
+      expect(lockupListener).toHaveBeenCalledTimes(1);
+
+      getOutputValueSpy.mockRestore();
+    });
+
+    test('should reject chain swap zero-conf through the guarded status write', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+      const tx = chainLockupTransaction();
+      const mockChainSwap = chainSwap(
+        tx,
+        { expectedAmount: 123 },
+        SwapUpdateEvent.SwapCreated,
+      );
+
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: mockChainSwap,
+        });
+      const setZeroConfRejected = jest.fn().mockImplementation(async (arg) => ({
+        ...arg,
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      }));
+      ChainSwapRepository.setZeroConfRejected = setZeroConfRejected;
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(123);
+
+      const rejectedListener = jest.fn();
+      const lockupListener = jest.fn();
+      nursery.on('chainSwap.lockup.zeroconf.rejected', rejectedListener);
+      nursery.on('chainSwap.lockup', lockupListener);
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        tx.transaction,
+        TransactionStatus.ZeroConfSafe,
+      );
+
+      expect(setZeroConfRejected).toHaveBeenCalledTimes(1);
+      expect(setZeroConfRejected).toHaveBeenCalledWith(
+        mockChainSwap,
+        tx.transaction.id,
+        0,
+      );
+      expect(rejectedListener).toHaveBeenCalledTimes(1);
+      expect(rejectedListener).toHaveBeenCalledWith({
+        transaction: tx.transaction,
+        swap: {
+          ...mockChainSwap,
+          status: SwapUpdateEvent.TransactionZeroConfRejected,
+        },
+        reason: Errors.SWAP_DOES_NOT_ACCEPT_ZERO_CONF().message,
+      });
+      expect(lockupListener).not.toHaveBeenCalled();
+
+      getOutputValueSpy.mockRestore();
+    });
+
+    test('should not emit a chain swap zero-conf rejection when the status write was refused', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+      const tx = chainLockupTransaction();
+      const mockChainSwap = chainSwap(
+        tx,
+        { expectedAmount: 123 },
+        SwapUpdateEvent.SwapCreated,
+      );
+
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: mockChainSwap,
+        });
+      const setZeroConfRejected = jest.fn().mockImplementation(async (arg) => ({
+        ...arg,
+        status: SwapUpdateEvent.TransactionConfirmed,
+      }));
+      ChainSwapRepository.setZeroConfRejected = setZeroConfRejected;
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(123);
+
+      const rejectedListener = jest.fn();
+      const lockupListener = jest.fn();
+      nursery.on('chainSwap.lockup.zeroconf.rejected', rejectedListener);
+      nursery.on('chainSwap.lockup', lockupListener);
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        tx.transaction,
+        TransactionStatus.ZeroConfSafe,
+      );
+
+      expect(setZeroConfRejected).toHaveBeenCalledTimes(1);
+      expect(rejectedListener).not.toHaveBeenCalled();
+      expect(lockupListener).not.toHaveBeenCalled();
+
+      getOutputValueSpy.mockRestore();
+    });
+
+    test('should emit an unconfirmed chain swap lockup when zero-conf is accepted', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+      const tx = chainLockupTransaction();
+      const mockChainSwap = {
+        ...chainSwap(tx, { expectedAmount: 123 }, SwapUpdateEvent.SwapCreated),
+        acceptZeroConf: true,
+      };
+
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Acquired,
+          swap: mockChainSwap,
+        });
+      const setZeroConfRejected = jest.fn();
+      ChainSwapRepository.setZeroConfRejected = setZeroConfRejected;
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(123);
+
+      const rejectedListener = jest.fn();
+      const lockupListener = jest.fn();
+      nursery.on('chainSwap.lockup.zeroconf.rejected', rejectedListener);
+      nursery.on('chainSwap.lockup', lockupListener);
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        tx.transaction,
+        TransactionStatus.ZeroConfSafe,
+      );
+
+      expect(setZeroConfRejected).not.toHaveBeenCalled();
+      expect(rejectedListener).not.toHaveBeenCalled();
+      expect(lockupListener).toHaveBeenCalledTimes(1);
+      expect(lockupListener).toHaveBeenCalledWith({
+        swap: mockChainSwap,
+        transaction: tx.transaction,
+        confirmed: false,
+      });
+
+      getOutputValueSpy.mockRestore();
+    });
+  });
 
   test('should handle unconfirmed Swap outputs', async () => {
     const checkSwapOutputs = nursery['checkOutputs'];
@@ -529,7 +1081,10 @@ describe('UtxoNursery', () => {
     lockupTracker.isAcceptable = jest.fn().mockResolvedValue(false);
 
     nursery.once('swap.lockup.zeroconf.rejected', (args) => {
-      expect(args.swap).toEqual(mockGetSwapResult);
+      expect(args.swap).toEqual({
+        ...mockGetSwapResult,
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      });
       expect(args.transaction).toEqual(transaction);
       expect(args.reason).toEqual(
         Errors.SWAP_DOES_NOT_ACCEPT_ZERO_CONF().message,
@@ -557,7 +1112,10 @@ describe('UtxoNursery', () => {
     mockGetSwapResult.acceptZeroConf = null;
 
     nursery.once('swap.lockup.zeroconf.rejected', (args) => {
-      expect(args.swap).toEqual(mockGetSwapResult);
+      expect(args.swap).toEqual({
+        ...mockGetSwapResult,
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      });
       expect(args.transaction).toEqual(transaction);
       expect(args.reason).toEqual(
         Errors.SWAP_DOES_NOT_ACCEPT_ZERO_CONF().message,
@@ -591,7 +1149,10 @@ describe('UtxoNursery', () => {
     rbfTransaction.updateInput(0, { sequence: 0xffffffff - 2 }, true);
 
     nursery.once('swap.lockup.zeroconf.rejected', (args) => {
-      expect(args.swap).toEqual(mockGetSwapResult);
+      expect(args.swap).toEqual({
+        ...mockGetSwapResult,
+        status: SwapUpdateEvent.TransactionZeroConfRejected,
+      });
       expect(args.transaction).toEqual(rbfTransaction);
       expect(args.reason).toEqual(
         Errors.LOCKUP_TRANSACTION_SIGNALS_RBF().message,
@@ -707,6 +1268,46 @@ describe('UtxoNursery', () => {
     expect(mockSetLockupTransaction).not.toHaveBeenCalled();
   });
 
+  test('should not emit a zero-conf rejection when the status write was refused', async () => {
+    const transaction = parseTx(sampleTransactions.lockup);
+    transaction.updateInput(0, { sequence: 0xffffffff }, true);
+    transaction.updateInput(1, { sequence: 0xffffffff }, true);
+
+    mockGetSwapResult = {
+      id: '0conf',
+      acceptZeroConf: true,
+      redeemScript: sampleRedeemScript,
+      type: SwapType.Submarine,
+      lockupAddress: encodeAddress(
+        Buffer.from(transaction.getOutput(0).script!),
+      ),
+    };
+
+    mockSetZeroConfRejected.mockImplementationOnce(async (arg) => ({
+      ...arg,
+      status: SwapUpdateEvent.TransactionConfirmed,
+    }));
+    lockupTracker.zeroConfAccepted = jest.fn().mockReturnValue(false);
+
+    const rejectedListener = jest.fn();
+    nursery.on('swap.lockup.zeroconf.rejected', rejectedListener);
+
+    await nursery['checkOutputs'](
+      btcChainClient,
+      btcWallet,
+      transaction,
+      TransactionStatus.ZeroConfSafe,
+    );
+
+    expect(mockSetZeroConfRejected).toHaveBeenCalledTimes(1);
+    expect(mockSetZeroConfRejected).toHaveBeenCalledWith(
+      mockGetSwapResult,
+      transaction.id,
+      expect.any(Number),
+    );
+    expect(rejectedListener).not.toHaveBeenCalled();
+  });
+
   test('should detect Taproot Swap outputs', async () => {
     const checkSwapOutputs = nursery['checkOutputs'];
 
@@ -762,7 +1363,7 @@ describe('UtxoNursery', () => {
       expect.anything(),
       transaction.id,
       Number(transaction.getOutput(0).amount),
-      true,
+      SwapUpdateEvent.TransactionConfirmed,
       0,
     );
     expect(mockGetKeysByIndex).toHaveBeenCalledTimes(1);
@@ -1805,8 +2406,11 @@ describe('UtxoNursery', () => {
         };
 
         mockSetLockupTransaction.mockImplementationOnce(async (swap) => ({
-          ...swap,
-          expectedAmount,
+          outcome: LockupWriteOutcome.Acquired,
+          swap: {
+            ...swap,
+            expectedAmount,
+          },
         }));
 
         const getOutputValueSpy = jest
@@ -1911,7 +2515,10 @@ describe('UtxoNursery', () => {
 
         ChainSwapRepository.setUserLockupTransaction = jest
           .fn()
-          .mockResolvedValue(mockChainSwap);
+          .mockResolvedValue({
+            outcome: LockupWriteOutcome.Acquired,
+            swap: mockChainSwap,
+          });
 
         const getOutputValueSpy = jest
           .spyOn(Core, 'getOutputValue')
@@ -1945,7 +2552,7 @@ describe('UtxoNursery', () => {
           mockChainSwap,
           transaction.id,
           outputValue,
-          true,
+          SwapUpdateEvent.TransactionConfirmed,
           0,
           undefined,
         );
@@ -2000,8 +2607,11 @@ describe('UtxoNursery', () => {
       ChainSwapRepository.setUserLockupTransaction = jest
         .fn()
         .mockResolvedValue({
-          ...mockChainSwap,
-          status: SwapUpdateEvent.TransactionLockupFailed,
+          outcome: LockupWriteOutcome.Idempotent,
+          swap: {
+            ...mockChainSwap,
+            status: SwapUpdateEvent.TransactionLockupFailed,
+          },
         });
 
       const getOutputValueSpy = jest
@@ -2022,7 +2632,7 @@ describe('UtxoNursery', () => {
         mockChainSwap,
         transaction.id,
         500,
-        true,
+        SwapUpdateEvent.TransactionConfirmed,
         0,
         undefined,
       );

--- a/test/unit/swap/UtxoNursery.spec.ts
+++ b/test/unit/swap/UtxoNursery.spec.ts
@@ -673,6 +673,38 @@ describe('UtxoNursery', () => {
       expect(lockupListener).not.toHaveBeenCalled();
     });
 
+    test('should not act when the lockup write was rejected', async () => {
+      const checkSwapOutputs = nursery['checkOutputs'];
+      const transaction = parseTx(sampleTransactions.lockup);
+
+      submarineSwap({
+        expectedAmount: Number(transaction.getOutput(0).amount),
+        lockupTransactionId: undefined,
+        status: SwapUpdateEvent.SwapCreated,
+      });
+      // The swap was taken over between the guard and the write
+      mockSetLockupTransaction.mockResolvedValueOnce({
+        outcome: LockupWriteOutcome.Rejected,
+        swap: mockGetSwapResult,
+      });
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('swap.lockup', lockupListener);
+      nursery.on('swap.lockup.failed', failedListener);
+
+      await checkSwapOutputs(
+        btcChainClient,
+        btcWallet,
+        transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(mockSetLockupTransaction).toHaveBeenCalledTimes(1);
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
+    });
+
     const chainLockupTransaction = () => {
       const ourKeys = makeKeys();
       const theirPublicKey = Buffer.from(makeKeys().publicKey);
@@ -798,6 +830,48 @@ describe('UtxoNursery', () => {
         ChainSwapRepository.setUserLockupTransaction,
       ).not.toHaveBeenCalled();
       expect(lockupListener).not.toHaveBeenCalled();
+
+      getOutputValueSpy.mockRestore();
+    });
+
+    test('should not act when the chain swap lockup write was rejected', async () => {
+      const checkChainSwapTransaction = nursery['checkChainSwapTransaction'];
+      const tx = chainLockupTransaction();
+      const mockChainSwap = chainSwap(
+        tx,
+        { expectedAmount: 123, transactionId: undefined },
+        SwapUpdateEvent.SwapCreated,
+      );
+
+      // The swap was taken over between the guard and the write
+      ChainSwapRepository.setUserLockupTransaction = jest
+        .fn()
+        .mockResolvedValue({
+          outcome: LockupWriteOutcome.Rejected,
+          swap: mockChainSwap,
+        });
+      const getOutputValueSpy = jest
+        .spyOn(Core, 'getOutputValue')
+        .mockReturnValue(123);
+
+      const lockupListener = jest.fn();
+      const failedListener = jest.fn();
+      nursery.on('chainSwap.lockup', lockupListener);
+      nursery.on('chainSwap.lockup.failed', failedListener);
+
+      await checkChainSwapTransaction(
+        mockChainSwap as any,
+        btcChainClient,
+        btcWallet,
+        tx.transaction,
+        TransactionStatus.Confirmed,
+      );
+
+      expect(
+        ChainSwapRepository.setUserLockupTransaction,
+      ).toHaveBeenCalledTimes(1);
+      expect(lockupListener).not.toHaveBeenCalled();
+      expect(failedListener).not.toHaveBeenCalled();
 
       getOutputValueSpy.mockRestore();
     });
@@ -1019,6 +1093,7 @@ describe('UtxoNursery', () => {
       expect(lockupListener).toHaveBeenCalledWith({
         swap: mockChainSwap,
         transaction: tx.transaction,
+        lockupTransactionVout: 0,
         confirmed: false,
       });
 

--- a/test/unit/wallet/ethereum/ConsolidatedEventHandler.spec.ts
+++ b/test/unit/wallet/ethereum/ConsolidatedEventHandler.spec.ts
@@ -74,6 +74,7 @@ describe('ConsolidatedEventHandler', () => {
     hash: string,
     blockNumber: number,
     swapValues = defaultEtherSwapValues,
+    logIndex = 0,
   ): Events['eth.lockup'] =>
     ({
       version: 4n,
@@ -81,6 +82,7 @@ describe('ConsolidatedEventHandler', () => {
         hash,
         blockNumber,
       },
+      logIndex,
       etherSwapValues: swapValues,
     }) as Events['eth.lockup'];
 
@@ -109,6 +111,7 @@ describe('ConsolidatedEventHandler', () => {
     hash: string,
     blockNumber: number,
     swapValues = defaultErc20SwapValues,
+    logIndex = 0,
   ): Events['erc20.lockup'] =>
     ({
       version: 4n,
@@ -116,6 +119,7 @@ describe('ConsolidatedEventHandler', () => {
         hash,
         blockNumber,
       },
+      logIndex,
       erc20SwapValues: swapValues,
     }) as Events['erc20.lockup'];
 
@@ -602,7 +606,7 @@ describe('ConsolidatedEventHandler', () => {
       jest.spyOn(Date, 'now').mockRestore();
     });
 
-    test('keeps distinct events from the same txHash with different swap values', async () => {
+    test('keeps distinct events from the same txHash with different log indices', async () => {
       const { provider, emitBlock } = createProvider(100);
       provider.getTransactionReceipt.mockResolvedValue({
         blockNumber: 100,
@@ -616,10 +620,12 @@ describe('ConsolidatedEventHandler', () => {
       const emitted = jest.fn();
       consolidated.on('eth.lockup', emitted);
 
-      const valuesA = { ...defaultEtherSwapValues, amount: 1000n };
-      const valuesB = { ...defaultEtherSwapValues, amount: 2000n };
-      v3.emitters['eth.lockup']!(ethLockup('0xsame-tx', 100, valuesA));
-      v3.emitters['eth.lockup']!(ethLockup('0xsame-tx', 100, valuesB));
+      v3.emitters['eth.lockup']!(
+        ethLockup('0xsame-tx', 100, defaultEtherSwapValues, 1),
+      );
+      v3.emitters['eth.lockup']!(
+        ethLockup('0xsame-tx', 100, defaultEtherSwapValues, 2),
+      );
       await flushAsync();
 
       await emitBlock(101);
@@ -649,7 +655,7 @@ describe('ConsolidatedEventHandler', () => {
       expect(emitted).toHaveBeenCalledTimes(1);
     });
 
-    test('keeps distinct erc20 events from the same txHash with different token addresses', async () => {
+    test('keeps distinct erc20 events from the same txHash with different log indices', async () => {
       const { provider, emitBlock } = createProvider(100);
       provider.getTransactionReceipt.mockResolvedValue({
         blockNumber: 100,
@@ -663,13 +669,11 @@ describe('ConsolidatedEventHandler', () => {
       const emitted = jest.fn();
       consolidated.on('erc20.lockup', emitted);
 
-      const valuesA = { ...defaultErc20SwapValues, tokenAddress: '0xtokena' };
-      const valuesB = { ...defaultErc20SwapValues, tokenAddress: '0xtokenb' };
       v3.emitters['erc20.lockup']!(
-        erc20Lockup('0xerc20-same-tx', 100, valuesA),
+        erc20Lockup('0xerc20-same-tx', 100, defaultErc20SwapValues, 1),
       );
       v3.emitters['erc20.lockup']!(
-        erc20Lockup('0xerc20-same-tx', 100, valuesB),
+        erc20Lockup('0xerc20-same-tx', 100, defaultErc20SwapValues, 2),
       );
       await flushAsync();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockup tracking by matching the exact on-chain output using transaction output/vout and Ethereum log index.
  * Prevented competing or unauthorized lockup updates from overwriting existing records, including idempotent retries.
  * Avoided confirmed→non-confirmed downgrades and tightened zero-confirmation rejection handling.
  * Refined Ethereum lockup verification and reduced incorrect/duplicate lockup failure emissions.
* **Reliability**
  * Serialized concurrent lockup validation per swap and improved event deduplication while preserving distinct lockup events.
  * Propagated log-index/output details through lockup, claim, and settlement flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->